### PR TITLE
Better block accounting: stop relying only on the first frame of clear animations

### DIFF
--- a/views/scores.ejs
+++ b/views/scores.ejs
@@ -84,7 +84,7 @@
 					<a class="details_score" href="/stats/scores/<%= score.id %>">details</a>
 					<% if (score.frame_file) { %>
 					-
-					<a class="replay_score" href="/replay/simple_1p/<%= score.id %>">replay</a>
+					<a class="replay_score" href="/replay/simple_1p/<%= score.id %>?bg=2&speed=2">replay</a>
 					<% } %>
 					-
 					<a class="delete_score" href="/stats/scores/<%= score.id %>">delete</a>


### PR DESCRIPTION
## Context

In layouts `classic`, `das_trainer`, `tomellosoulman`, block accounting assumes no frame drops and assumes it can capture the first frame of the line clear animation. This is a dangerous gambit: if the frame is missed, block accounting will go out of sync (possibly by counting a clear as an incorrect clear), piece counters will stop, and drought counter will stop.

This PR introduces a more resilient system, where clears are detected as long as any 2 frames of a particular clear are detected.

## Approach

1. List down explicitly the negative block counts that are possible and the sequence that can exist with this:
```javascript
const all_possible_negative_diffs = [
	-2, -4, -6, -8, -10, -12, -16, -18, -20, -24, -30, -32, -40,
];
const clear_diffs = [
	[-2,  -4,  -6,  -8, -10],
	[-4,  -8, -12, -16, -20],
	[-6, -12, -18, -24, -30],
	[-8, -16, -24, -32, -40],
];
```
2. Track full rows as piece moves

When a valid negative block count is seen

* check if there was full rows prior, and check if the negative diff is found in the possible value for that clear type (e.g. expecting a triple and seeing `-12`). If there's a match, we consider the clear matched and activate it. If the clear was a tetris, we play the tetris flash

* if there was no row prior, we record the negative diff, and wait for the next negative value. We can then find the clear type by finding the clear that contained both negative values. This works because many of the negative values are colliding across clear types (e.g. `-4` could be a single or a double), but there are no collision for 2 values!

Benefits:
* Identifying a clear type no longer relies on capturing a specific frame
* Use full rows as an expectation of clears
* Resilient to missing some frames in the clear animation, as long as there is no 5 consecutive frame drops.

This is still weak, but should be much more resilient than the prior approach.

Tested on emulator locally

## Risk 
Since this is a new algorithm, there could be undetected edge cases.
PR should get a bit more testing before being merged and deployed.
