### PR TITLE
Update data model: A user can only have a single producer

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -306,6 +306,8 @@ class MatchRoom extends Room {
 			this.admin.kick(reason);
 			this.admin = null;
 		}
+
+		this.emit('close');
 	}
 }
 

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -8,6 +8,7 @@ class MatchRoom extends Room {
 	constructor(owner, roomid) {
 		super(owner);
 
+		this.producers = new Set(); // users
 		this.admin = null;
 		this.roomid = roomid || '_default';
 		this.state = {
@@ -60,23 +61,45 @@ class MatchRoom extends Room {
 		this.sendStateToAdmin();
 	}
 
-	getProducerFields(connection) {
-		return _.pick(connection.user, PRODUCER_FIELDS);
+	getProducerFields(user) {
+		return _.pick(user, PRODUCER_FIELDS);
 	}
 
-	addProducer(connection) {
-		const is_new_user = super.addProducer(connection);
+	hasProducer(user) {
+		return this.producers.has(user);
+	}
+
+	addProducer(user) {
+		const is_new_user = !this.hasProducer(user);
 
 		if (is_new_user) {
+			this.producers.add(user);
 			this.sendStateToAdmin();
 		}
 	}
 
-	removeProducer(connection, is_replace_flow = false) {
-		const was_present = super.removeProducer(connection);
+	getProducer(user_id) {
+		const iter = this.producers.values();
+		let next;
 
-		if (was_present && !is_replace_flow) {
-			this.sendStateToAdmin();
+		while (next = iter.next()) {
+			const user = next.value;
+
+			if (user.id === user_id) {
+				return user;
+			}
+		}
+	}
+
+	removeProducer(user, is_replace_flow = false) {
+		const was_present = this.hasProducer(user);
+
+		if (was_present) {
+			this.producers.delete(user);
+
+			if (!is_replace_flow) {
+				this.sendStateToAdmin();
+			}
 		}
 	}
 
@@ -255,10 +278,10 @@ class MatchRoom extends Room {
 		}
 	}
 
-	onProducerMessage(producer, message) {
+	handleProducerMessage(user, message) {
 		// system where you can have one user being both players
 		[0, 1].forEach(p_num => {
-			if (this.state.players[p_num].id === producer.user.id) {
+			if (this.state.players[p_num].id === user.id) {
 				if (message instanceof Uint8Array) {
 					message[0] = (message[0] & 0b11111000) | p_num; // sets player number in header byte of binary message
 					this.sendToViews(message);
@@ -272,6 +295,12 @@ class MatchRoom extends Room {
 
 	close(reason) {
 		super.close(reason);
+
+		// dodgy iteration that empties the collection as it goes -_-
+		this.producers.forEach(user => {
+			this.removeProducer(user);
+		});
+		this.producers.clear(); // not needed, but added for clarity
 
 		if (this.admin) {
 			this.admin.kick(reason);

--- a/domains/PrivateRoom.js
+++ b/domains/PrivateRoom.js
@@ -1,30 +1,7 @@
-const _ = require('lodash');
-
 const Room = require('./Room');
 
 class PrivateRoom extends Room {
-	constructor(owner) {
-		super(owner);
-	}
-
-	addProducer(connection) {
-		// Only Owners can be producer of their private room
-		if (connection.user.id != this.owner.id) {
-			connection.kick('not_allowed');
-			return false; // throw?
-		}
-
-		super.addProducer(connection);
-	}
-
-	// Straight passthrough from producer to view
-	// Basically, we assume producer is just sending game frames
-	onProducerMessage(connection, message) {
-		this.sendToViews(message);
-	}
+	// No specific behaviour in private room for now
 }
-
-// API aliases:
-PrivateRoom.prototype.setProducer = PrivateRoom.prototype.addProducer;
 
 module.exports = PrivateRoom;

--- a/domains/Producer.js
+++ b/domains/Producer.js
@@ -1,0 +1,14 @@
+const _ = require('lodash');
+const Game = require('../modules/Game');
+
+class Producer {
+	constructor(user) {
+		this.user = user;
+
+		this.connection = null;
+	}
+
+	setConnection(connection) {
+
+	}
+}

--- a/domains/Producer.js
+++ b/domains/Producer.js
@@ -1,14 +1,73 @@
+const EventEmitter = require('events');
+
 const _ = require('lodash');
 const Game = require('../modules/Game');
 
-class Producer {
+class Producer extends EventEmitter {
 	constructor(user) {
 		this.user = user;
 
 		this.connection = null;
+		this.game = null;
 	}
 
 	setConnection(connection) {
+		if (this.connection) {
+			this.connection.kick('concurrency_limit');
+			this.endGame();
+		}
 
+		connection.on('message', message => {
+			if (!this.game) {
+				this.setGame();
+			}
+
+			if (message instanceof Uint8Array) {
+				// this is a game frame, we track it in the game instance
+				this.game.setFrame(message); // this call may reset the game as side effect
+			}
+
+			this.emit('message', message);
+		});
+
+		connection.on('close', () => {
+			if (this.connection === connection) {
+				this.connection = null;
+				this.endGame();
+				this.emit('close');
+			}
+		});
+
+		connection.on('error', err => {
+			this.endGame();
+			this.emit('error', err);
+		});
+
+		this.connection = connection;
+	}
+
+	setGame() {
+		if (this.game) {
+			delete this.game.onNewGame;
+		}
+
+		this.game = new Game(connection.user);
+
+		this.game.onNewGame = (frame) => {
+			console.log(`${this.user.id} is starting a new game`);
+
+			this.setGame();
+
+			this.game.setFrame(frame);
+		}
+
+		connection.game = game;
+	}
+
+	endGame() {
+		if (this.game) {
+			this.game.end();
+			this.game = null;
+		}
 	}
 }

--- a/domains/Producer.js
+++ b/domains/Producer.js
@@ -5,6 +5,8 @@ const Game = require('../modules/Game');
 
 class Producer extends EventEmitter {
 	constructor(user) {
+		super();
+
 		this.user = user;
 
 		this.connection = null;
@@ -46,12 +48,16 @@ class Producer extends EventEmitter {
 		this.connection = connection;
 	}
 
+	hasConnection() {
+		return !!this.connection;
+	}
+
 	setGame() {
 		if (this.game) {
 			delete this.game.onNewGame;
 		}
 
-		this.game = new Game(connection.user);
+		this.game = new Game(this.user);
 
 		this.game.onNewGame = (frame) => {
 			console.log(`${this.user.id} is starting a new game`);
@@ -60,8 +66,6 @@ class Producer extends EventEmitter {
 
 			this.game.setFrame(frame);
 		}
-
-		connection.game = game;
 	}
 
 	endGame() {
@@ -71,3 +75,5 @@ class Producer extends EventEmitter {
 		}
 	}
 }
+
+module.exports = Producer;

--- a/domains/Room.js
+++ b/domains/Room.js
@@ -1,5 +1,9 @@
-class Room {
+const EventEmitter = require('events');
+
+class Room extends EventEmitter {
 	constructor(owner) {
+		super();
+
 		this.owner = owner;
 		this.views = new Set(); // connections
 	}

--- a/domains/Room.js
+++ b/domains/Room.js
@@ -1,17 +1,15 @@
-const _ = require('lodash');
-
 class Room {
 	constructor(owner) {
 		this.owner = owner;
-		this.producers = new Set(); // users
 		this.views = new Set(); // connections
+	}
 
-		this.message_forwarders = new Map();
+	getOwner() {
+		return this.owner;
 	}
 
 	addView(connection) {
 		this.views.add(connection);
-
 		connection.on('close', () => this.removeView(connection));
 	}
 
@@ -23,50 +21,14 @@ class Room {
 		this.views.forEach(connection => connection.send(message));
 	}
 
-	hasProducer(user) {
-		return this.producer.has(user);
-	}
-
-	addProducer(user) {
-		const is_new_user = !this.hasProducer(user);
-
-		if (!is_new_user) {
-			this.producers.add(user);
-
-			const forwarder = (message) => {
-				this.onProducerMessage(user, message);
-			};
-
-			this.message_forwarders.set(user, forwarder);
-			user.getProducer().on('message', forwarder);
-		}
-
-		return is_new_user;
-	}
-
-	removeProducer(user) {
-		if (this.hasProducer(user)) {
-			const forwarder = this.message_forwarders.get(user);
-
-			user.getProducer().removeListener('message', forwarder);
-
-			this.message_forwarders.delete(user);
-			this.producers.delete(user);
-		}
-	}
-
 	close(reason) {
 		this.views.forEach(connection => connection.kick(reason));
 		this.views.clear();
-
-		// dodgy iteration that empties the collection as it goes -_-
-		this.producers.forEach(user => {
-			this.removeProducer(user);
-		});
-		this.producers.clear(); // not needed, but added for clarity
 	}
 
-	onProducerMessage() {}
+	handleProducerMessage(user, message) {
+		this.sendToViews(message);
+	}
 }
 
 module.exports = Room;

--- a/domains/User.js
+++ b/domains/User.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 const PrivateRoom = require('./PrivateRoom');
 const MatchRoom = require('./MatchRoom');
+const MatchRoom = require('./Producer');
 
 // Twitch stuff
 const TwitchAuth = require('twitch-auth');
@@ -37,6 +38,8 @@ class User extends EventEmitter{
 		// TODO: create rooms lazily
 		this.private_room = new PrivateRoom(this);
 		this.match_room = new MatchRoom(this);
+
+		this.producer = new Producer(this);
 
 		// keep track of all socket for the user
 		// dangerous, could lead to memory if not managed well

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -72,6 +72,12 @@ class Game {
 		}
 	}
 
+	end() {
+		if (!this.over) {
+			this._doGameOver();
+		}
+	}
+
 	setFrame(frame) {
 		const data = BinaryFrame.parse(frame);
 
@@ -121,10 +127,7 @@ class Game {
 		}
 
 		if (data.gameid != this.gameid) {
-			if (!this.over) {
-				this._doGameOver();
-			}
-
+			this.end();
 			this.onNewGame(frame);
 			return;
 		}
@@ -212,7 +215,7 @@ class Game {
 
 		// Check board for gameover event (curtain has fallen)
 		if (cur_num_blocks >= 200) {
-			this._doGameOver();
+			this.end();
 		}
 	}
 

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -277,6 +277,7 @@ class Game {
 
 				if (this.transition === null) {
 					this.transition = data.score;
+					this.onTransition();
 				}
 			}
 		}
@@ -358,8 +359,10 @@ class Game {
 		}
 	}
 
+	// TODO: change callbacks to emit events instead
 	onGameOver() {}
 	onTetris() {}
+	onTransition() {}
 	onNewGame() {}
 }
 

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -227,7 +227,11 @@ class Game {
 			this.frame_stream.end();
 		}
 
-		if (this.frame_count <= 2) return;
+		if (this.frame_count <= 2 || this.num_frames <= 2) {
+			// TODO: do we really need 2 frame counters?
+			// TODO: How to delete game file?
+			return;
+		}
 
 		const report = this.getReport();
 

--- a/public/js/connection.js
+++ b/public/js/connection.js
@@ -18,9 +18,14 @@ class Connection {
 		this.connect();
 	}
 
+	onBreak() {}
+	onResume() {}
+	onKicked() {}
 	onMessage() {}
 
-	_handleError() {}
+	_handleError(err) {
+		console.error(err);
+	}
 
 	_handleMessage(event) {
 		if (typeof event.data === 'string') {
@@ -30,8 +35,10 @@ class Connection {
 				// Connection-level command parsing
 				switch(data[0]) {
 					case '_kick': {
-						console.log('Socket kicked', data[1]);
+						const reason = data[1];
+						console.log('Socket kicked', reason);
 						this.close();
+						this.onKicked(reason);
 						return;
 					}
 				}
@@ -50,6 +57,7 @@ class Connection {
 
 	_handleClose() {
 		this._clearSocket();
+		this.onBreak();
 		setTimeout(this.connect, 5000); // TODO: exponential backoff
 	}
 
@@ -80,6 +88,11 @@ class Connection {
 
 	close() {
 		this._clearSocket();
+
+		delete this.onBreak;
+		delete this.onResume;
+		delete this.onKicked;
+		delete this.onMessage;
 	}
 
 	send(data) {

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -114,10 +114,28 @@ fieldset.field pre {
 	border: 1px solid black;
 }
 
+.notice {
+	font-weight: bold;
+	display: none;
+	padding-bottom: 1em;
+	text-align: center;
+}
+
+.error {
+	color: red;
+}
+
+.warning {
+	color: #ff8c00;
+}
+
 </style>
 </head>
 
 <body>
+
+<div class="notice"></div>
+
 <div id="calibration">
 	<img id="reference_ui" />
 	<canvas id="video_capture" />

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -115,10 +115,12 @@ fieldset.field pre {
 }
 
 .notice {
+	font-family: monospace;
 	font-weight: bold;
 	display: none;
 	padding-bottom: 1em;
 	text-align: center;
+	font-size: 14px;
 }
 
 .error {

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -153,6 +153,15 @@ function checkActivateGoButton() {
 	go_btn.disabled = !all_ready;
 }
 
+const notice = document.querySelector('div.notice');
+
+function resetNotice() {
+	notice.classList.remove('error');
+	notice.classList.remove('warning');
+	notice.textContent = '';
+	notice.style.display = 'none';
+}
+
 function connect() {
 	if (connection) {
 		connection.close();
@@ -160,7 +169,7 @@ function connect() {
 
 	connection = new Connection();
 
-	connection.onMessage= function(frame) {
+	connection.onMessage = function(frame) {
 		try{
 			let [method, ...args] = frame;
 
@@ -174,6 +183,22 @@ function connect() {
 			console.error(e);
 		}
 	}
+
+	connection.onKicked = function(reason) {
+		resetNotice();
+		notice.classList.add('error');
+		notice.textContent = `WARNING! The connection has been kicked because [${reason}]. The page will NOT attempt to reconnect.`;
+		notice.style.display = 'block';
+	}
+
+	connection.onBreak = function() {
+		resetNotice();
+		notice.classList.add('warning');
+		notice.textContent = `WARNING! The page is disconnected. It will try to reconnect automatically.`;
+		notice.style.display = 'block';
+	}
+
+	connection.onResume = resetNotice;
 }
 
 conn_host.addEventListener('change', connect);

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -155,18 +155,18 @@ module.exports = function init(server, wss) {
 			console.log('WS: Adding View', user.login, 'single?', request.tetris.view.single_player);
 			const room = request.tetris.view.single_player
 				? user.getPrivateRoom()
-				: user.getMatchRoom()
+				: user.getHostRoom()
 			;
 
 			room.addView(connection);
 		}
 		else if(pathname.startsWith('/ws/room/admin')) {
 			console.log(`MatchRoom: ${user.login}: Admin connected`);
-			user.getMatchRoom().setAdmin(connection);
+			user.getHostRoom().setAdmin(connection);
 		}
 		else if(pathname.startsWith('/ws/room/producer')) {
 			console.log(`PrivateRoom: ${user.login}: Producer connected`);
-			user.getPrivateRoom().setProducer(connection);
+			user.setProducerConnection(connection);
 		}
 		else if(m = pathname.match(/^\/ws\/room\/u\/([a-z0-9_-]+)\//)) {
 			const target_user = await UserDAO.getUserByLogin(m[1]);
@@ -188,17 +188,18 @@ module.exports = function init(server, wss) {
 				switch(connection_type) {
 					case 'admin': {
 						console.log(`MatchRoom: ${target_user.login}: Admin connected`);
-						target_user.getMatchRoom().setAdmin(connection);
+						target_user.getHostRoom().setAdmin(connection);
 						break;
 					}
 					case 'producer': {
 						console.log(`MatchRoom: ${target_user.login}: Producer ${user.login} connected`);
-						target_user.getMatchRoom().addProducer(connection);
+						user.setProducerConnection(connection);
+						user.joinMatchRoom(target_user);
 						break;
 					}
 					case 'view': {
 						console.log(`MatchRoom: ${target_user.login}: View connected, owned by ${user.login}`);
-						target_user.getMatchRoom().addView(connection);
+						target_user.getHostRoom().addView(connection);
 						break;
 					}
 					default: {


### PR DESCRIPTION
## Context

The restriction on producer used to be at the granularity of the room: one room could have a single producer per user, but a user could connect many producers to many rooms at once, and send different game data to different rooms.

While technically that made things somewhat easy, in practice, this does not make sense. As we expect users to be human tetris players, a single person can only play a single game at a time. There cannot be simultaneous games for a user at the same time.

Additionally, because rooms were independent, when a user's producer connection was in a match room, the same game data could not be sent to the user's private room, so he/she could not both be part of a host stream and have his/her own stream on nestrischamps.

## Approach

The PR changes the user/connection/room constraint.  A user can nowonly have a single producer. The producer is the entity that will track and record games. 

The producer always sends data to the user's private room.

When a user connects to a host's match room, then the game frames from the producer are additionally sent to that host's match room. Of course the frames might not make their way to the match view, if the game host didn't select the player as either player 1 and/or 2 in the admin page.

Thus a User object now has 3 properties:
* `private_room`: created with the user
* `host_room`: created with the user
* `match_room`: a reference to the match room the user connects to. `match_room` is initially null and is set when the user connects to a specific host's room. If the user connect to his/her own host room, then `match_room` will equal `host_room`
