### PR TITLE
[WIP] Firefox support

### DIFF
--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -158,11 +158,11 @@ class TetrisOCR extends EventTarget {
 		return min_idx;
 	}
 
-	initCaptureContext(frame) {
+	initCaptureContext(frame, half_height) {
 		this.capture_canvas = document.createElement('canvas');
 
 		this.capture_canvas.width = frame.width;
-		this.capture_canvas.height = frame.height;
+		this.capture_canvas.height = frame.height >> (half_height ? 1 : 0);
 
 		this.capture_canvas_ctx = this.capture_canvas.getContext('2d', { alpha: false });
 		this.capture_canvas_ctx.imageSmoothingEnabled = false;
@@ -182,15 +182,17 @@ class TetrisOCR extends EventTarget {
 		this.scaled_field_canvas_ctx.imageSmoothingQuality = 'medium';
 	}
 
-	async processFrame(frame) {
+	async processFrame(frame, half_height) {
 		if (!this.capture_canvas_ctx) {
-			this.initCaptureContext(frame);
+			this.initCaptureContext(frame, half_height);
 		}
 
 		const res = {};
 
 		performance.mark('start');
-		this.capture_canvas_ctx.drawImage(frame, 0, 0, frame.width, frame.height);
+		this.capture_canvas_ctx.drawImage(frame,
+			0, 0, frame.width, frame.height >> (half_height ? 1 : 0)
+		);
 		performance.mark('draw_end');
 		performance.measure('draw_frame', 'start', 'draw_end');
 

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -467,38 +467,28 @@ async function captureFrame() {
 
 	try {
 		let bitmap;
+		let force_half_height = false;
 
 		// let's assume that pixelated resize of height divided 2 is the same as dropping every other row
 		// which is equivalent to deinterlacing *cough*
 
 		performance.mark('capture_start');
 		if (blob) {
+			force_half_height = true;
 			// images are known to be 720x480
 			bitmap = await createImageBitmap(blob,
-				0, 0, 720, 480,
-				{
-					resizeWidth: 720,
-					resizeHeight: 480 >> 1,
-					resizeQuality: 'pixelated',
-				}
+				0, 0, 720, 480
 			);
 		}
 		else {
 			// we do cheap deinterlacing with pixelated resize...
 			bitmap = await createImageBitmap(video,
 				0, 0, video.videoWidth, video.videoHeight,
-				do_half_height
-					? {
-						resizeWidth: video.videoWidth,
-						resizeHeight: video.videoHeight >> 1,
-						resizeQuality: 'pixelated',
-					}
-					: {}
 			);
 		}
 		performance.mark('capture_end');
 
-		tetris_ocr.processFrame(bitmap);
+		tetris_ocr.processFrame(bitmap, do_half_height || force_half_height);
 	}
 	catch(err) {
 		console.error(err);

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -694,21 +694,18 @@ async function showParts(data) {
 			holder.appendChild(text_result);
 		}
 
-		const cropped = await createImageBitmap(task.crop_img, 0, 0, task.crop_img.width, task.crop_img.height, {
-			resizeWidth: task.crop_img.width * 2,
-			resizeHeight: task.crop_img.height * 2,
-			resizeQuality: 'pixelated'
-		});
-
-		const scaled = await createImageBitmap(task.scale_img, 0, 0, task.scale_img.width, task.scale_img.height, {
-			resizeWidth: task.scale_img.width * 2,
-			resizeHeight: task.scale_img.height * 2,
-			resizeQuality: 'pixelated'
-		});
+		const cropped = await createImageBitmap(task.crop_img, 0, 0, task.crop_img.width, task.crop_img.height);
+		const scaled = await createImageBitmap(task.scale_img, 0, 0, task.scale_img.width, task.scale_img.height);
 
 		// draw task captured areas
-		task.crop_canvas_ctx.drawImage(cropped, 0, 0);
-		task.scale_canvas_ctx.drawImage(scaled, 0, 0);
+		task.crop_canvas_ctx.drawImage(cropped
+			, 0, 0, task.crop_img.width, task.crop_img.height
+			, 0, 0, task.crop_img.width * 2, task.crop_img.height * 2
+		);
+		task.scale_canvas_ctx.drawImage(scaled
+			 , 0, 0, task.scale_img.width, task.scale_img.height
+			 , 0, 0, task.scale_img.width * 2, task.scale_img.height * 2
+		);
 
 		// highlight captured areas in source image
 		const [x, y, w, h] = task.crop;

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -347,6 +347,12 @@ async function playVideoFromDevice(device_id, fps) {
 			}
 		};
 
+		// whhhyyyyyy???
+		if (navigator.userAgent.indexOf("Firefox/") > -1) {
+			constraints.video.width.ideal = 1280;
+			delete constraints.video.height;
+		}
+
 		if (device_id) {
 			constraints.video.deviceId = { exact: device_id };
 		}

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -684,17 +684,19 @@ async function showParts(data) {
 			holder.appendChild(text_result);
 		}
 
-		const cropped = await createImageBitmap(task.crop_img, 0, 0, task.crop_img.width, task.crop_img.height);
-		const scaled = await createImageBitmap(task.scale_img, 0, 0, task.scale_img.width, task.scale_img.height);
-
-		// draw task captured areas
-		task.crop_canvas_ctx.drawImage(cropped
-			, 0, 0, task.crop_img.width, task.crop_img.height
-			, 0, 0, task.crop_img.width * 2, task.crop_img.height * 2
+		const cropped = await createImageBitmap(task.crop_img,
+			0, 0, task.crop_img.width, task.crop_img.height
 		);
-		task.scale_canvas_ctx.drawImage(scaled
-			 , 0, 0, task.scale_img.width, task.scale_img.height
-			 , 0, 0, task.scale_img.width * 2, task.scale_img.height * 2
+		const scaled = await createImageBitmap(task.scale_img,
+			0, 0, task.scale_img.width, task.scale_img.height
+		);
+
+		// draw task captured areas at 2x scale
+		task.crop_canvas_ctx.drawImage(cropped,
+			0, 0, task.crop_img.width * 2, task.crop_img.height * 2
+		);
+		task.scale_canvas_ctx.drawImage(scaled,
+			0, 0, task.scale_img.width * 2, task.scale_img.height * 2
 		);
 
 		// highlight captured areas in source image


### PR DESCRIPTION
I was using [`createImageBitmap()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap) to do in line scaling (no need to do it via an intermediary canvas), but sadly, firefox doesn't support the scaling parameters:

![image](https://user-images.githubusercontent.com/935223/112741548-63bd3c80-8fb9-11eb-8316-2329a7c4d6f5.png)

This PR removes all cases of inline scaling and uses canvas instead.