### PR TITLE
Report games on server

### DIFF
--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -142,7 +142,7 @@ class ScoreDAO {
 
 	async getScorePage(user, options = {}) {
 		options = {
-			sort_field: 'id',
+			sort_field: 'datetime',
 			sort_order: 'desc',
 			page_size: 100,
 			page_idx: 0,

--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -109,6 +109,7 @@ class ScoreDAO {
 			(
 				NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 			)
+			RETURNING id
 			`,
 			[
 				user.id,
@@ -126,6 +127,8 @@ class ScoreDAO {
 				game_data.transition,
 			]
 		);
+
+		return result.rows[0].id;
 	}
 
 	async getNumberOfScores(user) {

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -255,7 +255,7 @@ class MatchRoom extends Room {
 	}
 
 	onProducerMessage(producer, message) {
-		// system where you can have one plyer
+		// system where you can have one user being both players
 		[0, 1].forEach(p_num => {
 			if (this.state.players[p_num].id === producer.user.id) {
 				if (message instanceof Uint8Array) {

--- a/domains/Room.js
+++ b/domains/Room.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Game = require('../modules/Game');
-
+const ScoreDAO = require('../daos/ScoreDAO');
 
 
 function setGame(connection) {
@@ -12,9 +12,14 @@ function setGame(connection) {
 
 	const game = new Game();
 
-	game.onGameOver = () => {
-		// TODO: report into DB
-		console.log('Game report', connection.user.id, game.getReport());
+	game.onGameOver = async () => {
+		try {
+			await ScoreDAO.recordGame(connection.user, game.getReport());
+		}
+		catch(err) {
+			console.log('Unable to record game');
+			console.error(err);
+		}
 	}
 
 	game.onNewGame = (frame) => {

--- a/domains/Room.js
+++ b/domains/Room.js
@@ -92,7 +92,11 @@ class Room {
 				setGame(connection);
 			}
 
-			connection.game.setFrame(message); // this call may reset the game as side effect
+
+			if (typeof message != 'string') {
+				// this is a game frame, we track it in the game instance
+				connection.game.setFrame(message); // this call may reset the game as side effect
+			}
 
 			this.onProducerMessage(connection, message)
 		});

--- a/domains/Room.js
+++ b/domains/Room.js
@@ -14,7 +14,9 @@ function setGame(connection) {
 
 	game.onGameOver = async () => {
 		try {
-			await ScoreDAO.recordGame(connection.user, game.getReport());
+			const score_id = await ScoreDAO.recordGame(connection.user, game.getReport());
+
+			console.log(`Recorded new game with id ${score_id}`);
 		}
 		catch(err) {
 			console.log('Unable to record game');

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -1,0 +1,187 @@
+// Minimum amount of game tracking to do server side to be able to report games
+const BinaryFrame = require('../public/js/BinaryFrame');
+
+const PIECES = ['T', 'J', 'Z', 'O', 'S', 'L', 'I'];
+
+class Game {
+	constructor() {
+		this.data = null;
+		this.over = false;
+	}
+
+	setFrame(frame) {
+		const data = BinaryFrame.parse(frame);
+
+		if (!this.data) {
+			// store transient info ad accumulators
+			this.gameid = data.gameid;
+			this.start_ts = Date.now();
+			this.start_level = data.level;
+
+			this.num_pieces = 0;
+			this.prior_preview = null;
+
+			this.tetris_lines = 0;
+
+			this.cur_drought = 0;
+			this.max_drought = 0;
+			this.num_droughts = 0;
+
+			this.das_total = 0;
+
+			this.transition = null;
+			this.pieces = [];
+			this.clears = [];
+
+			this.pending_score = false;
+			this.pending_piece = true;
+
+			this.data = data; // record frame as current state
+
+			return;
+		}
+
+		if (data.gameid != this.gameid) {
+			// Note: this test could be done without parsing the whole message!
+			this.onNewGame(frame);
+			return;
+		}
+		else if (this.over) {
+			return;
+		}
+
+		if (this.pending_score) {
+			this.pending_score = false;
+			this.onScore(data); // update states
+		}
+		else if (data.score != this.data.score) {
+			this.pending_score = true;
+		}
+
+		if (this.pending_piece) {
+			this.pending_piece = false;
+			this.onPiece(data); // update states
+		}
+		else {
+			if (data.game_type === BinaryFrame.GAME_TYPE.CLASSIC) {
+				const num_pieces = this._getNumPieces(data);
+
+				if (num_pieces != this.num_pieces) {
+					this.pending_piece = true;
+				}
+			}
+			else {
+				// TODO; check field and block count
+			}
+		}
+
+		// Check board for gameover event
+		if (!this.over && data.field.slice(0, 10).every(cell => cell)) {
+			// Game Over!
+			this.over = true;
+			this.end_ts = Date.now();
+			this.onGameOver();
+		}
+	}
+
+	_getNumPieces(data) {
+		return PIECES.reduce((acc, p) => acc + (data[p] || 0), 0);
+	}
+
+	onScore(data) {
+		this.data.score = data.score;
+
+		const cleared = data.lines - this.data.lines;
+
+		// when score changes, lines may have changed
+		if (cleared) {
+			this.data.lines = data.lines;
+
+			this.clears.push(cleared);
+
+			if (cleared === 4) {
+				this.tetris_lines += cleared;
+			}
+
+			// when line changes, level may have changed
+			if (data.level != this.data.level) {
+				if (this.transition === null) {
+					this.transition = data.score;
+				}
+				this.data.level = data.level;
+			}
+		}
+	}
+
+	onPiece(data) {
+		let cur_piece;
+
+		if (data.game_type === BinaryFrame.GAME_TYPE.CLASSIC) {
+			if (this.num_pieces === 0) {
+				cur_piece = PIECES.find(p => data[p]); // first truthy value is piece
+			}
+			else {
+				cur_piece = this.prior_preview; // should be in sync 🤞
+			}
+
+			// record new state
+			this.num_pieces = this._getNumPieces(data);
+			PIECES.forEach(p => this.data[p] = data[p]);
+			this.prior_preview = data.preview;
+		}
+		else {
+			cur_piece = data.cur_piece; // 💪
+			this.das_total = data.cur_piece_das;
+		}
+
+		this.pieces.push(cur_piece);
+
+		if (cur_piece == 'I') {
+			if (this.cur_drought > this.max_drought) {
+				this.max_drought = this.cur_drought;
+			}
+
+			this.cur_drought = 0;
+		}
+		else {
+			if (++this.cur_drought === 13) {
+				this.num_droughts += 1;
+			}
+		}
+	}
+
+	getReport() {
+		let tetris_rate = null;
+		let das_avg = -1;
+
+		if (this.clears.length) {
+			tetris_rate = this.tetris_lines / this.clears.length;
+		}
+
+		if (this.pieces.length && this.das_total) {
+			das_avg = this.das_total / this.pieces.length;
+		}
+
+		return {
+			start_level:  this.start_level,
+			end_level:    this.data.level,
+			score:        this.data.score,
+			lines:        this.data.lines,
+			num_droughts: this.num_droughts,
+			max_drought:  this.max_drought,
+			duration:     (this.end_ts || Date.now()) - this.start_ts,
+			transition:   this.transition,
+			clears:       this.clears.join(''),
+			pieces:       this.pieces.join(''),
+
+			tetris_rate,
+			das_avg,
+		};
+	}
+
+	// client app to overwrite
+	onGameOver() {}
+	onNewGame() {}
+}
+
+module.exports = Game;

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -5,6 +5,7 @@ const PIECES = ['T', 'J', 'Z', 'O', 'S', 'L', 'I'];
 
 class Game {
 	constructor() {
+		this.frame_count = 0;
 		this.data = null;
 		this.over = false;
 	}
@@ -13,7 +14,8 @@ class Game {
 		const data = BinaryFrame.parse(frame);
 
 		if (!this.data) {
-			// store transient info ad accumulators
+			// game initialization frame
+
 			this.gameid = data.gameid;
 			this.start_ts = Date.now();
 			this.start_level = data.level;
@@ -40,6 +42,8 @@ class Game {
 
 			return;
 		}
+
+		this.frame_count++;
 
 		if (data.gameid != this.gameid) {
 			// Note: this test could be done without parsing the whole message!
@@ -80,7 +84,10 @@ class Game {
 			// Game Over!
 			this.over = true;
 			this.end_ts = Date.now();
-			this.onGameOver();
+
+			if (this.frame_count > 1) {
+				this.onGameOver();
+			}
 		}
 	}
 

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -60,7 +60,10 @@ class Game {
 		}
 
 		if (data.gameid != this.gameid) {
-			// Note: this test could be done without parsing the whole message!
+			if (!this.over) {
+				this._doGameOver();
+			}
+
 			this.onNewGame(frame);
 			return;
 		}
@@ -99,7 +102,7 @@ class Game {
 
 					switch(block_diff) {
 						case 4:
-							this.data.field = field;
+							this.data.field = data.field;
 							this.num_blocks = cur_num_blocks;
 							this.pending_piece = true;
 							break;
@@ -134,7 +137,7 @@ class Game {
 						default:
 							// We ignore invalid block count diffs. In many cases these dut to interlace artefacts when the pieces rotate of move
 							// TODO: block count tracking can fall out of sync, breaking piece count events. CCan anything be done to restore a "clean" count and resume
-							pending_single = false;
+							this.pending_single = false;
 					}
 
 				}
@@ -144,13 +147,16 @@ class Game {
 
 		// Check board for gameover event
 		if (!this.over && data.field.slice(0, 10).every(cell => cell)) {
-			// Game Over!
-			this.over = true;
-			this.end_ts = Date.now();
+			this._doGameOver();
+		}
+	}
 
-			if (this.frame_count > 2) {
-				this.onGameOver();
-			}
+	_doGameOver() {
+		this.over = true;
+		this.end_ts = Date.now();
+
+		if (this.frame_count > 2) {
+			this.onGameOver();
 		}
 	}
 

--- a/modules/db.js
+++ b/modules/db.js
@@ -1,6 +1,6 @@
-if (process.env.IS_PUBLIC_SERVER) {
-	const { Pool } = require('pg');
+const { Pool } = require('pg');
 
+if (process.env.IS_PUBLIC_SERVER) {
 	const pool = new Pool({
 		connectionString: process.env.DATABASE_URL,
 		ssl: {
@@ -17,6 +17,7 @@ if (process.env.IS_PUBLIC_SERVER) {
 	module.exports = pool;
 }
 else {
+	/*
 	// Fake Pool for local access
 	// TODO: make a sqlite version
 
@@ -39,4 +40,18 @@ else {
 
 		query,
 	};
+	/**/
+
+	const pool = new Pool({
+		connectionString: process.env.DATABASE_URL
+	});
+
+	// the pool will emit an error on behalf of any idle clients
+	// it contains if a backend error or network partition happens
+	pool.on('error', (err, client) => {
+		console.error('DB: Unexpected error on idle client', err);
+	});
+
+	module.exports = pool;
+
 }

--- a/modules/db.js
+++ b/modules/db.js
@@ -19,15 +19,24 @@ if (process.env.IS_PUBLIC_SERVER) {
 else {
 	// Fake Pool for local access
 	// TODO: make a sqlite version
+
+	async function query(query, args) {
+		console.log('Executing query');
+		console.log(query);
+		console.log(args);
+
+		return {
+			rows: [ {} ]
+		};
+	}
+
 	module.exports = {
 		async connect() {
 			return {
-				async query() {
-					return {
-						rows: [ {} ]
-					};
-				}
+				query,
 			};
-		}
+		},
+
+		query,
 	};
 }

--- a/public/js/BinaryFrame.js
+++ b/public/js/BinaryFrame.js
@@ -251,6 +251,7 @@ return BinaryFrame;
 
 })();
 
-if (module && module.exports) {
+try {
 	module.exports = BinaryFrame;
 }
+catch(err) {}

--- a/public/js/BinaryFrame.js
+++ b/public/js/BinaryFrame.js
@@ -250,3 +250,7 @@ BinaryFrame.GAME_TYPE = GAME_TYPE;
 return BinaryFrame;
 
 })();
+
+if (module && module.exports) {
+	module.exports = BinaryFrame;
+}

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -25,6 +25,8 @@ const PERF_METHODS = [
 	'scanCurPiece',
 ];
 
+const DEFAULT_COLOR_0 = [0xF0, 0xF0, 0xF0];
+
 function getDigitsWidth(n) {
 	// width per digit is 8px times 2
 	// and for last digit, we ignore the 1px (times 2)
@@ -85,6 +87,8 @@ class TetrisOCR extends EventTarget {
 		this.config = config;
 		this.palette = this.palettes && this.palettes[config.palette]; // will reset to undefined when needed
 
+		this.fixPalette();
+
 		const bounds = {
 			top:    0xFFFFFFFF,
 			left:   0xFFFFFFFF,
@@ -125,6 +129,22 @@ class TetrisOCR extends EventTarget {
 			w: bounds.right - bounds.left,
 			h: bounds.bottom - bounds.top,
 		};
+	}
+
+	fixPalette() {
+		if (!this.palette) return;
+
+		this.palette = this.palette.map(colors => {
+			if (colors.length == 2) {
+				return [
+					DEFAULT_COLOR_0,
+					colors[0],
+					colors[1]
+				]
+			}
+
+			return colors;
+		});
 	}
 
 	getDigit(pixel_data, max_check_index, is_red) {
@@ -231,7 +251,7 @@ class TetrisOCR extends EventTarget {
 				res.color1 = this.scanColor1(source_img);
 			}
 			else {
-				res.color1 = [0xF0, 0xF0, 0xF0];
+				res.color1 = DEFAULT_COLOR_0;
 			}
 
 			colors = [res.color1, res.color2, res.color3];
@@ -531,6 +551,9 @@ class TetrisOCR extends EventTarget {
 
 		crop(source_img, x, y, w, h, task.crop_img);
 		bicubic(task.crop_img, task.scale_img);
+
+		// I tried selecting the pixel with highest luma but that didn't work.
+		// On capture cards with heavy color bleeding, it's inaccurate.
 
 		// we select the brightest pixel in the center 3x3 square of the
 		const row_width = task.scale_img.width;

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -36,6 +36,7 @@ const reference_locations = {
 
 const configs = {
 	classic: {
+		game_type: BinaryFrame.GAME_TYPE.CLASSIC,
 		reference: '/ocr/reference_ui_classic.png',
 		fields: [
 			'score',
@@ -56,6 +57,7 @@ const configs = {
 		],
 	},
 	das_trainer: {
+		game_type: BinaryFrame.GAME_TYPE.DAS_TRAINER,
 		reference: '/ocr/reference_ui_das_trainer.png',
 		palette: 'easiercap',
 		fields: [
@@ -812,6 +814,7 @@ function toCol(col_tuple) {
 function saveConfig(config) {
 	// need to drop non-serializable fields
 	const config_copy = {
+		game_type: config.game_type,
 		device_id: config.device_id,
 		palette: config.palette,
 		frame_rate: config.frame_rate,

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -814,7 +814,6 @@ function toCol(col_tuple) {
 function saveConfig(config) {
 	// need to drop non-serializable fields
 	const config_copy = {
-		game_type: config.game_type,
 		device_id: config.device_id,
 		palette: config.palette,
 		frame_rate: config.frame_rate,
@@ -842,7 +841,13 @@ function loadConfig() {
 	const config = localStorage.getItem('config');
 
 	if (config) {
-		return JSON.parse(config);
+		const parsed = JSON.parse(config);
+
+		if (!parsed.hasOwnProperty('game_type')) {
+			parsed.game_type = parsed.tasks.T ? BinaryFrame.GAME_TYPE.CLASSIC : BinaryFrame.GAME_TYPE.DAS_TRAINER;
+		}
+
+		return parsed;
 	}
 }
 
@@ -898,6 +903,7 @@ function trackAndSendFrames() {
 
 	// TODO: better event system and name for frame data events
 	ocr_corrector.onMessage = async function(data) {
+		data.game_type = config.game_type || BinaryFrame.GAME_TYPE.CLASSIC;
 		data.ctime = Date.now() - start_time;
 
 		if (show_parts.checked) {

--- a/routes/score.js
+++ b/routes/score.js
@@ -115,7 +115,7 @@ router.get('/scores', middlewares.assertSession, async (req, res) => {
 	const ALLOWED_ORDER_DIRS = ['desc', 'asc'];
 
 	const options = {
-		sort_field: 'id',
+		sort_field: 'datetime',
 		sort_order: 'desc',
 		page_idx: 0,
 	};

--- a/routes/score.js
+++ b/routes/score.js
@@ -58,6 +58,9 @@ router.post('/report_game/:secret', express.json(), async (req, res) => {
 
 	console.log(`Found user ${user.login}`);
 
+	/*
+	// Game is reported server-ide now, no need to record here
+
 	let game_data = req.body;
 	let normalized_report;
 
@@ -97,6 +100,7 @@ router.post('/report_game/:secret', express.json(), async (req, res) => {
 	}
 
 	console.log('Game is recorded!');
+	/**/
 
 	res.json(await ScoreDAO.getStats(user));
 


### PR DESCRIPTION
## Context

Games are reported to be stored in DB by the 2 stats-heavy renderers `classic` and `das_trainer`. This works because the renderer belong to a user so in effect, the user reports his/her own score.

But if we want to report more score entries, then more renderers need to be updated.

Also, Match games cannot be reported "nicely" because the renderer belongs to the game host, not the player themselves, so if the renderer reports games, it'd be equivalent of having one user reports another user's scores, which is not great.

## Solution:
The solution is to track games on the server, using the producer data as input. 

Cons: Need to process server side some game stats and metrics. This could have an impact on the server's scalability in the future.

Pros: Every single game can be tracked, whether or not the renderer reports the game, and whether the player is in their own single player view, or in a match room that is hosted by someone else.

