### PR TITLE
Store Sessions in DB

### DIFF
--- a/domains/User.js
+++ b/domains/User.js
@@ -64,6 +64,14 @@ class User extends EventEmitter{
 		// in memory only, not in DB
 		this.token = token;
 		this.token.expiry = new Date(Date.now() + token.expires_in * 1000);
+
+		if (this.connections.length) {
+			this._connectToTwitchChat();
+		}
+	}
+
+	hasTwitchToken() {
+		return !!this.token;
 	}
 
 	addConnection(conn) {
@@ -75,7 +83,6 @@ class User extends EventEmitter{
 		});
 
 		this.checkScheduleDestroy();
-
 		this._connectToTwitchChat();
 	}
 
@@ -126,6 +133,7 @@ class User extends EventEmitter{
 				refreshToken: this.token.refresh_token,
 				expiry: this.token.expiry,
 				onRefresh: ({ accessToken, refreshToken, expiryDate }) => {
+					// How to update the session object(s) directly?
 					token.access_token = access_token;
 					token.refresh_token = refresh_token;
 					token.expiry = expiryDate;

--- a/domains/User.js
+++ b/domains/User.js
@@ -137,6 +137,7 @@ class User extends EventEmitter{
 					token.access_token = access_token;
 					token.refresh_token = refresh_token;
 					token.expiry = expiryDate;
+					token.expires_in = Math.max(0, Math.floor((expiryDate.getTime() - Date.now()) / 1000));
 				}
 			}
 		);

--- a/modules/middlewares.js
+++ b/modules/middlewares.js
@@ -1,6 +1,8 @@
 const session = require('express-session');
 const ULID = require('ulid');
 const MemoryStore = require('memorystore')(session);
+const dbPool = require('./db');
+const pgSession = require('connect-pg-simple')(session);
 
 module.exports = {
 	sessionMiddleware: session({
@@ -11,8 +13,9 @@ module.exports = {
 			secure: !!process.env.IS_PUBLIC_SERVER
 		},
 		genid: ULID.ulid,
-		store: new MemoryStore({
-			checkPeriod: 86400000 // prune expired entries every 24h
+		store: new pgSession({
+			pool:      dbPool,
+			tableName: 'sessions',
 		}),
 		name: 'nsid'
 	}),

--- a/modules/middlewares.js
+++ b/modules/middlewares.js
@@ -21,34 +21,43 @@ module.exports = {
 		name: 'nsid'
 	}),
 
-	async assertSession(req, res, next) {
+	assertSession(req, res, next) {
 		if (!req.session || !req.session.user) {
 			req.session.auth_success_redirect = req.originalUrl;
 			res.redirect('/auth');
 		}
 		else {
-			// bit of a hack, we check the user object and set the token if needed
-			// we assume that the token is in thee session!
-			const user = await UserDAO.getUserById(request.session.user.id);
-
-			if (!user.hasTwitchToken()) {
-				user.setTwitchToken(req.session.token);
-			}
-			else {
-				// verify if the user token has been refreshed and if the session should be updated accordingly
-				const utoken = user.token;
-				const stoken = req.session.token;
-
-				if (utoken.access_token != stoken.access_token) {
-					// set the session token to be the same as user token
-					req.session.token = {
-						...utoken.access_token,
-						expires_in: Math.max(0, Math.round((utoken.expiry.getTime() - Date.now()) / 1000));
-					};
-				}
-			}
-
 			next();
 		}
+	},
+
+	async checkToken(req, res, next) {
+		if (!req.session || !req.session.user) {
+			next();
+			return;
+		}
+
+		// bit of a hack, we check the user object and set the token if needed
+		// we assume that the token is in thee session!
+		const user = await UserDAO.getUserById(req.session.user.id);
+
+		if (!user.hasTwitchToken()) {
+			user.setTwitchToken(req.session.token);
+		}
+		else {
+			// verify if the user token has been refreshed and if the session should be updated accordingly
+			const utoken = user.token;
+			const stoken = req.session.token;
+
+			if (utoken.access_token != stoken.access_token) {
+				// set the session token to be the same as user token
+				req.session.token = {
+					...utoken,
+					expires_in: Math.max(0, Math.round((utoken.expiry.getTime() - Date.now()) / 1000))
+				};
+			}
+		}
+
+		next();
 	}
 };

--- a/modules/middlewares.js
+++ b/modules/middlewares.js
@@ -1,18 +1,19 @@
 const session = require('express-session');
-const ULID = require('ulid');
+const { v4: uuidv4 } = require('uuid');
 const MemoryStore = require('memorystore')(session);
 const dbPool = require('./db');
 const pgSession = require('connect-pg-simple')(session);
+const UserDAO = require('../daos/UserDAO');
 
 module.exports = {
 	sessionMiddleware: session({
-		secret: process.env.SESSION_SECRET || ULID.ulid(),
+		secret: process.env.SESSION_SECRET || uuidv4(),
 		resave: false,
 		saveUninitialized: true,
 		cookie: {
 			secure: !!process.env.IS_PUBLIC_SERVER
 		},
-		genid: ULID.ulid,
+		genid: uuidv4,
 		store: new pgSession({
 			pool:      dbPool,
 			tableName: 'sessions',
@@ -20,12 +21,33 @@ module.exports = {
 		name: 'nsid'
 	}),
 
-	assertSession(req, res, next) {
-		if (!req.session.user) {
+	async assertSession(req, res, next) {
+		if (!req.session || !req.session.user) {
 			req.session.auth_success_redirect = req.originalUrl;
 			res.redirect('/auth');
 		}
 		else {
+			// bit of a hack, we check the user object and set the token if needed
+			// we assume that the token is in thee session!
+			const user = await UserDAO.getUserById(request.session.user.id);
+
+			if (!user.hasTwitchToken()) {
+				user.setTwitchToken(req.session.token);
+			}
+			else {
+				// verify if the user token has been refreshed and if the session should be updated accordingly
+				const utoken = user.token;
+				const stoken = req.session.token;
+
+				if (utoken.access_token != stoken.access_token) {
+					// set the session token to be the same as user token
+					req.session.token = {
+						...utoken.access_token,
+						expires_in: Math.max(0, Math.round((utoken.expiry.getTime() - Date.now()) / 1000));
+					};
+				}
+			}
+
 			next();
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,6 +1554,16 @@
         "form-data": "^3.0.0"
       }
     },
+    "@types/pg": {
+      "version": "7.14.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.14.11.tgz",
+      "integrity": "sha512-EnZkZ1OMw9DvNfQkn2MTJrwKmhJYDEs5ujWrPfvseWNoI95N8B4HzU/Ltrq5ZfYxDX/Zg8mTzwr6UAyTjjFvXA==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "^1.2.0",
+        "pg-types": "^2.2.0"
+      }
+    },
     "@types/qs": {
       "version": "6.9.6",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
@@ -1784,6 +1794,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "connect-pg-simple": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-6.2.1.tgz",
+      "integrity": "sha512-bwDp/gKyRtyz0V5Vxy3SATSxItWBK/wDhaacncC79+q1B1VB8SQ49AlVaQCM+XxmIO29cWX4cvsFj65mD2qrzA==",
+      "requires": {
+        "@types/pg": "^7.14.4",
+        "pg": "^8.2.1"
+      }
     },
     "content-disposition": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.11.0",
     "@aws-sdk/lib-storage": "^3.12.0",
+    "connect-pg-simple": "^6.2.1",
     "ejs": "^3.1.6",
     "express": "^4.17.1",
     "express-session": "^1.17.1",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -100,6 +100,7 @@ router.get('/twitch/callback', async (req, res) => {
 
 		user.setTwitchToken(token);
 
+		req.session.token = token;
 		req.session.user = {
 			id:     user.id,
 			login:  user.login,

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -18,60 +18,84 @@ router.get('/', (req, res) => {
 	res.render('intro');
 });
 
-router.get('/room/admin', middlewares.assertSession, (req, res) => {
-	res.sendFile(path.join(__dirname, '../public/views/competition_admin.html'));
-});
-
-router.get('/room/u/:login/admin', middlewares.assertSession, async (req, res) => {
-	const target_user = await UserDAO.getUserByLogin(req.params.login);
-
-	if (!target_user) {
-		res.status(404).send('Target User Not found');
-		return;
+router.get('/room/admin',
+	middlewares.assertSession,
+	middlewares.checkToken,
+	(req, res) => {
+		res.sendFile(path.join(__dirname, '../public/views/competition_admin.html'));
 	}
+);
 
-	res.sendFile(path.join(__dirname, '../public/views/competition_admin.html'));
-});
+router.get('/room/u/:login/admin',
+	middlewares.assertSession,
+	middlewares.checkToken,
+	async (req, res) => {
+		const target_user = await UserDAO.getUserByLogin(req.params.login);
 
-router.get('/room/producer', middlewares.assertSession, (req, res) => {
-	res.sendFile(path.join(__dirname, '../public/ocr/ocr.html'));
-});
+		if (!target_user) {
+			res.status(404).send('Target User Not found');
+			return;
+		}
 
-router.get('/room/u/:login/producer', middlewares.assertSession, async (req, res) => {
-	const target_user = await UserDAO.getUserByLogin(req.params.login);
-
-	if (!target_user) {
-		res.status(404).send('Target User Not found');
-		return;
+		res.sendFile(path.join(__dirname, '../public/views/competition_admin.html'));
 	}
+);
 
-	res.sendFile(path.join(__dirname, '../public/ocr/ocr.html'));
-});
+router.get('/room/producer',
+	middlewares.assertSession,
+	middlewares.checkToken,
+	(req, res) => {
+		res.sendFile(path.join(__dirname, '../public/ocr/ocr.html'));
+	}
+);
+
+router.get('/room/u/:login/producer',
+	middlewares.assertSession,
+	middlewares.checkToken,
+	async (req, res) => {
+		const target_user = await UserDAO.getUserByLogin(req.params.login);
+
+		if (!target_user) {
+			res.status(404).send('Target User Not found');
+			return;
+		}
+
+		res.sendFile(path.join(__dirname, '../public/ocr/ocr.html'));
+	}
+);
 
 // This route should only be allowed by admin for non-owner
-router.get('/room/u/:login/view/:layout', middlewares.assertSession, async (req, res) => {
-	const target_user = await UserDAO.getUserByLogin(req.params.login);
+router.get('/room/u/:login/view/:layout',
+	middlewares.assertSession,
+	middlewares.checkToken,
+	async (req, res) => {
+		const target_user = await UserDAO.getUserByLogin(req.params.login);
 
-	if (!target_user) {
-		res.status(404).send('Target User Not found');
-		return;
+		if (!target_user) {
+			res.status(404).send('Target User Not found');
+			return;
+		}
+
+		const layout = layout_files[req.params.layout];
+
+		if (!layout) {
+			res.status(404).send('Layout Not found');
+			return;
+		}
+
+		res.sendFile(path.join(__dirname, `../public/views/${layout.file}.html`));
 	}
+);
 
-	const layout = layout_files[req.params.layout];
-
-	if (!layout) {
-		res.status(404).send('Layout Not found');
-		return;
-	}
-
-	res.sendFile(path.join(__dirname, `../public/views/${layout.file}.html`));
-});
-
-router.get('/renderers', middlewares.assertSession, (req, res) => {
+router.get('/renderers',
+	middlewares.assertSession,
+	middlewares.checkToken,
+	(req, res) => {
 	res.render('renderers', {
-		secret: req.session.user.secret
-	});
-});
+			secret: req.session.user.secret
+		});
+	}
+);
 
 
 // TODO: uniformalize the alyout and file names

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -7,6 +7,7 @@ const middlewares = require('../modules/middlewares');
 const UserDAO = require('../daos/UserDAO');
 
 router.use(middlewares.assertSession);
+router.use(middlewares.checkToken);
 
 router.get('/', async (req, res) => {
 	const user = await UserDAO.getUserById(req.session.user.id);

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -80,10 +80,6 @@ module.exports = function init(server, wss) {
 				secret: user.secret,
 			};
 
-			if (user.token) {
-				request.session.token = user.token;
-			}
-
 			wss.handleUpgrade(request, socket, head, function (ws) {
 				wss.emit('connection', ws, request);
 			});
@@ -144,7 +140,7 @@ module.exports = function init(server, wss) {
 		const user = await UserDAO.getUserById(request.session.user.id);
 
 		// synchronize session token if needed
-		await checkToken(request, {});
+		await middlewares.checkToken(request, {});
 
 		const connection = new Connection(user, ws);
 

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -80,6 +80,10 @@ module.exports = function init(server, wss) {
 				secret: user.secret,
 			};
 
+			if (user.token) {
+				request.session.token = user.token;
+			}
+
 			wss.handleUpgrade(request, socket, head, function (ws) {
 				wss.emit('connection', ws, request);
 			});
@@ -138,6 +142,9 @@ module.exports = function init(server, wss) {
 		console.log('WS: Connection!', request.url, request.session.user.id, request.session.user.login);
 
 		const user = await UserDAO.getUserById(request.session.user.id);
+
+		// synchronize session token if needed
+		await checkToken(request, {});
 
 		const connection = new Connection(user, ws);
 

--- a/setup/db.sql
+++ b/setup/db.sql
@@ -14,6 +14,8 @@ CREATE TABLE twitch_users (
 	last_login TIMESTAMP NOT NULL
 );
 
+CREATE INDEX IDX_users_email ON twitch_users (email);
+
 CREATE TABLE scores (
 	id SERIAL PRIMARY KEY,
 	datetime TIMESTAMP NOT NULL,
@@ -38,5 +40,21 @@ CREATE TABLE scores (
 			REFERENCES twitch_users(id)
 );
 
+CREATE INDEX IDX_scores_player_datetime ON scores (player_id, datetime);
+CREATE INDEX IDX_scores_player_score ON scores (player_id, score);
+CREATE INDEX IDX_scores_datetime ON scores (datetime);
+
+CREATE TABLE sessions (
+	sid varchar NOT NULL COLLATE "default",
+	sess json NOT NULL,
+	expire timestamp(6) NOT NULL
+)
+WITH (OIDS=FALSE);
+
+ALTER TABLE sessions ADD CONSTRAINT session_pkey PRIMARY KEY (sid) NOT DEFERRABLE INITIALLY IMMEDIATE;
+
+CREATE INDEX IDX_session_expire ON sessions (expire);
+
 INSERT INTO twitch_users VALUES (1, 'player1', 'player1@nestrischamps.com', 'PLAYER1', '', '', 'Player 1', '', NOW(), NOW());
 INSERT INTO twitch_users VALUES (2, 'player2', 'player2@nestrischamps.com', 'PLAYER2', '', '', 'Player 2', '', NOW(), NOW());
+


### PR DESCRIPTION
## Context

Sessions objects are currently stored in memory, which means that when the server restarts all users are kicked out and they need to login again. 

If the user doe snot notice that the producer and view are not longer working, he/she may play multiple games which won't be recorded.


## Approach

Store session information in DB instead of memory. On restart, view and producer should be able to reconnect successfully.

Games that was ongoing when the restart happened would still be disrupted, but things should resume shortly.

Note 1: Rooms are still not stored in DB. If a match was ongoing at the point of restart, the rooms will be recreated, and the players will be reconnect, but the host will need to setup the room a new by selecting player 1 and 2.

Note 2: The session management and twitch token synchronization is kind of  dirty... It might be better to store the access and refresh tokens for the user in the user records itself 🤔 

Bonus: Session Ids are now UUIDs, not ULID. Session IDs do not need to be lexically sortable and they do not appear in URLS, so we can use the full 128bits of randomness for the session IDs.

## Risk

The games files that were being uploaded to S3 might bet stuck, so S3 could end up being polluted over time, some mechanism to clean up S3 should be looked into eventually. Note that this problem was still existing in the previous system.

