### PR TITLE
Add optional FrameBuffer to smoothen playback

### DIFF
--- a/public/views/CTMCompetitionPlayer.js
+++ b/public/views/CTMCompetitionPlayer.js
@@ -5,6 +5,19 @@ const CTMCompetitionPlayer = (function () {
 		projection_box: DOM_DEV_NULL,
 	};
 
+	// one time check of Query String args
+	let buffer_time = QueryString.get('buffer_time') || '';
+
+	if (/^\d+$/.test(buffer_time)) {
+		buffer_time = parseInt(buffer_time, 10);
+	} else {
+		buffer_time = 0;
+	}
+
+	const DEFAULT_OPTIONS = {
+		buffer_time,
+	};
+
 	class CTMCompetitionPlayer extends CompetitionPlayer {
 		constructor(dom, options) {
 			super(
@@ -12,7 +25,10 @@ const CTMCompetitionPlayer = (function () {
 					...DEFAULT_DOM_REFS,
 					...dom,
 				},
-				options
+				{
+					...DEFAULT_OPTIONS,
+					...options,
+				}
 			);
 
 			// hack to force elements to be invisible no matter what

--- a/public/views/FrameBuffer.js
+++ b/public/views/FrameBuffer.js
@@ -1,0 +1,65 @@
+const FrameBuffer = (function () {
+	function noop() {}
+
+	class FrameBuffer {
+		constructor(duration_ms = 0, frame_callback = noop) {
+			this.duration_ms = duration_ms;
+			this.frame_callback = frame_callback;
+			this.buffer = [];
+
+			this.frame_to = null;
+
+			this.sendFrame = this.sendFrame.bind(this);
+		}
+
+		setFrame(frame) {
+			if (this.duration_ms <= 0) {
+				this.frame_callback(frame);
+				return;
+			}
+
+			this.buffer.push(frame);
+
+			if (this.buffer.length == 1) {
+				this.reset();
+			}
+		}
+
+		reset() {
+			if (this.buffer.length <= 0) return;
+
+			this.client_time_base = 0;
+			this.local_time_base = 0;
+			this.frame_to = setTimeout(this.sendFrame, this.duration_ms);
+		}
+
+		sendFrame() {
+			if (this.buffer.length <= 0) return;
+
+			const data = this.buffer.shift();
+			const now = Date.now();
+
+			// record client-local time equivalence
+			if (!this.client_time_base) {
+				this.client_time_base = data.ctime;
+				this.local_time_base = now;
+			}
+
+			// send current frame
+			this.frame_callback(data);
+
+			// schedule next frame if needed
+			if (this.buffer.length) {
+				const next_frame_ctime = this.buffer[0].ctime;
+				const elapsed = next_frame_ctime - this.client_time_base;
+
+				this.frame_to = setTimeout(
+					this.sendFrame,
+					this.local_time_base + elapsed - now
+				);
+			}
+		}
+	}
+
+	return FrameBuffer;
+})();

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -129,6 +129,7 @@ const Player = (function () {
 		tetris_sound: 1,
 		reliable_field: 1,
 		draw_field: 1,
+		buffer_time: 0,
 		format_score: (v, size) => {
 			if (!size) {
 				size = 7;
@@ -256,6 +257,7 @@ const Player = (function () {
 			};
 
 			this.renderWinnerFrame = this.renderWinnerFrame.bind(this);
+			this._setFrame = this._setFrame.bind(this);
 
 			this.reset();
 
@@ -435,6 +437,20 @@ const Player = (function () {
 		}
 
 		setFrame(data) {
+			if (this.options.buffer_time) {
+				if (!this.frame_buffer) {
+					this.frame_buffer = new FrameBuffer(
+						this.options.buffer_time,
+						this._setFrame
+					);
+				}
+				this.frame_buffer.setFrame(data);
+			} else {
+				this._setFrame(data);
+			}
+		}
+
+		_setFrame(data) {
 			if (this.game_over && this.curtain_down && data.gameid == this.gameid) {
 				return;
 			}

--- a/public/views/mp/ctm.html
+++ b/public/views/mp/ctm.html
@@ -142,6 +142,7 @@
 		<script src="/views/constants.js"></script>
 		<script src="/views/utils.js"></script>
 		<script src="/views/renderBlock.js"></script>
+		<script src="/views/FrameBuffer.js"></script>
 		<script src="/views/Player.js"></script>
 		<script src="/views/bg.js"></script>
 		<script src="/js/connection.js"></script>
@@ -190,6 +191,7 @@
 						{
 							preview_pixel_size: 2,
 							preview_align: 'tr',
+							buffer_time: 1000,
 						}
 					)
 			);

--- a/public/views/mp/ctm.html
+++ b/public/views/mp/ctm.html
@@ -191,7 +191,6 @@
 						{
 							preview_pixel_size: 2,
 							preview_align: 'tr',
-							buffer_time: 1000,
 						}
 					)
 			);

--- a/public/views/mp/ctm_2matches.html
+++ b/public/views/mp/ctm_2matches.html
@@ -229,6 +229,7 @@
 		<script src="/views/constants.js"></script>
 		<script src="/views/utils.js"></script>
 		<script src="/views/renderBlock.js"></script>
+		<script src="/views/FrameBuffer.js"></script>
 		<script src="/views/Player.js"></script>
 		<script src="/views/bg.js"></script>
 		<script src="/js/connection.js"></script>

--- a/public/views/mp/ctm_video.html
+++ b/public/views/mp/ctm_video.html
@@ -164,6 +164,7 @@
 		<script src="/views/constants.js"></script>
 		<script src="/views/utils.js"></script>
 		<script src="/views/renderBlock.js"></script>
+		<script src="/views/FrameBuffer.js"></script>
 		<script src="/views/Player.js"></script>
 		<script src="/views/bg.js"></script>
 		<script src="/js/connection.js"></script>

--- a/public/views/mp/ctm_video2.html
+++ b/public/views/mp/ctm_video2.html
@@ -177,6 +177,7 @@
 		<script src="/views/constants.js"></script>
 		<script src="/views/utils.js"></script>
 		<script src="/views/renderBlock.js"></script>
+		<script src="/views/FrameBuffer.js"></script>
 		<script src="/views/Player.js"></script>
 		<script src="/views/bg.js"></script>
 		<script src="/js/connection.js"></script>

--- a/public/views/mp/ctwc.html
+++ b/public/views/mp/ctwc.html
@@ -239,6 +239,7 @@
 		<script src="/views/bg.js"></script>
 		<script src="/views/utils.js"></script>
 		<script src="/views/renderBlock.js"></script>
+		<script src="/views/FrameBuffer.js"></script>
 		<script src="/views/Player.js"></script>
 		<script src="/js/connection.js"></script>
 		<script src="/views/CompetitionPlayer.js"></script>


### PR DESCRIPTION
Frames can be buffered to be replayed according to their recorded capture time on the sender-side. This should help smoothen out the playback when the latency is unstable (frames received clumped together will be played back with the correct time spacing).

Implementation is simple and straight forward, but I worry about edge cases (e.g. hard refresh of the producer), so this needs to be tested.

The Frame Buffer resets when it gets empty. This might create some weird visual glitches when connections are not stable.
