### PR TITLE
Upgrade dependencies + migrate to ESM (FE + BE)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
 	"extends": ["eslint:recommended", "prettier"],
 	"ignorePatterns": ["public"],
 	"parserOptions": {
-		"ecmaVersion": 12
+		"ecmaVersion": 12,
+		"sourceType": "module"
 	},
 	"rules": {}
 }

--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -1,4 +1,4 @@
-const dbPool = require('../modules/db');
+import dbPool from '../modules/db.js';
 
 class ScoreDAO {
 	async getStats(user) {
@@ -334,4 +334,4 @@ class ScoreDAO {
 	}
 }
 
-module.exports = new ScoreDAO();
+export default new ScoreDAO();

--- a/daos/UserDAO.js
+++ b/daos/UserDAO.js
@@ -1,5 +1,5 @@
-const User = require('../domains/User');
-const dbPool = require('../modules/db');
+import User from '../domains/User.js';
+import dbPool from '../modules/db.js';
 
 class UserDAO {
 	constructor() {
@@ -172,4 +172,4 @@ class UserDAO {
 	}
 }
 
-module.exports = new UserDAO();
+export default new UserDAO();

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -1,6 +1,4 @@
-const _ = require('lodash');
-
-const Room = require('./Room');
+import Room from './Room.js';
 
 const PRODUCER_FIELDS = ['id', 'login', 'display_name', 'profile_image_url'];
 const MAX_PLAYERS = 8;
@@ -535,4 +533,4 @@ class MatchRoom extends Room {
 	}
 }
 
-module.exports = MatchRoom;
+export default MatchRoom;

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Room from './Room.js';
 
 const PRODUCER_FIELDS = ['id', 'login', 'display_name', 'profile_image_url'];

--- a/domains/PrivateRoom.js
+++ b/domains/PrivateRoom.js
@@ -1,4 +1,4 @@
-const Room = require('./Room');
+import Room from './Room.js';
 
 class PrivateRoom extends Room {
 	constructor(owner) {
@@ -30,4 +30,4 @@ class PrivateRoom extends Room {
 	}
 }
 
-module.exports = PrivateRoom;
+export default PrivateRoom;

--- a/domains/Producer.js
+++ b/domains/Producer.js
@@ -1,6 +1,5 @@
-const EventEmitter = require('events');
-
-const Game = require('../modules/Game');
+import EventEmitter from 'events';
+import Game from '../modules/Game.js';
 
 class Producer extends EventEmitter {
 	constructor(user) {
@@ -106,4 +105,4 @@ class Producer extends EventEmitter {
 	}
 }
 
-module.exports = Producer;
+export default Producer;

--- a/domains/Replay.js
+++ b/domains/Replay.js
@@ -1,6 +1,5 @@
 import got from 'got';
 import zlib from 'zlib';
-import path from 'path';
 import fs from 'fs';
 
 import BinaryFrame from '../public/js/BinaryFrame.js';

--- a/domains/Replay.js
+++ b/domains/Replay.js
@@ -49,7 +49,7 @@ class Replay {
 			} else {
 				// data comes from local file
 				this.game_stream = fs
-					.createReadStream(path.join(__dirname, '..', file_path))
+					.createReadStream(file_path)
 					.pipe(zlib.createGunzip());
 			}
 		}

--- a/domains/Replay.js
+++ b/domains/Replay.js
@@ -1,9 +1,10 @@
-const BinaryFrame = require('../public/js/BinaryFrame');
-const ScoreDAO = require('../daos/ScoreDAO');
-const got = require('got');
-const zlib = require('zlib');
-const path = require('path');
-const fs = require('fs');
+import got from 'got';
+import zlib from 'zlib';
+import path from 'path';
+import fs from 'fs';
+
+import BinaryFrame from '../public/js/BinaryFrame.js';
+import ScoreDAO from '../daos/ScoreDAO.js';
 
 class Replay {
 	constructor(connection, player_num, game_id_or_url, time_scale = 1) {
@@ -146,4 +147,4 @@ class Replay {
 	}
 }
 
-module.exports = Replay;
+export default Replay;

--- a/domains/Room.js
+++ b/domains/Room.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events');
+import EventEmitter from 'events';
 
 class Room extends EventEmitter {
 	constructor(owner) {
@@ -45,4 +45,4 @@ class Room extends EventEmitter {
 	}
 }
 
-module.exports = Room;
+export default Room;

--- a/domains/User.js
+++ b/domains/User.js
@@ -1,13 +1,11 @@
-const EventEmitter = require('events');
-const PrivateRoom = require('./PrivateRoom');
-const MatchRoom = require('./MatchRoom');
-const Producer = require('./Producer');
+import EventEmitter from 'events';
+import PrivateRoom from './PrivateRoom.js';
+import MatchRoom from './MatchRoom.js';
+import Producer from './Producer.js';
 
 // Twitch stuff
-const TwitchAuth = require('twitch-auth');
-const StaticAuthProvider = TwitchAuth.StaticAuthProvider;
-const RefreshableAuthProvider = TwitchAuth.RefreshableAuthProvider;
-const ChatClient = require('twitch-chat-client').ChatClient;
+import { StaticAuthProvider, RefreshableAuthProvider } from 'twitch-auth';
+import { ChatClient } from 'twitch-chat-client';
 
 const USER_SESSION_TIMEOUT = 30 * 60 * 1000; // 30 minutes before we destroy user! TODO: Make tunable
 
@@ -296,4 +294,4 @@ class User extends EventEmitter {
 	}
 }
 
-module.exports = User;
+export default User;

--- a/modules/Connection.js
+++ b/modules/Connection.js
@@ -1,10 +1,10 @@
 // thin wrapper above websocket to handle destruction
 
-const _ = require('lodash');
-const EventEmitter = require('events');
-const ULID = require('ulid');
+import _ from 'lodash';
+import EventEmitter from 'events';
+import ULID from 'ulid';
 
-const BinaryFrame = require('../public/js/BinaryFrame');
+import BinaryFrame from '../public/js/BinaryFrame.js';
 
 const KICK_DESTROY_DELAY = 1000; // allows UI to get message and know it should not attempt to reconnect
 const PING_INTERVAL = 15000;
@@ -149,4 +149,4 @@ class Connection extends EventEmitter {
 	}
 }
 
-module.exports = Connection;
+export default Connection;

--- a/modules/Connection.js
+++ b/modules/Connection.js
@@ -97,13 +97,15 @@ class Connection extends EventEmitter {
 		this.emit('close', code, reason);
 	}
 
-	_onMessage(message) {
-		if (message instanceof Uint8Array) {
+	_onMessage(message, isBinary) {
+		if (isBinary) {
 			// binary frames are always game frames
 			try {
 				message = BinaryFrame.getFrameFromBuffer(message); // throws if message is invalid
 			} catch (err) {
-				console.warn(`Unable to process binary frame: ${err.message}`);
+				console.warn(
+					`Unable to process binary frame: ${err.message} - ${message.length}`
+				);
 				return;
 			}
 		} else {

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -1,16 +1,16 @@
 // Minimum amount of game tracking to do server side to be able to report games
-const BinaryFrame = require('../public/js/BinaryFrame');
-const ScoreDAO = require('../daos/ScoreDAO');
-const ULID = require('ulid');
+import BinaryFrame from '../public/js/BinaryFrame.js';
+import ScoreDAO from '../daos/ScoreDAO.js';
+import ULID from 'ulid';
 
 // The below is to upload game frames to S3
 // That should be refactored into another file
-const { Upload } = require('@aws-sdk/lib-storage');
-const { S3Client } = require('@aws-sdk/client-s3');
-const zlib = require('zlib');
+import { Upload } from '@aws-sdk/lib-storage';
+import { S3Client } from '@aws-sdk/client-s3';
+import zlib from 'zlib';
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 const PIECES = ['T', 'J', 'Z', 'O', 'S', 'L', 'I'];
 const SCORE_BASES = [0, 40, 100, 300, 1200];
@@ -404,4 +404,4 @@ class Game {
 	onNewGame() {}
 }
 
-module.exports = Game;
+export default Game;

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -64,10 +64,9 @@ class Game {
 				);
 			} else if (!process.env.IS_PUBLIC_SERVER) {
 				// Saving on local filesystem
-				const full_dir = path.join(__dirname, '..', dir);
 
-				fs.mkdirSync(full_dir, { recursive: true }); // sync action is no good! Can we do without the sync? 😰
-				this.frame_stream.pipe(fs.createWriteStream(path.join(full_dir, file)));
+				fs.mkdirSync(dir, { recursive: true }); // sync action is no good! Can we do without the sync? 😰
+				this.frame_stream.pipe(fs.createWriteStream(path.join(dir, file)));
 			}
 		}
 	}

--- a/modules/app.js
+++ b/modules/app.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import express from 'express';
 import middlewares from './middlewares.js';
 

--- a/modules/app.js
+++ b/modules/app.js
@@ -7,7 +7,7 @@ const app = express();
 app.set('view engine', 'ejs');
 app.set('trust proxy', 1); // trust first proxy (i.e. heroku) -- needed to get req.protocol correctly
 
-app.use(express.static(path.join(__dirname, '../public')));
+app.use(express.static('../public'));
 app.use(middlewares.sessionMiddleware);
 
 const TWITCH_LOGIN_BASE_URI = 'https://id.twitch.tv/oauth2/authorize?';
@@ -46,9 +46,14 @@ app.use((req, res, next) => {
 	next();
 });
 
-app.use('/auth', require('../routes/auth'));
-app.use('/stats', require('../routes/score'));
-app.use('/settings', require('../routes/settings'));
-app.use('', require('../routes/routes'));
+import authRoutes from '../routes/auth.js';
+import scoreRoutes from '../routes/score.js';
+import settingsRoute from '../routes/settings.js';
+import defaultRoutes from '../routes/routes.js';
+
+app.use('/auth', authRoutes);
+app.use('/stats', scoreRoutes);
+app.use('/settings', settingsRoute);
+app.use('', defaultRoutes);
 
 export default app;

--- a/modules/app.js
+++ b/modules/app.js
@@ -1,6 +1,7 @@
-const path = require('path');
-const express = require('express');
-const middlewares = require('./middlewares');
+import path from 'path';
+import express from 'express';
+import middlewares from './middlewares.js';
+
 const app = express();
 
 app.set('view engine', 'ejs');
@@ -50,4 +51,4 @@ app.use('/stats', require('../routes/score'));
 app.use('/settings', require('../routes/settings'));
 app.use('', require('../routes/routes'));
 
-module.exports = app;
+export default app;

--- a/modules/app.js
+++ b/modules/app.js
@@ -7,7 +7,7 @@ const app = express();
 app.set('view engine', 'ejs');
 app.set('trust proxy', 1); // trust first proxy (i.e. heroku) -- needed to get req.protocol correctly
 
-app.use(express.static('../public'));
+app.use(express.static('public'));
 app.use(middlewares.sessionMiddleware);
 
 const TWITCH_LOGIN_BASE_URI = 'https://id.twitch.tv/oauth2/authorize?';

--- a/modules/db.js
+++ b/modules/db.js
@@ -1,7 +1,9 @@
-const { Pool } = require('pg');
+import pg from 'pg';
+
+let pool;
 
 if (process.env.IS_PUBLIC_SERVER) {
-	const pool = new Pool({
+	pool = new pg.Pool({
 		connectionString: process.env.DATABASE_URL,
 		ssl: {
 			rejectUnauthorized: false,
@@ -13,8 +15,6 @@ if (process.env.IS_PUBLIC_SERVER) {
 	pool.on('error', err => {
 		console.error('DB: Unexpected error on idle client', err);
 	});
-
-	module.exports = pool;
 } else {
 	/*
 	// Fake Pool for local access
@@ -41,7 +41,7 @@ if (process.env.IS_PUBLIC_SERVER) {
 	};
 	/**/
 
-	const pool = new Pool({
+	pool = new pg.Pool({
 		connectionString: process.env.DATABASE_URL,
 	});
 
@@ -50,6 +50,6 @@ if (process.env.IS_PUBLIC_SERVER) {
 	pool.on('error', err => {
 		console.error('DB: Unexpected error on idle client', err);
 	});
-
-	module.exports = pool;
 }
+
+export default pool;

--- a/modules/layouts.js
+++ b/modules/layouts.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const glob = require('glob');
+import fs from 'fs';
+import glob from 'glob';
 
 const layouts = {
 	_types: {
@@ -59,4 +59,4 @@ const elapsed = Date.now() - start;
 
 console.log(`Populated layouts data from filesystem in ${elapsed} ms.`);
 
-module.exports = layouts;
+export default layouts;

--- a/modules/middlewares.js
+++ b/modules/middlewares.js
@@ -1,10 +1,12 @@
-const session = require('express-session');
-const { v4: uuidv4 } = require('uuid');
-const dbPool = require('./db');
-const pgSession = require('connect-pg-simple')(session);
-const UserDAO = require('../daos/UserDAO');
+import session from 'express-session';
+import { v4 as uuidv4 } from 'uuid';
+import dbPool from './db.js';
+import pgConnect from 'connect-pg-simple';
+import UserDAO from '../daos/UserDAO.js';
 
-module.exports = {
+const pgSession = pgConnect(session);
+
+export default {
 	sessionMiddleware: session({
 		secret: process.env.SESSION_SECRET || uuidv4(),
 		resave: false,

--- a/modules/timezones.js
+++ b/modules/timezones.js
@@ -1,4 +1,6 @@
-const timezones = require('timezones.json')
+import tzs from 'timezones.json';
+
+const timezones = tzs
 	.reduce((acc, o) => {
 		return acc.push(...o.utc), acc;
 	}, [])
@@ -28,4 +30,4 @@ const tz_set = new Set(timezones); // to remove duplicates
 // Here's hoping the resultant set is a strict subset of Postgres:
 // "SELECT name FROM pg_timezone_names;"
 
-module.exports = [...tz_set].sort();
+export default [...tz_set].sort();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,23 +1010,6 @@
 				"tslib": "^2.3.0"
 			}
 		},
-		"@d-fischer/cache-decorators": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-2.1.3.tgz",
-			"integrity": "sha512-MlM8ipg5Exkc0Ok//sG83smBW4mLRL+/ZngfxYQ8IgxBjfpM3m2M+Y2X+a9St3EyJfYoVKHR8RWdICsU+W3gSA==",
-			"requires": {
-				"@d-fischer/shared-utils": "^3.0.1",
-				"@types/node": "^14.14.22",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "14.18.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-					"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
-				}
-			}
-		},
 		"@d-fischer/connection": {
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/@d-fischer/connection/-/connection-6.6.2.tgz",
@@ -1081,15 +1064,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@d-fischer/isomorphic-ws/-/isomorphic-ws-7.0.0.tgz",
 			"integrity": "sha512-bydCy1tKvPKvyF0KeDvN1aiAZA4CzQVa2gHifNQczW9Czl89vZ4QHnJMjUcTboWKecbnz5mGiM9PjKA1Xx2Dyg=="
-		},
-		"@d-fischer/logger": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-3.1.0.tgz",
-			"integrity": "sha512-kNg9PjmiyH9DMr70mAWU+i+dy3+e1hI0lR+No5RJduQtexI247NmEzNd0pethpwm+1uA0MRf3w9QnqZ1PHKvyA==",
-			"requires": {
-				"detect-node": "^2.0.4",
-				"tslib": "^2.0.3"
-			}
 		},
 		"@d-fischer/promise.allsettled": {
 			"version": "2.0.2",
@@ -1254,6 +1228,151 @@
 			"integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
 			"requires": {
 				"defer-to-connect": "^2.0.1"
+			}
+		},
+		"@twurple/api": {
+			"version": "5.0.18",
+			"resolved": "https://registry.npmjs.org/@twurple/api/-/api-5.0.18.tgz",
+			"integrity": "sha512-ubf00qA6t+Az//zl4vFmOKR+axqwwmS9pIrHwUAS5jTqNlvVfxO73jtnRnoM45K4zHjt6yQvVZnum/uFUNM8yw==",
+			"requires": {
+				"@d-fischer/cache-decorators": "^3.0.0",
+				"@d-fischer/logger": "^4.0.0",
+				"@d-fischer/rate-limiter": "^0.4.4",
+				"@d-fischer/shared-utils": "^3.2.0",
+				"@twurple/api-call": "^5.0.18",
+				"@twurple/common": "^5.0.18",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"@d-fischer/cache-decorators": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
+					"integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
+					"requires": {
+						"@d-fischer/shared-utils": "^3.0.1",
+						"@types/node": "^14.14.22",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@d-fischer/logger": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
+					"integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
+					"requires": {
+						"@d-fischer/shared-utils": "^3.2.0",
+						"detect-node": "^2.0.4",
+						"tslib": "^2.0.3"
+					}
+				},
+				"@types/node": {
+					"version": "14.18.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+					"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
+				}
+			}
+		},
+		"@twurple/api-call": {
+			"version": "5.0.18",
+			"resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-5.0.18.tgz",
+			"integrity": "sha512-OTCuGdCOXo1CmpKJ2qKQ6Yn02I3GlRJ8M2pl41WdQgMEQUYO1dqrAik14f5GXwKmGYh1XFsEJKn66IP93gLehA==",
+			"requires": {
+				"@d-fischer/cross-fetch": "^4.0.2",
+				"@d-fischer/qs": "^7.0.2",
+				"@twurple/common": "^5.0.18",
+				"@types/node-fetch": "^2.5.7",
+				"tslib": "^2.0.3"
+			}
+		},
+		"@twurple/auth": {
+			"version": "5.0.18",
+			"resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-5.0.18.tgz",
+			"integrity": "sha512-ktwwGmmXWTu3JmTZCweuH/NntzFNtC96+c5setbPb12h/q7HjCJxdvmBbGFbUgipFnZ9Z7iQGS2s5WPwK2IAsA==",
+			"requires": {
+				"@d-fischer/logger": "^4.0.0",
+				"@d-fischer/shared-utils": "^3.2.0",
+				"@twurple/api-call": "^5.0.18",
+				"@twurple/common": "^5.0.18",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"@d-fischer/logger": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
+					"integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
+					"requires": {
+						"@d-fischer/shared-utils": "^3.2.0",
+						"detect-node": "^2.0.4",
+						"tslib": "^2.0.3"
+					}
+				}
+			}
+		},
+		"@twurple/chat": {
+			"version": "5.0.18",
+			"resolved": "https://registry.npmjs.org/@twurple/chat/-/chat-5.0.18.tgz",
+			"integrity": "sha512-kgHOXoKiM+8TRxX9GAuv1yWYMDVeOMUNS5nwuIV/gd0aWnNfFSIUJKcDu+FHevSDj4IodJq4rNx/oPiotPOFhQ==",
+			"requires": {
+				"@d-fischer/cache-decorators": "^3.0.0",
+				"@d-fischer/deprecate": "^2.0.2",
+				"@d-fischer/logger": "^4.0.0",
+				"@d-fischer/rate-limiter": "^0.4.4",
+				"@d-fischer/shared-utils": "^3.2.0",
+				"@d-fischer/typed-event-emitter": "^3.2.2",
+				"@twurple/common": "^5.0.18",
+				"ircv3": "^0.28.0",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"@d-fischer/cache-decorators": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
+					"integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
+					"requires": {
+						"@d-fischer/shared-utils": "^3.0.1",
+						"@types/node": "^14.14.22",
+						"tslib": "^2.1.0"
+					}
+				},
+				"@d-fischer/logger": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
+					"integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
+					"requires": {
+						"@d-fischer/shared-utils": "^3.2.0",
+						"detect-node": "^2.0.4",
+						"tslib": "^2.0.3"
+					}
+				},
+				"@types/node": {
+					"version": "14.18.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+					"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
+				},
+				"ircv3": {
+					"version": "0.28.1",
+					"resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.28.1.tgz",
+					"integrity": "sha512-zYTN7S96evwQrQF7+1024JpGzPrK0enSiabd9uhzik9TZMstsellIUkLcQHYOxdq+P0dfDPqbvGqKrg2OAiaeA==",
+					"requires": {
+						"@d-fischer/connection": "^6.6.0",
+						"@d-fischer/escape-string-regexp": "^5.0.0",
+						"@d-fischer/logger": "^4.0.0",
+						"@d-fischer/shared-utils": "^3.0.1",
+						"@d-fischer/typed-event-emitter": "^3.2.2",
+						"@types/node": "^14.14.19",
+						"klona": "^2.0.4",
+						"tslib": "^2.0.3"
+					}
+				}
+			}
+		},
+		"@twurple/common": {
+			"version": "5.0.18",
+			"resolved": "https://registry.npmjs.org/@twurple/common/-/common-5.0.18.tgz",
+			"integrity": "sha512-pyC1OOOqR4yAUPzgq1DwLyV1SAvVFeUPCgUIY03WtvIoJYL17I1JUNEYFnrBViXTQtjH6ucXprnOR2aQEKghSQ==",
+			"requires": {
+				"@d-fischer/shared-utils": "^3.2.0",
+				"klona": "^2.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"@types/cacheable-request": {
@@ -2411,28 +2530,6 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 		},
-		"ircv3": {
-			"version": "0.26.14",
-			"resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.26.14.tgz",
-			"integrity": "sha512-R0wiULLrl2d6Rrmw3vgyi9Cxw1KHky9/RwTkSo/Y6sXFH45EuLpVJhm9eLHFTs8EKrayq4H6FYfEN95KBC1qMQ==",
-			"requires": {
-				"@d-fischer/connection": "^6.4.2",
-				"@d-fischer/escape-string-regexp": "^5.0.0",
-				"@d-fischer/logger": "^3.1.0",
-				"@d-fischer/shared-utils": "^3.0.1",
-				"@d-fischer/typed-event-emitter": "^3.2.2",
-				"@types/node": "^14.14.19",
-				"klona": "^2.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "14.18.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-					"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
-				}
-			}
-		},
 		"is-arguments": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -3359,11 +3456,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
 			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
 		},
-		"top-package": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/top-package/-/top-package-1.0.1.tgz",
-			"integrity": "sha512-tsuhQlHSigOTTvonxHXwqSKEVSnWMh2GvpTvXa5YmoyOwL5YvU4lTd/KNVZlKM5v7gqx44UEuQxyPQEpmaIHdg=="
-		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -3373,76 +3465,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-		},
-		"twitch": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/twitch/-/twitch-4.6.7.tgz",
-			"integrity": "sha512-inOFFLFhTcls/sskGcQWIfPgvhAF92fDo3uoGHdk0YRzo87NUHprvPE/LJJKh2IsysOPCmA1/mpnjReAgr5opA==",
-			"requires": {
-				"@d-fischer/cache-decorators": "^2.1.1",
-				"@d-fischer/deprecate": "^2.0.2",
-				"@d-fischer/logger": "^3.1.0",
-				"@d-fischer/rate-limiter": "^0.4.3",
-				"@d-fischer/shared-utils": "^3.0.1",
-				"top-package": "^1.0.0",
-				"tslib": "^2.0.3",
-				"twitch-api-call": "^4.6.7",
-				"twitch-auth": "^4.6.7",
-				"twitch-common": "^4.6.7"
-			}
-		},
-		"twitch-api-call": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.6.7.tgz",
-			"integrity": "sha512-JPiboygoHX3O2jdeWrmwW+VxpJbBYQJRg6+Th9GmqrsHivFFiyjBQproSMVJEgtrViGV1gHw6xlw1wHpoSU4Mw==",
-			"requires": {
-				"@d-fischer/cross-fetch": "^4.0.2",
-				"@d-fischer/qs": "^7.0.2",
-				"@types/node-fetch": "^2.5.7",
-				"node-fetch": "^2.6.1",
-				"tslib": "^2.0.3",
-				"twitch-common": "^4.6.7"
-			}
-		},
-		"twitch-auth": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.6.7.tgz",
-			"integrity": "sha512-9AkenhrZfXVdL1P2hJ7rLFKWOOGnkgf5isTJbjGD/GP2NYFYS+Oh8TYp8uyjW3/jQODIFuZeHPIhE6AIK5TVIA==",
-			"requires": {
-				"@d-fischer/deprecate": "^2.0.2",
-				"@d-fischer/logger": "^3.1.0",
-				"@d-fischer/shared-utils": "^3.0.1",
-				"tslib": "^2.0.3",
-				"twitch-api-call": "^4.6.7",
-				"twitch-common": "^4.6.7"
-			}
-		},
-		"twitch-chat-client": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.6.7.tgz",
-			"integrity": "sha512-KXRiEIWC1eK3Xbwsphcq6Bl/JAlzJEx9IVYOh3CXgkeu/tYgxzOlwVEtpmoK4CO9Z0CwpxBhE23NF8ZZ9wGdBQ==",
-			"requires": {
-				"@d-fischer/cache-decorators": "^2.1.1",
-				"@d-fischer/deprecate": "^2.0.2",
-				"@d-fischer/logger": "^3.1.0",
-				"@d-fischer/rate-limiter": "^0.4.3",
-				"@d-fischer/shared-utils": "^3.0.1",
-				"@d-fischer/typed-event-emitter": "^3.2.2",
-				"ircv3": "^0.26.14",
-				"tslib": "^2.0.3",
-				"twitch-auth": "^4.6.7",
-				"twitch-common": "^4.6.7"
-			}
-		},
-		"twitch-common": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/twitch-common/-/twitch-common-4.6.7.tgz",
-			"integrity": "sha512-Jwhp8bPnrzGjarPw/sA6jBLjjJnpNGptSJpZcKDzXXShFh2KxxRD7RwKPSLQS8st/SZ5iDwQs+jjSoWugOBJxg==",
-			"requires": {
-				"@d-fischer/logger": "^3.1.0",
-				"@d-fischer/shared-utils": "^3.0.1",
-				"tslib": "^2.0.3"
-			}
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,32 +1010,6 @@
 				"tslib": "^2.3.0"
 			}
 		},
-		"@babel/code-frame": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-			"dev": true,
-			"requires": {
-				"@babel/highlight": "^7.10.4"
-			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-			"dev": true
-		},
-		"@babel/highlight": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.16.7",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			}
-		},
 		"@d-fischer/cache-decorators": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-2.1.3.tgz",
@@ -1201,18 +1175,18 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-			"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+			"integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
-				"debug": "^4.1.1",
-				"espree": "^7.3.0",
+				"debug": "^4.3.2",
+				"espree": "^9.3.1",
 				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^3.13.1",
+				"js-yaml": "^4.1.0",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -1226,6 +1200,12 @@
 						"ms": "2.1.2"
 					}
 				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1235,12 +1215,12 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
 			"dev": true,
 			"requires": {
-				"@humanwhocodes/object-schema": "^1.2.0",
+				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.4"
 			},
@@ -1274,11 +1254,11 @@
 			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
 		},
 		"@szmarczak/http-timer": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+			"integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
 			"requires": {
-				"defer-to-connect": "^2.0.0"
+				"defer-to-connect": "^2.0.1"
 			}
 		},
 		"@types/cacheable-request": {
@@ -1326,12 +1306,12 @@
 			}
 		},
 		"@types/pg": {
-			"version": "7.14.11",
-			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.14.11.tgz",
-			"integrity": "sha512-EnZkZ1OMw9DvNfQkn2MTJrwKmhJYDEs5ujWrPfvseWNoI95N8B4HzU/Ltrq5ZfYxDX/Zg8mTzwr6UAyTjjFvXA==",
+			"version": "8.6.4",
+			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.4.tgz",
+			"integrity": "sha512-uYA7UMVzDFpJobCrqwW/iWkFmvizy6knIUgr0Quaw7K1Le3ZnF7hI3bKqFoxPZ+fju1Sc7zdTvOl9YfFZPcmeA==",
 			"requires": {
 				"@types/node": "*",
-				"pg-protocol": "^1.2.0",
+				"pg-protocol": "*",
 				"pg-types": "^2.2.0"
 			}
 		},
@@ -1361,9 +1341,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -1384,12 +1364,6 @@
 				"uri-js": "^4.2.2"
 			}
 		},
-		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
-		},
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1405,13 +1379,10 @@
 			}
 		},
 		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"array-differ": {
 			"version": "3.0.0",
@@ -1446,12 +1417,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
 			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-			"dev": true
-		},
-		"astral-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 			"dev": true
 		},
 		"async": {
@@ -1525,9 +1490,9 @@
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
 		},
 		"cacheable-lookup": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz",
+			"integrity": "sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A=="
 		},
 		"cacheable-request": {
 			"version": "7.0.2",
@@ -1541,6 +1506,13 @@
 				"lowercase-keys": "^2.0.0",
 				"normalize-url": "^6.0.1",
 				"responselike": "^2.0.0"
+			},
+			"dependencies": {
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+				}
 			}
 		},
 		"call-bind": {
@@ -1603,12 +1575,12 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"connect-pg-simple": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-6.2.1.tgz",
-			"integrity": "sha512-bwDp/gKyRtyz0V5Vxy3SATSxItWBK/wDhaacncC79+q1B1VB8SQ49AlVaQCM+XxmIO29cWX4cvsFj65mD2qrzA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-7.0.0.tgz",
+			"integrity": "sha512-fbNZUkxz8m+FRbctoxAU18DzRKp8GQSL+9gTJ0+LgSCElXLon2q8tDE8V74jUzf+w2ARZX8HKKyV0laX1NUZ/Q==",
 			"requires": {
-				"@types/pg": "^7.14.4",
-				"pg": "^8.2.1"
+				"@types/pg": "^8.6.1",
+				"pg": "^8.7.1"
 			}
 		},
 		"content-disposition": {
@@ -1734,12 +1706,6 @@
 				"jake": "^10.6.1"
 			}
 		},
-		"emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -1751,15 +1717,6 @@
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"requires": {
 				"once": "^1.4.0"
-			}
-		},
-		"enquirer": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "^4.1.1"
 			}
 		},
 		"entities": {
@@ -1835,49 +1792,44 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
-			"version": "7.32.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+			"integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.3",
-				"@humanwhocodes/config-array": "^0.5.0",
+				"@eslint/eslintrc": "^1.2.0",
+				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
-				"debug": "^4.0.1",
+				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
-				"enquirer": "^2.3.5",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^2.1.0",
-				"eslint-visitor-keys": "^2.0.0",
-				"espree": "^7.3.1",
+				"eslint-scope": "^7.1.1",
+				"eslint-utils": "^3.0.0",
+				"eslint-visitor-keys": "^3.3.0",
+				"espree": "^9.3.1",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.1.2",
+				"glob-parent": "^6.0.1",
 				"globals": "^13.6.0",
-				"ignore": "^4.0.6",
+				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"js-yaml": "^3.13.1",
+				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.0.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"progress": "^2.0.0",
-				"regexpp": "^3.1.0",
-				"semver": "^7.2.1",
-				"strip-ansi": "^6.0.0",
+				"regexpp": "^3.2.0",
+				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"table": "^6.0.9",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
@@ -1961,62 +1913,48 @@
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
+				"estraverse": "^5.2.0"
 			}
 		},
 		"eslint-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.1.0"
+				"eslint-visitor-keys": "^2.0.0"
 			},
 			"dependencies": {
 				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				}
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
 			"dev": true
 		},
 		"espree": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-			"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+			"integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.4.0",
+				"acorn": "^8.7.0",
 				"acorn-jsx": "^5.3.1",
-				"eslint-visitor-keys": "^1.3.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-					"dev": true
-				}
+				"eslint-visitor-keys": "^3.3.0"
 			}
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
 		},
 		"esquery": {
 			"version": "1.4.0",
@@ -2025,14 +1963,6 @@
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
 			}
 		},
 		"esrecurse": {
@@ -2042,20 +1972,12 @@
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.2.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
 			}
 		},
 		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true
 		},
 		"esutils": {
@@ -2245,6 +2167,11 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"form-data-encoder": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+			"integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+		},
 		"forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2312,12 +2239,12 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
 			"requires": {
-				"is-glob": "^4.0.1"
+				"is-glob": "^4.0.3"
 			}
 		},
 		"globals": {
@@ -2330,21 +2257,30 @@
 			}
 		},
 		"got": {
-			"version": "11.8.3",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-			"integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-12.0.1.tgz",
+			"integrity": "sha512-1Zhoh+lDej3t7Ks1BP/Jufn+rNqdiHQgUOcTxHzg2Dao1LQfp5S4Iq0T3iBxN4Zdo7QqCJL+WJUNzDX6rCP2Ew==",
 			"requires": {
-				"@sindresorhus/is": "^4.0.0",
-				"@szmarczak/http-timer": "^4.0.5",
-				"@types/cacheable-request": "^6.0.1",
+				"@sindresorhus/is": "^4.2.0",
+				"@szmarczak/http-timer": "^5.0.1",
+				"@types/cacheable-request": "^6.0.2",
 				"@types/responselike": "^1.0.0",
-				"cacheable-lookup": "^5.0.3",
+				"cacheable-lookup": "^6.0.4",
 				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
-				"http2-wrapper": "^1.0.0-beta.5.2",
-				"lowercase-keys": "^2.0.0",
-				"p-cancelable": "^2.0.0",
+				"form-data-encoder": "1.7.1",
+				"get-stream": "^6.0.1",
+				"http2-wrapper": "^2.1.9",
+				"lowercase-keys": "^3.0.0",
+				"p-cancelable": "^3.0.0",
 				"responselike": "^2.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+				}
 			}
 		},
 		"has": {
@@ -2396,12 +2332,12 @@
 			}
 		},
 		"http2-wrapper": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"version": "2.1.10",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.10.tgz",
+			"integrity": "sha512-QHgsdYkieKp+6JbXP25P+tepqiHYd+FVnDwXpxi/BlUcoIB0nsmTOymTNvETuTO+pDuwcSklPE72VR3DqV+Haw==",
 			"requires": {
 				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.0.0"
+				"resolve-alpn": "^1.2.0"
 			}
 		},
 		"human-signals": {
@@ -2430,9 +2366,9 @@
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -2547,12 +2483,6 @@
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
-		"is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true
-		},
 		"is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2665,20 +2595,13 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
 		"js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			}
 		},
 		"json-buffer": {
@@ -2741,25 +2664,10 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"lodash.truncate": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
-			"dev": true
-		},
 		"lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -2947,9 +2855,9 @@
 			}
 		},
 		"p-cancelable": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+			"integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="
 		},
 		"p-limit": {
 			"version": "2.3.0",
@@ -3176,12 +3084,6 @@
 				}
 			}
 		},
-		"progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
-		},
 		"proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3253,12 +3155,6 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
-		},
 		"resolve-alpn": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -3276,6 +3172,13 @@
 			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
 			"requires": {
 				"lowercase-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+				}
 			}
 		},
 		"rimraf": {
@@ -3296,15 +3199,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
 		},
 		"send": {
 			"version": "0.17.2",
@@ -3380,53 +3274,10 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"slice-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				}
-			}
-		},
 		"split2": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
 			"integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
 		},
 		"statuses": {
 			"version": "1.5.0",
@@ -3440,17 +3291,6 @@
 			"requires": {
 				"inherits": "~2.0.4",
 				"readable-stream": "^3.5.0"
-			}
-		},
-		"string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"requires": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
 			}
 		},
 		"string.prototype.trimend": {
@@ -3506,39 +3346,6 @@
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"requires": {
 				"has-flag": "^3.0.0"
-			}
-		},
-		"table": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-			"dev": true,
-			"requires": {
-				"ajv": "^8.0.1",
-				"lodash.truncate": "^4.4.2",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "8.10.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-					"integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"json-schema-traverse": "^1.0.0",
-						"require-from-string": "^2.0.2",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-					"dev": true
-				}
 			}
 		},
 		"text-table": {
@@ -3777,20 +3584,14 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-			"integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
 		},
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1056,11 +1056,6 @@
 					"version": "16.11.26",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
 					"integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
-				},
-				"ws": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-					"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
 				}
 			}
 		},
@@ -3380,9 +3375,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"twitch": {
-			"version": "4.6.5",
-			"resolved": "https://registry.npmjs.org/twitch/-/twitch-4.6.5.tgz",
-			"integrity": "sha512-vQ9p7s9SHcUgU7Lul7pAf70p8vQXk2o9BCwkGqzZjmMsVMsoikk3MLD7n9Cjle9bIPvWuqW/MyMOw3WdrMe8yg==",
+			"version": "4.6.7",
+			"resolved": "https://registry.npmjs.org/twitch/-/twitch-4.6.7.tgz",
+			"integrity": "sha512-inOFFLFhTcls/sskGcQWIfPgvhAF92fDo3uoGHdk0YRzo87NUHprvPE/LJJKh2IsysOPCmA1/mpnjReAgr5opA==",
 			"requires": {
 				"@d-fischer/cache-decorators": "^2.1.1",
 				"@d-fischer/deprecate": "^2.0.2",
@@ -3391,9 +3386,9 @@
 				"@d-fischer/shared-utils": "^3.0.1",
 				"top-package": "^1.0.0",
 				"tslib": "^2.0.3",
-				"twitch-api-call": "^4.6.5",
-				"twitch-auth": "^4.6.5",
-				"twitch-common": "^4.6.5"
+				"twitch-api-call": "^4.6.7",
+				"twitch-auth": "^4.6.7",
+				"twitch-common": "^4.6.7"
 			}
 		},
 		"twitch-api-call": {
@@ -3410,22 +3405,22 @@
 			}
 		},
 		"twitch-auth": {
-			"version": "4.6.5",
-			"resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.6.5.tgz",
-			"integrity": "sha512-BVeW3P2coQn1aNV1sVH/Q0wbgkl1Saf/M76OSanitcA8IgvnEfCGY3iDt2Taec98eBXL+E8SN1iLHLsl3GBHvg==",
+			"version": "4.6.7",
+			"resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.6.7.tgz",
+			"integrity": "sha512-9AkenhrZfXVdL1P2hJ7rLFKWOOGnkgf5isTJbjGD/GP2NYFYS+Oh8TYp8uyjW3/jQODIFuZeHPIhE6AIK5TVIA==",
 			"requires": {
 				"@d-fischer/deprecate": "^2.0.2",
 				"@d-fischer/logger": "^3.1.0",
 				"@d-fischer/shared-utils": "^3.0.1",
 				"tslib": "^2.0.3",
-				"twitch-api-call": "^4.6.5",
-				"twitch-common": "^4.6.5"
+				"twitch-api-call": "^4.6.7",
+				"twitch-common": "^4.6.7"
 			}
 		},
 		"twitch-chat-client": {
-			"version": "4.6.5",
-			"resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.6.5.tgz",
-			"integrity": "sha512-MpWSGWHvrw9DLpJZokdwzJxVOtSLApIm9JAbEsND47qxKgrxymf/1RfinSL93qRDrJhtrWwqlUXV2SpZz5YxpQ==",
+			"version": "4.6.7",
+			"resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.6.7.tgz",
+			"integrity": "sha512-KXRiEIWC1eK3Xbwsphcq6Bl/JAlzJEx9IVYOh3CXgkeu/tYgxzOlwVEtpmoK4CO9Z0CwpxBhE23NF8ZZ9wGdBQ==",
 			"requires": {
 				"@d-fischer/cache-decorators": "^2.1.1",
 				"@d-fischer/deprecate": "^2.0.2",
@@ -3435,8 +3430,8 @@
 				"@d-fischer/typed-event-emitter": "^3.2.2",
 				"ircv3": "^0.26.14",
 				"tslib": "^2.0.3",
-				"twitch-auth": "^4.6.5",
-				"twitch-common": "^4.6.5"
+				"twitch-auth": "^4.6.7",
+				"twitch-common": "^4.6.7"
 			}
 		},
 		"twitch-common": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,9 +2021,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
-			"integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
 			"dev": true
 		},
 		"eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -22,32 +22,32 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"@aws-sdk/client-s3": "^3.49.0",
-		"@aws-sdk/lib-storage": "^3.49.0",
-		"connect-pg-simple": "^6.2.1",
+		"@aws-sdk/client-s3": "^3.53.1",
+		"@aws-sdk/lib-storage": "^3.53.1",
+		"connect-pg-simple": "^7.0.0",
 		"country-list": "^2.2.0",
 		"ejs": "^3.1.6",
-		"express": "^4.17.2",
+		"express": "^4.17.3",
 		"express-session": "^1.17.2",
 		"glob": "^7.2.0",
-		"got": "^11.8.3",
+		"got": "^12.0.1",
 		"lodash": "^4.17.21",
 		"nocache": "^3.0.1",
-		"pg": "^8.7.1",
-		"timezones.json": "^1.6.0",
+		"pg": "^8.7.3",
+		"timezones.json": "^1.6.1",
 		"twitch": "4.6.5",
 		"twitch-auth": "4.6.5",
 		"twitch-chat-client": "4.6.5",
 		"ulid": "^2.3.0",
 		"uuid": "^8.3.2",
-		"ws": "^7.5.6"
+		"ws": "^8.5.0"
 	},
 	"engines": {
 		"node": "14.x"
 	},
 	"devDependencies": {
-		"eslint": "^7.32.0",
-		"eslint-config-prettier": "^8.3.0",
+		"eslint": "^8.10.0",
+		"eslint-config-prettier": "^8.4.0",
 		"husky": "^7.0.4",
 		"prettier": "^2.5.1",
 		"pretty-quick": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"eslint": "^8.10.0",
-		"eslint-config-prettier": "^8.4.0",
+		"eslint-config-prettier": "^8.5.0",
 		"husky": "^7.0.4",
 		"prettier": "^2.5.1",
 		"pretty-quick": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
 	"name": "NESTrisChamps",
 	"version": "1.0.0",
 	"description": "",
-	"main": "index.js",
+	"exports": "./index.js",
+	"type": "module",
 	"scripts": {
 		"start": "node server.js",
 		"env-linux": "export $(cat .env | xargs) && env",
@@ -35,9 +36,9 @@
 		"nocache": "^3.0.1",
 		"pg": "^8.7.3",
 		"timezones.json": "^1.6.1",
-		"twitch": "4.6.5",
-		"twitch-auth": "4.6.5",
-		"twitch-chat-client": "4.6.5",
+		"twitch": "^4.6.7",
+		"twitch-auth": "^4.6.7",
+		"twitch-chat-client": "^4.6.7",
 		"ulid": "^2.3.0",
 		"uuid": "^8.3.2",
 		"ws": "^8.5.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.53.1",
 		"@aws-sdk/lib-storage": "^3.53.1",
+		"@twurple/api": "^5.0.18",
+		"@twurple/auth": "^5.0.18",
+		"@twurple/chat": "^5.0.18",
 		"connect-pg-simple": "^7.0.0",
 		"country-list": "^2.2.0",
 		"ejs": "^3.1.6",
@@ -36,9 +39,6 @@
 		"nocache": "^3.0.1",
 		"pg": "^8.7.3",
 		"timezones.json": "^1.6.1",
-		"twitch": "^4.6.7",
-		"twitch-auth": "^4.6.7",
-		"twitch-chat-client": "^4.6.7",
 		"ulid": "^2.3.0",
 		"uuid": "^8.3.2",
 		"ws": "^8.5.0"

--- a/public/.eslintrc.json
+++ b/public/.eslintrc.json
@@ -9,7 +9,8 @@
 	"extends": ["eslint:recommended", "prettier"],
 	"ignorePatterns": ["opencv.js"],
 	"parserOptions": {
-		"ecmaVersion": 12
+		"ecmaVersion": 12,
+		"sourceType": "module"
 	},
 	"rules": {}
 }

--- a/public/js/BinaryFrame.js
+++ b/public/js/BinaryFrame.js
@@ -326,8 +326,4 @@ const BinaryFrame = (function () {
 	return BinaryFrame;
 })();
 
-try {
-	module.exports = BinaryFrame;
-} catch (err) {
-	// nothing to do, we're not in node
-}
+export default BinaryFrame;

--- a/public/js/BinaryFrame.js
+++ b/public/js/BinaryFrame.js
@@ -1,329 +1,323 @@
-const BinaryFrame = (function () {
-	const FORMAT_VERSION = 2;
+const FORMAT_VERSION = 2;
 
-	const FRAME_SIZE_BY_VERSION = {
-		1: 71,
-		2: 72,
-	};
+const FRAME_SIZE_BY_VERSION = {
+	1: 71,
+	2: 72,
+};
 
-	const GAME_TYPE = {
-		CLASSIC: 1,
-		DAS_TRAINER: 2,
-	};
+const GAME_TYPE = {
+	CLASSIC: 1,
+	DAS_TRAINER: 2,
+};
 
-	const PIECE_TO_VALUE = {
-		T: 0,
-		J: 1,
-		Z: 2,
-		O: 3,
-		S: 4,
-		L: 5,
-		I: 6,
-	};
+const PIECE_TO_VALUE = {
+	T: 0,
+	J: 1,
+	Z: 2,
+	O: 3,
+	S: 4,
+	L: 5,
+	I: 6,
+};
 
-	const VALUE_TO_PIECE = {
-		0: 'T',
-		1: 'J',
-		2: 'Z',
-		3: 'O',
-		4: 'S',
-		5: 'L',
-		6: 'I',
-	};
+const VALUE_TO_PIECE = {
+	0: 'T',
+	1: 'J',
+	2: 'Z',
+	3: 'O',
+	4: 'S',
+	5: 'L',
+	6: 'I',
+};
 
-	const PIECES = Object.keys(PIECE_TO_VALUE);
+const PIECES = Object.keys(PIECE_TO_VALUE);
 
-	const NULLABLE_FIELDS = [
-		'score',
-		'lines',
-		'level',
-		'instant_das',
-		'cur_piece_das',
-		...PIECES,
-	];
+const NULLABLE_FIELDS = [
+	'score',
+	'lines',
+	'level',
+	'instant_das',
+	'cur_piece_das',
+	...PIECES,
+];
 
-	const POSSIBLE_RIGHT_PADDING = 50 /* field */ + 1; /* null terminator */
+const POSSIBLE_RIGHT_PADDING = 50 /* field */ + 1; /* null terminator */
 
-	class BinaryFrame {
-		static encode(pojo) {
-			// TODO: validate pojo fields
-			// TODO: throw if values are not compatible with format
+export default class BinaryFrame {
+	static encode(pojo) {
+		// TODO: validate pojo fields
+		// TODO: throw if values are not compatible with format
 
-			// sanitize values to represent null
-			const sanitized = { ...pojo };
+		// sanitize values to represent null
+		const sanitized = { ...pojo };
 
-			NULLABLE_FIELDS.forEach(field => {
-				// capture null and undefined on purpose
-				if (sanitized[field] == null) {
-					sanitized[field] = 0xffffffff;
-				}
-			});
-
-			if (sanitized.preview == null) {
-				sanitized.preview = 0xffffffff;
-			} else {
-				sanitized.preview = PIECE_TO_VALUE[sanitized.preview];
+		NULLABLE_FIELDS.forEach(field => {
+			// capture null and undefined on purpose
+			if (sanitized[field] == null) {
+				sanitized[field] = 0xffffffff;
 			}
+		});
 
-			if (sanitized.cur_piece == null) {
-				sanitized.cur_piece = 0xffffffff;
-			} else {
-				sanitized.cur_piece = PIECE_TO_VALUE[sanitized.cur_piece];
-			}
-
-			if (sanitized.field == null) {
-				sanitized.field = Array(200).fill(0);
-			}
-
-			// fields are now clean, encode!
-
-			const buffer = new Uint8Array(FRAME_SIZE_BY_VERSION[FORMAT_VERSION]);
-
-			let bidx = 0; // byte index
-
-			// header
-			buffer[bidx++] =
-				((FORMAT_VERSION & 0b111) << 5) | ((sanitized.game_type & 0b11) << 3);
-
-			// gameid - 16 bits
-			buffer[bidx++] = (sanitized.gameid & 0xff00) >> 8;
-			buffer[bidx++] = (sanitized.gameid & 0x00ff) >> 0;
-
-			// ctime - 28 bits
-			buffer[bidx++] = (sanitized.ctime & 0xff00000) >> 20;
-			buffer[bidx++] = (sanitized.ctime & 0x00ff000) >> 12;
-			buffer[bidx++] = (sanitized.ctime & 0x0000ff0) >> 4;
-			buffer[bidx++] =
-				((sanitized.ctime & 0x0f) << 4) | ((sanitized.lines & 0xf00) >> 8);
-
-			// lines - 12 bits
-			buffer[bidx++] = sanitized.lines & 0xff;
-
-			// level - 8 bits
-			buffer[bidx++] = sanitized.level & 0xff;
-
-			// score - 24 bits
-			buffer[bidx++] = (sanitized.score & 0xff0000) >> 16;
-			buffer[bidx++] = (sanitized.score & 0x00ff00) >> 8;
-			buffer[bidx++] = (sanitized.score & 0x0000ff);
-
-			// instant_das (5) + preview (3)
-			buffer[bidx++] =
-				((sanitized.instant_das & 0b11111) << 3) | (sanitized.preview & 0b111);
-
-			// cur piece das (5) + cur piece (3)
-			buffer[bidx++] =
-				((sanitized.cur_piece_das & 0b11111) << 3) |
-				(sanitized.cur_piece & 0b111);
-
-			// piece stats (9 bits each - does not lign nicely to byte boundaries 😓)
-			buffer[bidx++] = ((sanitized.T & 0b111111110) >> 1);
-			buffer[bidx++] = ((sanitized.T & 0b000000001) << 7) | ((sanitized.J & 0b111111100) >> 2);
-			buffer[bidx++] = ((sanitized.J & 0b000000011) << 6) | ((sanitized.Z & 0b111111000) >> 3);
-			buffer[bidx++] = ((sanitized.Z & 0b000000111) << 5) | ((sanitized.O & 0b111110000) >> 4);
-			buffer[bidx++] = ((sanitized.O & 0b000001111) << 4) | ((sanitized.S & 0b111100000) >> 5);
-			buffer[bidx++] = ((sanitized.S & 0b000011111) << 3) | ((sanitized.L & 0b111000000) >> 6);
-			buffer[bidx++] = ((sanitized.L & 0b000111111) << 2) | ((sanitized.I & 0b110000000) >> 7);
-			buffer[bidx++] = ((sanitized.I & 0b001111111) << 1);
-
-			// field
-			for (
-				let block_idx = 0;
-				block_idx < sanitized.field.length;
-				block_idx += 4
-			) {
-				buffer[bidx++] =
-					((sanitized.field[block_idx + 0] & 0b11) << 6) |
-					((sanitized.field[block_idx + 1] & 0b11) << 4) |
-					((sanitized.field[block_idx + 2] & 0b11) << 2) |
-					((sanitized.field[block_idx + 3] & 0b11) << 0);
-			}
-
-			return buffer;
+		if (sanitized.preview == null) {
+			sanitized.preview = 0xffffffff;
+		} else {
+			sanitized.preview = PIECE_TO_VALUE[sanitized.preview];
 		}
 
-		static parse(buffer_or_uintarray) {
-			const f = BinaryFrame.getFrameFromBuffer(buffer_or_uintarray); // may throw
-
-			const pojo = {};
-
-			let bidx = 0;
-
-			pojo.version = (f[bidx] & 0b11100000) >> 5;
-			pojo.game_type = (f[bidx] & 0b11000) >> 3;
-			pojo.player_num = f[bidx++] & 0b111;
-
-			pojo.gameid = (f[bidx++] << 8) | f[bidx++];
-
-			pojo.ctime =
-				(f[bidx++] << 20) |
-				(f[bidx++] << 12) |
-				(f[bidx++] << 4) |
-				((f[bidx] & 0xf0) >> 4);
-
-			if (pojo.version === FORMAT_VERSION) {
-				pojo.lines = ((f[bidx++] & 0x0f) << 8) | f[bidx++];
-
-				pojo.level = f[bidx++];
-
-				pojo.score = (f[bidx++] << 16) | (f[bidx++] << 8) | f[bidx++];
-
-				pojo.instant_das = (f[bidx] & 0b11111000) >> 3;
-				pojo.preview = f[bidx++] & 0b111;
-
-				pojo.cur_piece_das = (f[bidx] & 0b11111000) >> 3;
-				pojo.cur_piece = f[bidx++] & 0b111;
-
-				// piece stats)
-				pojo.T = ((f[bidx++] & 0b11111111) << 1) | ((f[bidx] & 0b10000000) >> 7);
-				pojo.J = ((f[bidx++] & 0b01111111) << 2) | ((f[bidx] & 0b11000000) >> 6);
-				pojo.Z = ((f[bidx++] & 0b00111111) << 3) | ((f[bidx] & 0b11100000) >> 5);
-				pojo.O = ((f[bidx++] & 0b00011111) << 4) | ((f[bidx] & 0b11110000) >> 4);
-				pojo.S = ((f[bidx++] & 0b00001111) << 5) | ((f[bidx] & 0b11111000) >> 3);
-				pojo.L = ((f[bidx++] & 0b00000111) << 6) | ((f[bidx] & 0b11111100) >> 2);
-				pojo.I = ((f[bidx++] & 0b00000011) << 7) | ((f[bidx] & 0b11111110) >> 1);
-
-				bidx++;
-			} else {
-				// can only be version 1 for now, no need to check more
-				pojo.score =
-					((f[bidx++] & 0x0f) << 17) |
-					(f[bidx++] << 9) |
-					(f[bidx++] << 1) |
-					((f[bidx] & 0b10000000) >> 7);
-
-				pojo.lines =
-					((f[bidx++] & 0b01111111) << 2) | ((f[bidx] & 0b11000000) >> 6);
-
-				pojo.level = f[bidx++] & 0b0111111;
-
-				pojo.instant_das = (f[bidx] & 0b11111000) >> 3;
-				pojo.preview = f[bidx++] & 0b111;
-
-				pojo.cur_piece_das = (f[bidx] & 0b11111000) >> 3;
-				pojo.cur_piece = f[bidx++] & 0b111;
-
-				// piece stats
-				pojo.T = f[bidx++];
-				pojo.J = f[bidx++];
-				pojo.Z = f[bidx++];
-				pojo.O = f[bidx++];
-				pojo.S = f[bidx++];
-				pojo.L = f[bidx++];
-				pojo.I = f[bidx++];
-			}
-
-			pojo.field = Array(200);
-
-			for (let idx = 0; idx < 50; idx++, bidx++) {
-				pojo.field[idx * 4 + 0] = (f[bidx] & 0b11000000) >> 6;
-				pojo.field[idx * 4 + 1] = (f[bidx] & 0b00110000) >> 4;
-				pojo.field[idx * 4 + 2] = (f[bidx] & 0b00001100) >> 2;
-				pojo.field[idx * 4 + 3] = (f[bidx] & 0b00000011) >> 0;
-			}
-
-			// we've extracted all the value, now checks for nulls
-
-			if (pojo.version === FORMAT_VERSION) {
-				if (pojo.score === 0xffffff) pojo.score = null;
-				if (pojo.lines === 0xfff) pojo.lines = null;
-				if (pojo.level === 0xff) pojo.level = null;
-
-				PIECES.forEach(piece => {
-					if (pojo[piece] === 0x1ff) {
-						pojo[piece] = null;
-					}
-				});
-			}
-			else {
-				if (pojo.score === 0x1fffff) pojo.score = null;
-				if (pojo.lines === 0b111111111) pojo.lines = null;
-				if (pojo.level === 0b111111) pojo.level = null;
-
-				PIECES.forEach(piece => {
-					if (pojo[piece] === 0xff) {
-						pojo[piece] = null;
-					}
-				});
-			}
-
-			if (pojo.instant_das === 0b11111) pojo.instant_das = null;
-			if (pojo.cur_piece_das === 0b11111) pojo.cur_piece_das = null;
-
-
-			if (pojo.preview === 0b111) {
-				pojo.preview = null;
-			} else {
-				pojo.preview = VALUE_TO_PIECE[pojo.preview];
-			}
-
-			if (pojo.cur_piece === 0b111) {
-				pojo.cur_piece = null;
-			} else {
-				pojo.cur_piece = VALUE_TO_PIECE[pojo.cur_piece];
-			}
-
-			return pojo;
+		if (sanitized.cur_piece == null) {
+			sanitized.cur_piece = 0xffffffff;
+		} else {
+			sanitized.cur_piece = PIECE_TO_VALUE[sanitized.cur_piece];
 		}
 
-		static getCTime(frame_arr) {
-			return (
-				(frame_arr[3] << 20) |
-				(frame_arr[4] << 12) |
-				(frame_arr[5] << 4) |
-				((frame_arr[6] & 0xf0) >> 4)
-			);
+		if (sanitized.field == null) {
+			sanitized.field = Array(200).fill(0);
 		}
 
-		static getFrameFromBuffer(buffer_or_uintarray) {
-			let f;
+		// fields are now clean, encode!
 
-			if (buffer_or_uintarray instanceof Uint8Array) {
-				f = buffer_or_uintarray;
-			} else {
-				f = new Uint8Array(buffer_or_uintarray);
-			}
+		const buffer = new Uint8Array(FRAME_SIZE_BY_VERSION[FORMAT_VERSION]);
 
-			const version = f[0] >> 5; // 3 bits with mask 0b11100000
+		let bidx = 0; // byte index
 
-			if (!FRAME_SIZE_BY_VERSION[version]) {
-				throw new Error('Invalid Frame: Version not supported');
-			}
+		// header
+		buffer[bidx++] =
+			((FORMAT_VERSION & 0b111) << 5) | ((sanitized.game_type & 0b11) << 3);
 
-			const normal_size = FRAME_SIZE_BY_VERSION[version];
+		// gameid - 16 bits
+		buffer[bidx++] = (sanitized.gameid & 0xff00) >> 8;
+		buffer[bidx++] = (sanitized.gameid & 0x00ff) >> 0;
 
-			if (f.length === normal_size) {
-				return f;
-			}
+		// ctime - 28 bits
+		buffer[bidx++] = (sanitized.ctime & 0xff00000) >> 20;
+		buffer[bidx++] = (sanitized.ctime & 0x00ff000) >> 12;
+		buffer[bidx++] = (sanitized.ctime & 0x0000ff0) >> 4;
+		buffer[bidx++] =
+			((sanitized.ctime & 0x0f) << 4) | ((sanitized.lines & 0xf00) >> 8);
 
-			if (f.length > normal_size) {
-				throw new Error('Invalid frame: too long');
-			}
+		// lines - 12 bits
+		buffer[bidx++] = sanitized.lines & 0xff;
 
-			// Minor transport optimization below
-			// The tail of the frame (field) may
-			// be omitted and will pad with zeros to compensate
+		// level - 8 bits
+		buffer[bidx++] = sanitized.level & 0xff;
 
-			if (f.length < normal_size - POSSIBLE_RIGHT_PADDING) {
-				throw new Error('Invalid frame: too short');
-			}
+		// score - 24 bits
+		buffer[bidx++] = (sanitized.score & 0xff0000) >> 16;
+		buffer[bidx++] = (sanitized.score & 0x00ff00) >> 8;
+		buffer[bidx++] = (sanitized.score & 0x0000ff);
 
-			// frame is too short, but paddable
-			// 1. init as all zeros
-			const padded = new Uint8Array(normal_size);
+		// instant_das (5) + preview (3)
+		buffer[bidx++] =
+			((sanitized.instant_das & 0b11111) << 3) | (sanitized.preview & 0b111);
 
-			// 2. (inefficient) copy the values from f
-			// Can't we do a fast low-level buffer copy? :'(
-			f.forEach((v, i) => (padded[i] = v));
+		// cur piece das (5) + cur piece (3)
+		buffer[bidx++] =
+			((sanitized.cur_piece_das & 0b11111) << 3) |
+			(sanitized.cur_piece & 0b111);
 
-			return padded;
+		// piece stats (9 bits each - does not lign nicely to byte boundaries 😓)
+		buffer[bidx++] = ((sanitized.T & 0b111111110) >> 1);
+		buffer[bidx++] = ((sanitized.T & 0b000000001) << 7) | ((sanitized.J & 0b111111100) >> 2);
+		buffer[bidx++] = ((sanitized.J & 0b000000011) << 6) | ((sanitized.Z & 0b111111000) >> 3);
+		buffer[bidx++] = ((sanitized.Z & 0b000000111) << 5) | ((sanitized.O & 0b111110000) >> 4);
+		buffer[bidx++] = ((sanitized.O & 0b000001111) << 4) | ((sanitized.S & 0b111100000) >> 5);
+		buffer[bidx++] = ((sanitized.S & 0b000011111) << 3) | ((sanitized.L & 0b111000000) >> 6);
+		buffer[bidx++] = ((sanitized.L & 0b000111111) << 2) | ((sanitized.I & 0b110000000) >> 7);
+		buffer[bidx++] = ((sanitized.I & 0b001111111) << 1);
+
+		// field
+		for (
+			let block_idx = 0;
+			block_idx < sanitized.field.length;
+			block_idx += 4
+		) {
+			buffer[bidx++] =
+				((sanitized.field[block_idx + 0] & 0b11) << 6) |
+				((sanitized.field[block_idx + 1] & 0b11) << 4) |
+				((sanitized.field[block_idx + 2] & 0b11) << 2) |
+				((sanitized.field[block_idx + 3] & 0b11) << 0);
 		}
+
+		return buffer;
 	}
 
-	BinaryFrame.GAME_TYPE = GAME_TYPE;
-	BinaryFrame.FRAME_SIZE_BY_VERSION = FRAME_SIZE_BY_VERSION;
+	static parse(buffer_or_uintarray) {
+		const f = BinaryFrame.getFrameFromBuffer(buffer_or_uintarray); // may throw
 
-	return BinaryFrame;
-})();
+		const pojo = {};
 
-export default BinaryFrame;
+		let bidx = 0;
+
+		pojo.version = (f[bidx] & 0b11100000) >> 5;
+		pojo.game_type = (f[bidx] & 0b11000) >> 3;
+		pojo.player_num = f[bidx++] & 0b111;
+
+		pojo.gameid = (f[bidx++] << 8) | f[bidx++];
+
+		pojo.ctime =
+			(f[bidx++] << 20) |
+			(f[bidx++] << 12) |
+			(f[bidx++] << 4) |
+			((f[bidx] & 0xf0) >> 4);
+
+		if (pojo.version === FORMAT_VERSION) {
+			pojo.lines = ((f[bidx++] & 0x0f) << 8) | f[bidx++];
+
+			pojo.level = f[bidx++];
+
+			pojo.score = (f[bidx++] << 16) | (f[bidx++] << 8) | f[bidx++];
+
+			pojo.instant_das = (f[bidx] & 0b11111000) >> 3;
+			pojo.preview = f[bidx++] & 0b111;
+
+			pojo.cur_piece_das = (f[bidx] & 0b11111000) >> 3;
+			pojo.cur_piece = f[bidx++] & 0b111;
+
+			// piece stats)
+			pojo.T = ((f[bidx++] & 0b11111111) << 1) | ((f[bidx] & 0b10000000) >> 7);
+			pojo.J = ((f[bidx++] & 0b01111111) << 2) | ((f[bidx] & 0b11000000) >> 6);
+			pojo.Z = ((f[bidx++] & 0b00111111) << 3) | ((f[bidx] & 0b11100000) >> 5);
+			pojo.O = ((f[bidx++] & 0b00011111) << 4) | ((f[bidx] & 0b11110000) >> 4);
+			pojo.S = ((f[bidx++] & 0b00001111) << 5) | ((f[bidx] & 0b11111000) >> 3);
+			pojo.L = ((f[bidx++] & 0b00000111) << 6) | ((f[bidx] & 0b11111100) >> 2);
+			pojo.I = ((f[bidx++] & 0b00000011) << 7) | ((f[bidx] & 0b11111110) >> 1);
+
+			bidx++;
+		} else {
+			// can only be version 1 for now, no need to check more
+			pojo.score =
+				((f[bidx++] & 0x0f) << 17) |
+				(f[bidx++] << 9) |
+				(f[bidx++] << 1) |
+				((f[bidx] & 0b10000000) >> 7);
+
+			pojo.lines =
+				((f[bidx++] & 0b01111111) << 2) | ((f[bidx] & 0b11000000) >> 6);
+
+			pojo.level = f[bidx++] & 0b0111111;
+
+			pojo.instant_das = (f[bidx] & 0b11111000) >> 3;
+			pojo.preview = f[bidx++] & 0b111;
+
+			pojo.cur_piece_das = (f[bidx] & 0b11111000) >> 3;
+			pojo.cur_piece = f[bidx++] & 0b111;
+
+			// piece stats
+			pojo.T = f[bidx++];
+			pojo.J = f[bidx++];
+			pojo.Z = f[bidx++];
+			pojo.O = f[bidx++];
+			pojo.S = f[bidx++];
+			pojo.L = f[bidx++];
+			pojo.I = f[bidx++];
+		}
+
+		pojo.field = Array(200);
+
+		for (let idx = 0; idx < 50; idx++, bidx++) {
+			pojo.field[idx * 4 + 0] = (f[bidx] & 0b11000000) >> 6;
+			pojo.field[idx * 4 + 1] = (f[bidx] & 0b00110000) >> 4;
+			pojo.field[idx * 4 + 2] = (f[bidx] & 0b00001100) >> 2;
+			pojo.field[idx * 4 + 3] = (f[bidx] & 0b00000011) >> 0;
+		}
+
+		// we've extracted all the value, now checks for nulls
+
+		if (pojo.version === FORMAT_VERSION) {
+			if (pojo.score === 0xffffff) pojo.score = null;
+			if (pojo.lines === 0xfff) pojo.lines = null;
+			if (pojo.level === 0xff) pojo.level = null;
+
+			PIECES.forEach(piece => {
+				if (pojo[piece] === 0x1ff) {
+					pojo[piece] = null;
+				}
+			});
+		}
+		else {
+			if (pojo.score === 0x1fffff) pojo.score = null;
+			if (pojo.lines === 0b111111111) pojo.lines = null;
+			if (pojo.level === 0b111111) pojo.level = null;
+
+			PIECES.forEach(piece => {
+				if (pojo[piece] === 0xff) {
+					pojo[piece] = null;
+				}
+			});
+		}
+
+		if (pojo.instant_das === 0b11111) pojo.instant_das = null;
+		if (pojo.cur_piece_das === 0b11111) pojo.cur_piece_das = null;
+
+
+		if (pojo.preview === 0b111) {
+			pojo.preview = null;
+		} else {
+			pojo.preview = VALUE_TO_PIECE[pojo.preview];
+		}
+
+		if (pojo.cur_piece === 0b111) {
+			pojo.cur_piece = null;
+		} else {
+			pojo.cur_piece = VALUE_TO_PIECE[pojo.cur_piece];
+		}
+
+		return pojo;
+	}
+
+	static getCTime(frame_arr) {
+		return (
+			(frame_arr[3] << 20) |
+			(frame_arr[4] << 12) |
+			(frame_arr[5] << 4) |
+			((frame_arr[6] & 0xf0) >> 4)
+		);
+	}
+
+	static getFrameFromBuffer(buffer_or_uintarray) {
+		let f;
+
+		if (buffer_or_uintarray instanceof Uint8Array) {
+			f = buffer_or_uintarray;
+		} else {
+			f = new Uint8Array(buffer_or_uintarray);
+		}
+
+		const version = f[0] >> 5; // 3 bits with mask 0b11100000
+
+		if (!FRAME_SIZE_BY_VERSION[version]) {
+			throw new Error('Invalid Frame: Version not supported');
+		}
+
+		const normal_size = FRAME_SIZE_BY_VERSION[version];
+
+		if (f.length === normal_size) {
+			return f;
+		}
+
+		if (f.length > normal_size) {
+			throw new Error('Invalid frame: too long');
+		}
+
+		// Minor transport optimization below
+		// The tail of the frame (field) may
+		// be omitted and will pad with zeros to compensate
+
+		if (f.length < normal_size - POSSIBLE_RIGHT_PADDING) {
+			throw new Error('Invalid frame: too short');
+		}
+
+		// frame is too short, but paddable
+		// 1. init as all zeros
+		const padded = new Uint8Array(normal_size);
+
+		// 2. (inefficient) copy the values from f
+		// Can't we do a fast low-level buffer copy? :'(
+		f.forEach((v, i) => (padded[i] = v));
+
+		return padded;
+	}
+}
+
+BinaryFrame.GAME_TYPE = GAME_TYPE;
+BinaryFrame.FRAME_SIZE_BY_VERSION = FRAME_SIZE_BY_VERSION;

--- a/public/js/QueryString.js
+++ b/public/js/QueryString.js
@@ -1,3 +1,3 @@
 // Return the searchParams Objet for the current page URL
 
-const QueryString = new URL(location).searchParams;
+export default new URL(location).searchParams;

--- a/public/js/connection.js
+++ b/public/js/connection.js
@@ -1,4 +1,6 @@
-class Connection {
+import BinaryFrame from '/js/BinaryFrame.js';
+
+export default class Connection {
 	constructor(uri = null, extra_search_params = null) {
 		let url;
 

--- a/public/ocr/LevelFixer.js
+++ b/public/ocr/LevelFixer.js
@@ -43,7 +43,7 @@ We correct all possible misreads of A/4 and B/8
 
 /**/
 
-class LevelFixer {
+export default class LevelFixer {
 	constructor() {
 		this.last_good_digits = null;
 	}

--- a/public/ocr/OCRSanitizer.js
+++ b/public/ocr/OCRSanitizer.js
@@ -1,272 +1,269 @@
-const OCRSanitizer = (function () {
-	const FIX_LEVEL = QueryString.get('fixlevel') !== '0';
+import QueryString from '/js/QueryString.js';
+import ScoreFixer from '/ocr/ScoreFixer.js';
+import LevelFixer from '/ocr/LevelFixer.js';
 
-	/*
-	 * OCRSanitizer sanitizes a stream of Tetris OCRed data.
-	 *
-	 * That is because with intelaced input, a change occurs over 2 frame.
-	 * Reading a value as soon as it is changed can yield incorrect values, since the OCR was performed on
-	 * a transition interlaced frame
-	 *
-	 * So, each change is buffered for 1 frame to hopefully read a clean stable value.
-	 *
-	 * The buffering is done with an understanding of how Tetris fields are connected
-	 * Score: may change independently (push down points), but also always changes with lines increase
-	 * Lines: can change independently
-	 * Level: Only changes if lines changes too
-	 * Piece counters: Can change independently (but only one at a time!)
-	 * Instant Das: changes at every frame: cannot be buffered to stability (read and hope for the best)
-	 * Cur piece Das: Changes on piece change
-	 * Preview: Can change independently
-	 * Cur piece:  Can change independently
-	 *
-	 * The Sanitizer Also corrects invalid detection on the high scores and level, where scores greater than 1M are rendered with letter.
-	 */
+const FIX_LEVEL = QueryString.get('fixlevel') !== '0';
 
-	class OCRSanitizer {
-		constructor(tetris_ocr, config) {
-			this.config = config;
-			this.tetris_ocr = tetris_ocr;
+/*
+ * OCRSanitizer sanitizes a stream of Tetris OCRed data.
+ *
+ * That is because with intelaced input, a change occurs over 2 frame.
+ * Reading a value as soon as it is changed can yield incorrect values, since the OCR was performed on
+ * a transition interlaced frame
+ *
+ * So, each change is buffered for 1 frame to hopefully read a clean stable value.
+ *
+ * The buffering is done with an understanding of how Tetris fields are connected
+ * Score: may change independently (push down points), but also always changes with lines increase
+ * Lines: can change independently
+ * Level: Only changes if lines changes too
+ * Piece counters: Can change independently (but only one at a time!)
+ * Instant Das: changes at every frame: cannot be buffered to stability (read and hope for the best)
+ * Cur piece Das: Changes on piece change
+ * Preview: Can change independently
+ * Cur piece:  Can change independently
+ *
+ * The Sanitizer Also corrects invalid detection on the high scores and level, where scores greater than 1M are rendered with letter.
+ */
 
-			this.last_frame = null;
+export default class OCRSanitizer {
+	constructor(tetris_ocr, config) {
+		this.config = config;
+		this.tetris_ocr = tetris_ocr;
 
-			this.score_fixer = new ScoreFixer();
-			this.level_fixer = new LevelFixer();
+		this.last_frame = null;
 
-			this._handleFirstFrame = this._handleFirstFrame.bind(this);
-			this._sanitize = this._sanitize.bind(this);
+		this.score_fixer = new ScoreFixer();
+		this.level_fixer = new LevelFixer();
 
-			tetris_ocr.onMessage = this._handleFirstFrame;
+		this._handleFirstFrame = this._handleFirstFrame.bind(this);
+		this._sanitize = this._sanitize.bind(this);
 
-			this.gameid = 1;
-			this.in_game = false;
+		this.tetris_ocr.onMessage = this._handleFirstFrame;
 
-			this.pending_score = false;
-			this.pending_line = false;
-			this.pending_piece = false;
-		}
+		this.gameid = 1;
+		this.in_game = false;
 
-		onMessage() {
-			// class user to implement
-		}
-
-		_handleFirstFrame(data) {
-			this.last_frame = { ...data }; // first frame is assumed "good" - because no choice!
-			this.previous_preview = data.preview; // used in das trainer to populate the current_frame
-
-			tetris_ocr.onMessage = this._sanitize;
-		}
-
-		_sanitize(data) {
-			performance.mark('start_sanitize');
-
-			do {
-				if (this.pending_lines) {
-					this.pending_lines = false;
-
-					this.last_frame.lines = data.lines;
-					this.last_frame.level = data.level;
-
-					// a line change always has a score change
-					// if score readwas not pending, force a read now anyway to synchronize with the lines
-					this.pending_score = true;
-				} else if (!OCRSanitizer.arrEqual(data.lines, this.last_frame.lines)) {
-					this.pending_lines = true;
-
-					if (this.pending_score) {
-						// because score was already pending, the lines value is (probably) already
-						// clean to read but we somehow didn't detect the change previously
-						// let's read it right away after all by looping back up!
-						continue;
-					}
-				}
-
-				break;
-			} while (true);
-
-			// ==========
-
-			if (this.pending_score) {
-				this.pending_score = false;
-
-				this.last_frame.score = data.score;
-			} else if (!OCRSanitizer.arrEqual(data.score, this.last_frame.score)) {
-				this.pendig_score = true;
-			}
-
-			// ==========
-
-			// mutually exclusive pendding_piece checks based on selected rom
-			if (this.config.tasks.T) {
-				// In classic rom, we have several way of determining the cur_piece
-				// 1. on piece change, cur_piece is the previous preview
-				// 2. on piece change, cur_piece if the piece with the last incremented counter
-				// So... Should this populate the cur_piece? it's not OCR...
-				// then again, the corrections are not really OCR too either
-				// TODO: populate cur_piece into the frame for classic rom (maybe?)
-				if (this.pending_piece) {
-					this.pending_piece = false;
-
-					this.last_frame.preview = data.preview;
-					this.last_frame.T = data.T;
-					this.last_frame.J = data.J;
-					this.last_frame.Z = data.Z;
-					this.last_frame.O = data.O;
-					this.last_frame.S = data.S;
-					this.last_frame.L = data.L;
-					this.last_frame.I = data.I;
-				} else if (!OCRSanitizer.pieceCountersEqual(this.last_frame, data)) {
-					this.pending_piece = true;
-				}
-			} else if (this.config.tasks.instant_das) {
-				if (this.pending_piece) {
-					this.pending_piece = false;
-
-					this.last_frame.preview = data.preview;
-					this.last_frame.cur_piece = data.cur_piece;
-					this.last_frame.cur_piece_das = data.cur_piece_das;
-				} else if (
-					!OCRSanitizer.arrEqual(
-						data.cur_piece_das,
-						this.last_frame.cur_piece_das
-					)
-				) {
-					this.pending_piece = true;
-				}
-			}
-
-			performance.mark('end_sanitize');
-			performance.measure('sanitize', 'start_sanitize', 'end_sanitize');
-
-			// ==========
-			// we have now corrected the reads to be on stable values
-			// the stable values may still be incorrect with regards to the 8-B and 4-A detection
-			// but that wouldbe fixed in the next step
-
-			// inform listener that a frame is ready
-			this._emitLastFrameData();
-
-			// Finally, record current frame for next iteration
-			// (and keep previous frame around in case we want to do more change comparison
-			this.previous_frame = this.last_frame;
-			this.last_frame = data;
-		}
-
-		_emitLastFrameData() {
-			performance.mark('start_fix_and_convert');
-
-			// replicate NESTrisOCR gameid logic
-			// also check if the fixers must be reset
-			if (
-				this.last_frame.lines == null ||
-				this.last_frame.score == null ||
-				this.last_frame.level == null
-			) {
-				this.in_game = false;
-			} else if (!this.in_game) {
-				this.in_game = true;
-
-				if (
-					OCRSanitizer.arrEqual(this.last_frame.score, [0, 0, 0, 0, 0, 0]) &&
-					(OCRSanitizer.arrEqual(this.last_frame.lines, [0, 0, 0]) || // mode A
-						OCRSanitizer.arrEqual(this.last_frame.lines, [0, 2, 5])) // mode B
-				) {
-					this.gameid++;
-
-					this.score_fixer.reset();
-					this.score_fixer.fix(this.last_frame.score);
-
-					if (FIX_LEVEL) {
-						this.level_fixer.reset();
-						this.level_fixer.fix(this.last_frame.level);
-					}
-				}
-			}
-
-			const pojo = {
-				gameid: this.gameid,
-				lines: OCRSanitizer.digitsToValue(this.last_frame.lines),
-				field: this.last_frame.field,
-				preview: this.last_frame.preview,
-
-				score: OCRSanitizer.digitsToValue(
-					this.score_fixer.fix(this.last_frame.score)
-				), // note: nulls are passthrough
-				level: OCRSanitizer.digitsToValue(
-					FIX_LEVEL
-						? this.level_fixer.fix(this.last_frame.level)
-						: OCRSanitizer.arrEqual(this.last_frame.level, [10, 9])
-						? [6, 1] // special correction for Cheez 2.3M game with broken Tetris Gym 🤷
-						: this.last_frame.level
-				), // note: nulls are passthrough
-			};
-
-			if (this.config.tasks.T) {
-				pojo.T = OCRSanitizer.digitsToValue(this.last_frame.T);
-				pojo.J = OCRSanitizer.digitsToValue(this.last_frame.J);
-				pojo.Z = OCRSanitizer.digitsToValue(this.last_frame.Z);
-				pojo.O = OCRSanitizer.digitsToValue(this.last_frame.O);
-				pojo.S = OCRSanitizer.digitsToValue(this.last_frame.S);
-				pojo.L = OCRSanitizer.digitsToValue(this.last_frame.L);
-				pojo.I = OCRSanitizer.digitsToValue(this.last_frame.I);
-
-				pojo.color1 = this.last_frame.color1;
-				pojo.color2 = this.last_frame.color2;
-				pojo.color3 = this.last_frame.color3;
-			} else {
-				pojo.instant_das = OCRSanitizer.digitsToValue(
-					this.last_frame.instant_das
-				);
-				pojo.cur_piece_das = OCRSanitizer.digitsToValue(
-					this.last_frame.cur_piece_das
-				);
-				pojo.cur_piece = this.last_frame.cur_piece;
-			}
-
-			performance.mark('end_fix_and_convert');
-			performance.measure(
-				'fix_and_convert',
-				'start_fix_and_convert',
-				'end_fix_and_convert'
-			);
-
-			this.onMessage(pojo);
-		}
+		this.pending_score = false;
+		this.pending_line = false;
+		this.pending_piece = false;
 	}
 
-	OCRSanitizer.digitsToValue = function digitsToValue(digits) {
-		if (digits === null) return null;
+	onMessage() {
+		// class user to implement
+	}
 
-		return digits.reduce(
-			(acc, v, idx) => acc + v * Math.pow(10, digits.length - idx - 1),
-			0
+	_handleFirstFrame(data) {
+		this.last_frame = { ...data }; // first frame is assumed "good" - because no choice!
+		this.previous_preview = data.preview; // used in das trainer to populate the current_frame
+
+		this.tetris_ocr.onMessage = this._sanitize;
+	}
+
+	_sanitize(data) {
+		performance.mark('start_sanitize');
+
+		do {
+			if (this.pending_lines) {
+				this.pending_lines = false;
+
+				this.last_frame.lines = data.lines;
+				this.last_frame.level = data.level;
+
+				// a line change always has a score change
+				// if score readwas not pending, force a read now anyway to synchronize with the lines
+				this.pending_score = true;
+			} else if (!OCRSanitizer.arrEqual(data.lines, this.last_frame.lines)) {
+				this.pending_lines = true;
+
+				if (this.pending_score) {
+					// because score was already pending, the lines value is (probably) already
+					// clean to read but we somehow didn't detect the change previously
+					// let's read it right away after all by looping back up!
+					continue;
+				}
+			}
+
+			break;
+		} while (true);
+
+		// ==========
+
+		if (this.pending_score) {
+			this.pending_score = false;
+
+			this.last_frame.score = data.score;
+		} else if (!OCRSanitizer.arrEqual(data.score, this.last_frame.score)) {
+			this.pendig_score = true;
+		}
+
+		// ==========
+
+		// mutually exclusive pendding_piece checks based on selected rom
+		if (this.config.tasks.T) {
+			// In classic rom, we have several way of determining the cur_piece
+			// 1. on piece change, cur_piece is the previous preview
+			// 2. on piece change, cur_piece if the piece with the last incremented counter
+			// So... Should this populate the cur_piece? it's not OCR...
+			// then again, the corrections are not really OCR too either
+			// TODO: populate cur_piece into the frame for classic rom (maybe?)
+			if (this.pending_piece) {
+				this.pending_piece = false;
+
+				this.last_frame.preview = data.preview;
+				this.last_frame.T = data.T;
+				this.last_frame.J = data.J;
+				this.last_frame.Z = data.Z;
+				this.last_frame.O = data.O;
+				this.last_frame.S = data.S;
+				this.last_frame.L = data.L;
+				this.last_frame.I = data.I;
+			} else if (!OCRSanitizer.pieceCountersEqual(this.last_frame, data)) {
+				this.pending_piece = true;
+			}
+		} else if (this.config.tasks.instant_das) {
+			if (this.pending_piece) {
+				this.pending_piece = false;
+
+				this.last_frame.preview = data.preview;
+				this.last_frame.cur_piece = data.cur_piece;
+				this.last_frame.cur_piece_das = data.cur_piece_das;
+			} else if (
+				!OCRSanitizer.arrEqual(
+					data.cur_piece_das,
+					this.last_frame.cur_piece_das
+				)
+			) {
+				this.pending_piece = true;
+			}
+		}
+
+		performance.mark('end_sanitize');
+		performance.measure('sanitize', 'start_sanitize', 'end_sanitize');
+
+		// ==========
+		// we have now corrected the reads to be on stable values
+		// the stable values may still be incorrect with regards to the 8-B and 4-A detection
+		// but that wouldbe fixed in the next step
+
+		// inform listener that a frame is ready
+		this._emitLastFrameData();
+
+		// Finally, record current frame for next iteration
+		// (and keep previous frame around in case we want to do more change comparison
+		this.previous_frame = this.last_frame;
+		this.last_frame = data;
+	}
+
+	_emitLastFrameData() {
+		performance.mark('start_fix_and_convert');
+
+		// replicate NESTrisOCR gameid logic
+		// also check if the fixers must be reset
+		if (
+			this.last_frame.lines == null ||
+			this.last_frame.score == null ||
+			this.last_frame.level == null
+		) {
+			this.in_game = false;
+		} else if (!this.in_game) {
+			this.in_game = true;
+
+			if (
+				OCRSanitizer.arrEqual(this.last_frame.score, [0, 0, 0, 0, 0, 0]) &&
+				(OCRSanitizer.arrEqual(this.last_frame.lines, [0, 0, 0]) || // mode A
+					OCRSanitizer.arrEqual(this.last_frame.lines, [0, 2, 5])) // mode B
+			) {
+				this.gameid++;
+
+				this.score_fixer.reset();
+				this.score_fixer.fix(this.last_frame.score);
+
+				if (FIX_LEVEL) {
+					this.level_fixer.reset();
+					this.level_fixer.fix(this.last_frame.level);
+				}
+			}
+		}
+
+		const pojo = {
+			gameid: this.gameid,
+			lines: OCRSanitizer.digitsToValue(this.last_frame.lines),
+			field: this.last_frame.field,
+			preview: this.last_frame.preview,
+
+			score: OCRSanitizer.digitsToValue(
+				this.score_fixer.fix(this.last_frame.score)
+			), // note: nulls are passthrough
+			level: OCRSanitizer.digitsToValue(
+				FIX_LEVEL
+					? this.level_fixer.fix(this.last_frame.level)
+					: OCRSanitizer.arrEqual(this.last_frame.level, [10, 9])
+					? [6, 1] // special correction for Cheez 2.3M game with broken Tetris Gym 🤷
+					: this.last_frame.level
+			), // note: nulls are passthrough
+		};
+
+		if (this.config.tasks.T) {
+			pojo.T = OCRSanitizer.digitsToValue(this.last_frame.T);
+			pojo.J = OCRSanitizer.digitsToValue(this.last_frame.J);
+			pojo.Z = OCRSanitizer.digitsToValue(this.last_frame.Z);
+			pojo.O = OCRSanitizer.digitsToValue(this.last_frame.O);
+			pojo.S = OCRSanitizer.digitsToValue(this.last_frame.S);
+			pojo.L = OCRSanitizer.digitsToValue(this.last_frame.L);
+			pojo.I = OCRSanitizer.digitsToValue(this.last_frame.I);
+
+			pojo.color1 = this.last_frame.color1;
+			pojo.color2 = this.last_frame.color2;
+			pojo.color3 = this.last_frame.color3;
+		} else {
+			pojo.instant_das = OCRSanitizer.digitsToValue(
+				this.last_frame.instant_das
+			);
+			pojo.cur_piece_das = OCRSanitizer.digitsToValue(
+				this.last_frame.cur_piece_das
+			);
+			pojo.cur_piece = this.last_frame.cur_piece;
+		}
+
+		performance.mark('end_fix_and_convert');
+		performance.measure(
+			'fix_and_convert',
+			'start_fix_and_convert',
+			'end_fix_and_convert'
 		);
-	};
 
-	OCRSanitizer.arrEqual = function arrEqual(arr1, arr2) {
-		return (
-			(arr1 === null && arr2 === null) ||
-			(arr1 &&
-				arr2 &&
-				arr1.length === arr2.length &&
-				arr1.every((v, i) => v === arr2[i]))
-		);
-	};
+		this.onMessage(pojo);
+	}
+}
 
-	OCRSanitizer.pieceCountersEqual = function pieceCountersEqual(
-		frame1,
-		frame2
-	) {
-		return (
-			OCRSanitizer.arrEqual(frame1.T, frame2.T) &&
-			OCRSanitizer.arrEqual(frame1.J, frame2.J) &&
-			OCRSanitizer.arrEqual(frame1.Z, frame2.Z) &&
-			OCRSanitizer.arrEqual(frame1.O, frame2.O) &&
-			OCRSanitizer.arrEqual(frame1.S, frame2.S) &&
-			OCRSanitizer.arrEqual(frame1.L, frame2.L) &&
-			OCRSanitizer.arrEqual(frame1.I, frame2.I)
-		);
-	};
+OCRSanitizer.digitsToValue = function digitsToValue(digits) {
+	if (digits === null) return null;
 
-	return OCRSanitizer;
-})();
+	return digits.reduce(
+		(acc, v, idx) => acc + v * Math.pow(10, digits.length - idx - 1),
+		0
+	);
+};
+
+OCRSanitizer.arrEqual = function arrEqual(arr1, arr2) {
+	return (
+		(arr1 === null && arr2 === null) ||
+		(arr1 &&
+			arr2 &&
+			arr1.length === arr2.length &&
+			arr1.every((v, i) => v === arr2[i]))
+	);
+};
+
+OCRSanitizer.pieceCountersEqual = function pieceCountersEqual(frame1, frame2) {
+	return (
+		OCRSanitizer.arrEqual(frame1.T, frame2.T) &&
+		OCRSanitizer.arrEqual(frame1.J, frame2.J) &&
+		OCRSanitizer.arrEqual(frame1.Z, frame2.Z) &&
+		OCRSanitizer.arrEqual(frame1.O, frame2.O) &&
+		OCRSanitizer.arrEqual(frame1.S, frame2.S) &&
+		OCRSanitizer.arrEqual(frame1.L, frame2.L) &&
+		OCRSanitizer.arrEqual(frame1.I, frame2.I)
+	);
+};

--- a/public/ocr/ScoreFixer.js
+++ b/public/ocr/ScoreFixer.js
@@ -1,4 +1,4 @@
-class ScoreFixer {
+export default class ScoreFixer {
 	constructor() {
 		this.last_good_digits = null;
 	}

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -1,753 +1,752 @@
-const TetrisOCR = (function () {
-	const PATTERN_MAX_INDEXES = {
-		B: 3, // null, 0, 1 (Binary)
-		T: 4, // null, 0, 1, 2 (Ternary)
-		Q: 6, // null, 0, 1, 2, 3, 4 (Quintic)
-		D: 11, // null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 (Digits)
-		L: 13, // null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B (Level)
-		A: 17, // null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F (Alphanums)
-	};
+import { timingDecorator } from '/ocr/utils.js';
+import { bicubic, crop, luma } from '/ocr/image_tools.js';
+import { rgb2lab } from '/ocr/utils.js';
 
-	const PERF_METHODS = [
-		'getSourceImageData',
-		'scanScore',
-		'scanLevel',
-		'scanLines',
-		'scanColor1',
-		'scanColor2',
-		'scanColor3',
-		'scanPreview',
-		'scanField',
-		'scanPieceStats',
+const PATTERN_MAX_INDEXES = {
+	B: 3, // null, 0, 1 (Binary)
+	T: 4, // null, 0, 1, 2 (Ternary)
+	Q: 6, // null, 0, 1, 2, 3, 4 (Quintic)
+	D: 11, // null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 (Digits)
+	L: 13, // null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B (Level)
+	A: 17, // null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F (Alphanums)
+};
 
-		'scanInstantDas',
-		'scanCurPieceDas',
-		'scanCurPiece',
-	];
+const PERF_METHODS = [
+	'getSourceImageData',
+	'scanScore',
+	'scanLevel',
+	'scanLines',
+	'scanColor1',
+	'scanColor2',
+	'scanColor3',
+	'scanPreview',
+	'scanField',
+	'scanPieceStats',
 
-	const DEFAULT_COLOR_0 = [0x00, 0x00, 0x00];
-	const DEFAULT_COLOR_1 = [0xf0, 0xf0, 0xf0];
+	'scanInstantDas',
+	'scanCurPieceDas',
+	'scanCurPiece',
+];
 
-	function getDigitsWidth(n) {
-		// width per digit is 8px times 2
-		// and for last digit, we ignore the 1px (times 2)
-		// border on the right, hence -2
-		return 16 * n - 2;
+const DEFAULT_COLOR_0 = [0x00, 0x00, 0x00];
+const DEFAULT_COLOR_1 = [0xf0, 0xf0, 0xf0];
+
+function getDigitsWidth(n) {
+	// width per digit is 8px times 2
+	// and for last digit, we ignore the 1px (times 2)
+	// border on the right, hence -2
+	return 16 * n - 2;
+}
+
+// Resize areas based on logical NES pixels (2x for digits)
+const TASK_RESIZE = {
+	score: [getDigitsWidth(6), 14],
+	level: [getDigitsWidth(2), 14],
+	lines: [getDigitsWidth(3), 14],
+	field: [79, 159],
+	preview: [31, 15],
+	cur_piece: [23, 12],
+	instant_das: [getDigitsWidth(2), 14],
+	cur_piece_das: [getDigitsWidth(2), 14],
+	color1: [5, 5],
+	color2: [5, 5],
+	color3: [5, 5],
+	stats: [getDigitsWidth(3), 14 * 7 + 14 * 7], // height captures all the individual stats...
+	piece_count: [getDigitsWidth(3), 14],
+};
+
+const SHINE_LUMA_THRESHOLD = 75; // Since shine is white, should this threshold be higher?
+
+export default class TetrisOCR extends EventTarget {
+	constructor(templates, palettes, config) {
+		super();
+
+		this.templates = templates;
+		this.palettes = palettes;
+		this.setConfig(config);
+
+		this.digit_img = new ImageData(14, 14); // 2x for better matching
+		this.shine_img = new ImageData(2, 3);
+
+		// decorate relevant methods to capture timings
+		PERF_METHODS.forEach(name => {
+			const method = this[name].bind(this);
+			this[name] = timingDecorator(name, method);
+		});
 	}
 
-	// Resize areas based on logical NES pixels (2x for digits)
-	const TASK_RESIZE = {
-		score: [getDigitsWidth(6), 14],
-		level: [getDigitsWidth(2), 14],
-		lines: [getDigitsWidth(3), 14],
-		field: [79, 159],
-		preview: [31, 15],
-		cur_piece: [23, 12],
-		instant_das: [getDigitsWidth(2), 14],
-		cur_piece_das: [getDigitsWidth(2), 14],
-		color1: [5, 5],
-		color2: [5, 5],
-		color3: [5, 5],
-		stats: [getDigitsWidth(3), 14 * 7 + 14 * 7], // height captures all the individual stats...
-		piece_count: [getDigitsWidth(3), 14],
-	};
+	/*
+	 * processConfig()
+	 * 1. Calculate the overal crop area based on the individual task crop areas
+	 * 2. Instantiate ImageData objects for each cropped and resize job, so they can:
+	 *    a. be reused without memory allocation
+	 *    b. be shared via the config reference with client app (say for display of the areas)
+	 *
+	 */
+	setConfig(config) {
+		this.config = config;
+		this.palette = this.palettes && this.palettes[config.palette]; // will reset to undefined when needed
 
-	const SHINE_LUMA_THRESHOLD = 75; // Since shine is white, should this threshold be higher?
+		this.fixPalette();
 
-	class TetrisOCR extends EventTarget {
-		constructor(templates, palettes, config) {
-			super();
+		const bounds = {
+			top: 0xffffffff,
+			left: 0xffffffff,
+			bottom: -1,
+			right: -1,
+		};
 
-			this.templates = templates;
-			this.palettes = palettes;
-			this.setConfig(config);
+		// This create a lot of imageData objects of similar sizes
+		// Somecould be shared because they are the same dimensions (e.g. 3 digits for lines, and piece stats)
+		// but if we share them, we wouldnotbe able to display them individually in the debug UI
+		for (const [name, task] of Object.entries(this.config.tasks)) {
+			if (this.palette && name.startsWith('color')) continue;
 
-			this.digit_img = new ImageData(14, 14); // 2x for better matching
-			this.shine_img = new ImageData(2, 3);
+			const {
+				crop: [x, y, w, h],
+			} = task;
 
-			// decorate relevant methods to capture timings
-			PERF_METHODS.forEach(name => {
-				const method = this[name].bind(this);
-				this[name] = timingDecorator(name, method);
-			});
-		}
+			bounds.top = Math.min(bounds.top, y);
+			bounds.left = Math.min(bounds.left, x);
+			bounds.bottom = Math.max(bounds.bottom, y + h);
+			bounds.right = Math.max(bounds.right, x + w);
 
-		/*
-		 * processConfig()
-		 * 1. Calculate the overal crop area based on the individual task crop areas
-		 * 2. Instantiate ImageData objects for each cropped and resize job, so they can:
-		 *    a. be reused without memory allocation
-		 *    b. be shared via the config reference with client app (say for display of the areas)
-		 *
-		 */
-		setConfig(config) {
-			this.config = config;
-			this.palette = this.palettes && this.palettes[config.palette]; // will reset to undefined when needed
+			let resize_tuple;
 
-			this.fixPalette();
-
-			const bounds = {
-				top: 0xffffffff,
-				left: 0xffffffff,
-				bottom: -1,
-				right: -1,
-			};
-
-			// This create a lot of imageData objects of similar sizes
-			// Somecould be shared because they are the same dimensions (e.g. 3 digits for lines, and piece stats)
-			// but if we share them, we wouldnotbe able to display them individually in the debug UI
-			for (const [name, task] of Object.entries(this.config.tasks)) {
-				if (this.palette && name.startsWith('color')) continue;
-
-				const {
-					crop: [x, y, w, h],
-				} = task;
-
-				bounds.top = Math.min(bounds.top, y);
-				bounds.left = Math.min(bounds.left, x);
-				bounds.bottom = Math.max(bounds.bottom, y + h);
-				bounds.right = Math.max(bounds.right, x + w);
-
-				let resize_tuple;
-
-				if (name.length === 1) {
-					resize_tuple = TASK_RESIZE.piece_count;
-				} else {
-					resize_tuple = TASK_RESIZE[name];
-				}
-
-				task.crop_img = new ImageData(w, h);
-				task.scale_img = new ImageData(...resize_tuple);
-			}
-
-			this.config.capture_bounds = bounds;
-			this.config.capture_area = {
-				x: bounds.left,
-				y: bounds.top,
-				w: bounds.right - bounds.left,
-				h: bounds.bottom - bounds.top,
-			};
-		}
-
-		fixPalette() {
-			if (!this.palette) return;
-
-			this.palette = this.palette.map(colors => {
-				if (colors.length == 2) {
-					return [DEFAULT_COLOR_1, colors[0], colors[1]];
-				}
-
-				return colors;
-			});
-		}
-
-		getDigit(pixel_data, max_check_index, is_red) {
-			const sums = new Float64Array(max_check_index);
-			const size = pixel_data.length >>> 2;
-			const red_scale = 255 / 155; // scale red values as if capped at 155
-
-			for (let p_idx = size; p_idx--; ) {
-				const offset_idx = p_idx << 2;
-				const pixel_luma = is_red
-					? Math.min(pixel_data[offset_idx] * red_scale, 255) // only consider red component for luma, with scaling and capped
-					: luma(
-							pixel_data[offset_idx],
-							pixel_data[offset_idx + 1],
-							pixel_data[offset_idx + 2]
-					  );
-
-				for (let t_idx = max_check_index; t_idx--; ) {
-					const diff = pixel_luma - this.templates[t_idx][p_idx];
-					sums[t_idx] += diff * diff;
-				}
-			}
-
-			let min_val = 0xffffffff;
-			let min_idx = -1;
-
-			for (let s_idx = sums.length; s_idx--; ) {
-				if (sums[s_idx] < min_val) {
-					min_val = sums[s_idx];
-					min_idx = s_idx;
-				}
-			}
-
-			return min_idx;
-		}
-
-		initCaptureContext(frame, half_height) {
-			this.capture_canvas = document.createElement('canvas');
-
-			this.capture_canvas.width = frame.width;
-			this.capture_canvas.height = frame.height >> (half_height ? 1 : 0);
-
-			this.capture_canvas_ctx = this.capture_canvas.getContext('2d', {
-				alpha: false,
-			});
-			this.capture_canvas_ctx.imageSmoothingEnabled = false;
-
-			// On top of the capture context, we need one more canvas for the scaled field
-			// because the performance of OffScreenCanvas are horrible, and same gvoes for the bicubic lib for any image that's not super small :(
-
-			// TODO: get rid of this additional canvas when we can T_T
-			this.scaled_field_canvas = document.createElement('canvas');
-
-			this.scaled_field_canvas.width = TASK_RESIZE.field[0];
-			this.scaled_field_canvas.height = TASK_RESIZE.field[1];
-
-			this.scaled_field_canvas_ctx = this.scaled_field_canvas.getContext('2d', {
-				alpha: false,
-			});
-			this.scaled_field_canvas_ctx.imageSmoothingEnabled = true;
-			this.scaled_field_canvas_ctx.imageSmoothingQuality = 'medium';
-		}
-
-		async processFrame(frame, half_height) {
-			if (!this.capture_canvas_ctx) {
-				this.initCaptureContext(frame, half_height);
-			}
-
-			const res = {};
-
-			performance.mark('start');
-			this.capture_canvas_ctx.drawImage(
-				frame,
-				0,
-				0,
-				frame.width,
-				frame.height >> (half_height ? 1 : 0)
-			);
-			performance.mark('draw_end');
-			performance.measure('draw_frame', 'start', 'draw_end');
-
-			const source_img = this.getSourceImageData();
-
-			res.score = this.scanScore(source_img);
-			res.level = this.scanLevel(source_img);
-			res.lines = this.scanLines(source_img);
-
-			const level_units = res.level == null ? 0 : res.level[1];
-
-			// WARNING: We need to use the level for color and board reads
-			// WARNING: level *may* be read incorrectly when changing value
-			// TODO: Store source_img, and level and board should be read after the 1-frame sanitization pipeline
-
-			// color are either supplied from palette or read, there's no other choice
-			if (this.palette) {
-				[res.color1, res.color2, res.color3] = this.palette[level_units];
+			if (name.length === 1) {
+				resize_tuple = TASK_RESIZE.piece_count;
 			} else {
-				// assume tasks color1 and color2 are set
-				res.color2 = this.scanColor2(source_img);
-				res.color3 = this.scanColor3(source_img);
-
-				if (this.config.tasks.color1) {
-					res.color1 = this.scanColor1(source_img);
-				} else {
-					res.color1 = DEFAULT_COLOR_1;
-				}
+				resize_tuple = TASK_RESIZE[name];
 			}
 
-			const colors = [res.color1, res.color2, res.color3];
-
-			if (level_units != 6 && level_units != 7) {
-				colors.unshift(DEFAULT_COLOR_0); // add black
-			}
-
-			res.field = await this.scanField(source_img, colors);
-			res.preview = this.scanPreview(source_img);
-
-			if (this.config.tasks.instant_das) {
-				// assumes all 3 das tasks are a unit
-				res.instant_das = this.scanInstantDas(source_img);
-				res.cur_piece_das = this.scanCurPieceDas(source_img);
-				res.cur_piece = this.scanCurPiece(source_img);
-			}
-
-			if (this.config.tasks.T) {
-				Object.assign(res, this.scanPieceStats(source_img));
-			}
-
-			// round the colors if needed
-			if (res.color2) {
-				res.color2 = res.color2.map(v => Math.round(v));
-				res.color3 = res.color3.map(v => Math.round(v));
-			}
-
-			this.onMessage(res);
+			task.crop_img = new ImageData(w, h);
+			task.scale_img = new ImageData(...resize_tuple);
 		}
 
-		scanScore(source_img) {
-			return this.ocrDigits(source_img, this.config.tasks.score);
-		}
-
-		scanLevel(source_img) {
-			return this.ocrDigits(source_img, this.config.tasks.level);
-		}
-
-		scanLines(source_img) {
-			return this.ocrDigits(source_img, this.config.tasks.lines);
-		}
-
-		scanColor2(source_img) {
-			return this.scanColor(source_img, this.config.tasks.color2);
-		}
-
-		scanColor3(source_img) {
-			return this.scanColor(source_img, this.config.tasks.color3);
-		}
-
-		scanInstantDas(source_img) {
-			return this.ocrDigits(source_img, this.config.tasks.instant_das);
-		}
-
-		scanCurPieceDas(source_img) {
-			return this.ocrDigits(source_img, this.config.tasks.cur_piece_das);
-		}
-
-		scanPieceStats(source_img) {
-			return {
-				T: this.ocrDigits(source_img, this.config.tasks.T),
-				J: this.ocrDigits(source_img, this.config.tasks.J),
-				Z: this.ocrDigits(source_img, this.config.tasks.Z),
-				O: this.ocrDigits(source_img, this.config.tasks.O),
-				S: this.ocrDigits(source_img, this.config.tasks.S),
-				L: this.ocrDigits(source_img, this.config.tasks.L),
-				I: this.ocrDigits(source_img, this.config.tasks.I),
-			};
-		}
-
-		getSourceImageData() {
-			const pixels = this.capture_canvas_ctx.getImageData(
-				this.config.capture_area.x,
-				this.config.capture_area.y,
-				this.config.capture_area.w,
-				this.config.capture_area.h
-			);
-
-			/*
-		const pixels_per_rows = this.config.capture_area.w * 4;
-		const max_rows = this.config.capture_bounds.bottom;
-
-		for (let row_idx = 1; row_idx < max_rows; row_idx++) {
-			pixels.data.copyWithin(
-				pixels_per_rows * row_idx,
-				pixels_per_rows * row_idx * 2,
-				pixels_per_rows * (row_idx * 2 + 1)
-			);
-		}
-		/**/
-
-			this.config.source_img = pixels;
-
-			return pixels;
-		}
-
-		getCropCoordinates(task) {
-			const [raw_x, raw_y, w, h] = task.crop;
-
-			return [
-				raw_x - this.config.capture_area.x,
-				raw_y - this.config.capture_area.y,
-				w,
-				h,
-			];
-		}
-
-		ocrDigits(source_img, task) {
-			const [x, y, w, h] = this.getCropCoordinates(task);
-			const digits = Array(task.pattern.length);
-
-			crop(source_img, x, y, w, h, task.crop_img);
-			bicubic(task.crop_img, task.scale_img);
-
-			for (let idx = digits.length; idx--; ) {
-				const char = task.pattern[idx];
-
-				crop(task.scale_img, idx * 16, 0, 14, 14, this.digit_img);
-
-				const digit = this.getDigit(
-					this.digit_img.data,
-					PATTERN_MAX_INDEXES[char],
-					task.red
-				);
-
-				if (!digit) return null;
-
-				digits[idx] = digit - 1;
-			}
-
-			return digits;
-		}
-
-		/*
-		 * Returns true if at least one of the pixel has a luma higher than threshold
-		 */
-		hasShine(img, block_x, block_y) {
-			// extract the shine area at the location supplied
-			const shine_width = 2;
-			crop(img, block_x, block_y, shine_width, 3, this.shine_img);
-
-			const img_data = this.shine_img.data;
-			const shine_pix_ref = [
-				[0, 0],
-				[1, 1],
-				[1, 2],
-			];
-
-			return shine_pix_ref.some(([x, y]) => {
-				const offset_idx = (y * shine_width + x) << 2;
-				const pixel_luma = luma(
-					img_data[offset_idx],
-					img_data[offset_idx + 1],
-					img_data[offset_idx + 2]
-				);
-
-				return pixel_luma > SHINE_LUMA_THRESHOLD;
-			});
-		}
-
-		scanPreview(source_img) {
-			const task = this.config.tasks.preview;
-			const [x, y, w, h] = this.getCropCoordinates(task);
-
-			crop(source_img, x, y, w, h, task.crop_img);
-			bicubic(task.crop_img, task.scale_img);
-
-			// Trying side i blocks
-			if (
-				this.hasShine(task.scale_img, 0, 4) &&
-				this.hasShine(task.scale_img, 28, 4) // not top-left corner, but since I block are white, should work
-			) {
-				return 'I';
-			}
-
-			// now trying the 3x2 matrix for T, L, J, S, Z
-			const top_row = [
-				this.hasShine(task.scale_img, 4, 0),
-				this.hasShine(task.scale_img, 12, 0),
-				this.hasShine(task.scale_img, 20, 0),
-			];
-
-			if (top_row[0] && top_row[1] && top_row[2]) {
-				// J, T, L
-				if (this.hasShine(task.scale_img, 4, 8)) {
-					return 'L';
-				}
-				if (this.hasShine(task.scale_img, 12, 8)) {
-					return 'T';
-				}
-				if (this.hasShine(task.scale_img, 20, 8)) {
-					return 'J';
-				}
-
-				return null;
-			}
-
-			if (top_row[1] && top_row[2]) {
-				if (
-					this.hasShine(task.scale_img, 4, 8) &&
-					this.hasShine(task.scale_img, 12, 8)
-				) {
-					return 'S';
-				}
-			}
-
-			if (top_row[0] && top_row[1]) {
-				if (
-					this.hasShine(task.scale_img, 12, 8) &&
-					this.hasShine(task.scale_img, 20, 8)
-				) {
-					return 'Z';
-				}
-			}
-
-			// lastly check for O
-			if (
-				this.hasShine(task.scale_img, 8, 0) &&
-				this.hasShine(task.scale_img, 16, 0) &&
-				this.hasShine(task.scale_img, 8, 8) &&
-				this.hasShine(task.scale_img, 16, 8)
-			) {
-				return 'O';
-			}
-
-			return null;
-		}
-
-		scanCurPiece(source_img) {
-			const task = this.config.tasks.cur_piece;
-			const [x, y, w, h] = this.getCropCoordinates(task);
-
-			// curPieces are not vertically aligned on the op row
-			// L and J are rendered 1 pixel higher
-			// than S, Z, T, O
-
-			crop(source_img, x, y, w, h, task.crop_img);
-			bicubic(task.crop_img, task.scale_img);
-
-			// Trying side i blocks
-			if (
-				this.hasShine(task.scale_img, 0, 4) &&
-				this.hasShine(task.scale_img, 20, 4)
-			) {
-				return 'I';
-			}
-
-			// now trying for L, J (top pixel alignment)
-			let top_row = [
-				this.hasShine(task.scale_img, 2, 0),
-				this.hasShine(task.scale_img, 8, 0),
-				this.hasShine(task.scale_img, 14, 0),
-			];
-
-			if (top_row[0] && top_row[1] && top_row[2]) {
-				if (this.hasShine(task.scale_img, 2, 6)) {
-					return 'L';
-				}
-				if (this.hasShine(task.scale_img, 14, 6)) {
-					return 'J';
-				}
-			}
-
-			// checking S, Z, T
-			top_row = [
-				this.hasShine(task.scale_img, 2, 1),
-				this.hasShine(task.scale_img, 8, 1),
-				this.hasShine(task.scale_img, 14, 1),
-			];
-
-			if (top_row[0] && top_row[1] && top_row[2]) {
-				if (this.hasShine(task.scale_img, 8, 7)) {
-					return 'T';
-				}
-
-				return null;
-			}
-
-			if (top_row[1] && top_row[2]) {
-				if (
-					this.hasShine(task.scale_img, 2, 7) &&
-					this.hasShine(task.scale_img, 8, 7)
-				) {
-					return 'S';
-				}
-			}
-
-			if (top_row[0] && top_row[1]) {
-				if (
-					this.hasShine(task.scale_img, 8, 7) &&
-					this.hasShine(task.scale_img, 14, 7)
-				) {
-					return 'Z';
-				}
-			}
-
-			// lastly check for O
-			if (
-				this.hasShine(task.scale_img, 5, 1) &&
-				this.hasShine(task.scale_img, 11, 1) &&
-				this.hasShine(task.scale_img, 5, 7) &&
-				this.hasShine(task.scale_img, 11, 7)
-			) {
-				return 'O';
-			}
-
-			return null;
-		}
-
-		scanColor1(source_img) {
-			const task = this.config.tasks.color1;
-			const xywh_coordinates = this.getCropCoordinates(task);
-
-			crop(source_img, ...xywh_coordinates, task.crop_img);
-			bicubic(task.crop_img, task.scale_img);
-
-			// I tried selecting the pixel with highest luma but that didn't work.
-			// On capture cards with heavy color bleeding, it's inaccurate.
-
-			// we select the brightest pixel in the center 3x3 square of the
-			const row_width = task.scale_img.width;
-
-			let composite_white = [0, 0, 0];
-
-			// we check luma pixels on the inside only
-			for (let y = task.scale_img.height - 1; --y; ) {
-				for (let x = task.scale_img.width - 1; --x; ) {
-					const pix_offset = (y * row_width + x) << 2;
-					const cur_color = task.scale_img.data.subarray(
-						pix_offset,
-						pix_offset + 3
-					);
-
-					composite_white[0] = Math.max(composite_white[0], cur_color[0]);
-					composite_white[1] = Math.max(composite_white[1], cur_color[1]);
-					composite_white[2] = Math.max(composite_white[2], cur_color[2]);
-				}
-			}
-
-			return composite_white;
-
-			/*
-		// possible alternative:
-		// compute color average for pixel references
-		[[1, 3], [2, 2], [3, 1], [3, 3]]
-		OR
-		[[1, 2], [2, 2], [3, 2], [3, 1], [3, 3]]
-		/**/
-		}
-
-		scanColor(source_img, task) {
-			// to get the average color, we take the average of squares, or it might be too dark
-			// see: https://www.youtube.com/watch?v=LKnqECcg6Gw
-
-			const xywh_coordinates = this.getCropCoordinates(task);
-
-			crop(source_img, ...xywh_coordinates, task.crop_img);
-			bicubic(task.crop_img, task.scale_img);
-
-			const row_width = task.scale_img.width;
-			const pix_refs = [
-				[3, 2],
-				[3, 3],
-				[2, 3],
-			];
-
-			return pix_refs
-				.map(([x, y]) => {
-					const col_idx = (y * row_width + x) << 2;
-					return task.scale_img.data.subarray(col_idx, col_idx + 3);
-				})
-				.reduce(
-					(acc, col) => {
-						acc[0] += col[0] * col[0];
-						acc[1] += col[1] * col[1];
-						acc[2] += col[2] * col[2];
-						return acc;
-					},
-					[0, 0, 0]
-				)
-				.map(v => Math.sqrt(v / pix_refs.length));
-		}
-
-		async scanField(source_img, _colors) {
-			// Note: We work in the square of colors domain
-			// see: https://www.youtube.com/watch?v=LKnqECcg6Gw
-			const task = this.config.tasks.field;
-			const xywh_coordinates = this.getCropCoordinates(task);
-			const colors = _colors.map(rgb2lab); // we operate in Lab color space
-			const index_offset = _colors.length == 4 ? 0 : 1; // length of colors is either 3 or 4
-
-			// crop is not needed, but done anyway to share task captured area with caller app
-			crop(source_img, ...xywh_coordinates, task.crop_img);
-
-			/*
-		// the 2 lines below show what's actually needed: a simple crop and scale on the source image
-		// but cubic scaling in JS is MUCH slower than with native code, so we use canvas instead
-		bicubic(task.crop_img, task.scale_img);
-		const field_img = task.scale_img;
-		/**/
-
-			/**/
-			// crop and scale with canva
-			const original_field_img = await createImageBitmap(
-				source_img,
-				...xywh_coordinates
-			);
-
-			this.scaled_field_canvas_ctx.drawImage(
-				original_field_img,
-				0,
-				0,
-				...TASK_RESIZE.field
-			);
-
-			const field_img = this.scaled_field_canvas_ctx.getImageData(
-				0,
-				0,
-				...TASK_RESIZE.field
-			);
-
-			// writing into scale_img is not needed, but done anyway to share area with caller app
-			task.scale_img.data.set(field_img.data);
-			/**/
-
-			// Make a memory efficient array for our needs
-			const field = new Uint8Array(200);
-
-			// shine pixels
-			const shine_pix_refs = [
-				[1, 1],
-				[1, 2],
-				[2, 1],
-			];
-
-			// we read 4 judiciously positionned logical pixels per block
-			const pix_refs = [
-				[2, 4],
-				[3, 3],
-				[4, 4],
-				[4, 2],
-			];
-
-			const row_width = 9 * 8 + 7; // the last block in a row is one pixel less!
-
-			for (let ridx = 0; ridx < 20; ridx++) {
-				for (let cidx = 0; cidx < 10; cidx++) {
-					const block_offset = (ridx * row_width * 8 + cidx * 8) * 4;
-
-					const has_shine = shine_pix_refs.some(([x, y]) => {
-						const col_idx = block_offset + y * row_width * 4 + x * 4;
-						const col = field_img.data.subarray(col_idx, col_idx + 3);
-
-						return luma(...col) > SHINE_LUMA_THRESHOLD;
-					});
-
-					if (!has_shine) {
-						field[ridx * 10 + cidx] = 0; // we have black for sure!
-						continue;
-					}
-
-					const channels = rgb2lab(
-						pix_refs
-							.map(([x, y]) => {
-								const col_idx = block_offset + y * row_width * 4 + x * 4;
-								return field_img.data.subarray(col_idx, col_idx + 3);
-							})
-							.reduce(
-								(acc, col) => {
-									acc[0] += col[0] * col[0];
-									acc[1] += col[1] * col[1];
-									acc[2] += col[2] * col[2];
-									return acc;
-								},
-								[0, 0, 0]
-							)
-							.map(v => Math.sqrt(v / pix_refs.length))
-					);
-
-					let min_diff = 0xffffffff;
-					let min_idx = -1;
-
-					colors.forEach((col, col_idx) => {
-						const sum = col.reduce(
-							(acc, c, idx) => acc + (c - channels[idx]) * (c - channels[idx]),
-							0
-						);
-
-						if (sum < min_diff) {
-							min_diff = sum;
-							min_idx = col_idx;
-						}
-					});
-
-					field[ridx * 10 + cidx] = min_idx + index_offset;
-				}
-			}
-			/**/
-
-			return field;
-		}
+		this.config.capture_bounds = bounds;
+		this.config.capture_area = {
+			x: bounds.left,
+			y: bounds.top,
+			w: bounds.right - bounds.left,
+			h: bounds.bottom - bounds.top,
+		};
 	}
 
-	return TetrisOCR;
-})();
+	fixPalette() {
+		if (!this.palette) return;
+
+		this.palette = this.palette.map(colors => {
+			if (colors.length == 2) {
+				return [DEFAULT_COLOR_1, colors[0], colors[1]];
+			}
+
+			return colors;
+		});
+	}
+
+	getDigit(pixel_data, max_check_index, is_red) {
+		const sums = new Float64Array(max_check_index);
+		const size = pixel_data.length >>> 2;
+		const red_scale = 255 / 155; // scale red values as if capped at 155
+
+		for (let p_idx = size; p_idx--; ) {
+			const offset_idx = p_idx << 2;
+			const pixel_luma = is_red
+				? Math.min(pixel_data[offset_idx] * red_scale, 255) // only consider red component for luma, with scaling and capped
+				: luma(
+						pixel_data[offset_idx],
+						pixel_data[offset_idx + 1],
+						pixel_data[offset_idx + 2]
+				  );
+
+			for (let t_idx = max_check_index; t_idx--; ) {
+				const diff = pixel_luma - this.templates[t_idx][p_idx];
+				sums[t_idx] += diff * diff;
+			}
+		}
+
+		let min_val = 0xffffffff;
+		let min_idx = -1;
+
+		for (let s_idx = sums.length; s_idx--; ) {
+			if (sums[s_idx] < min_val) {
+				min_val = sums[s_idx];
+				min_idx = s_idx;
+			}
+		}
+
+		return min_idx;
+	}
+
+	initCaptureContext(frame, half_height) {
+		this.capture_canvas = document.createElement('canvas');
+
+		this.capture_canvas.width = frame.width;
+		this.capture_canvas.height = frame.height >> (half_height ? 1 : 0);
+
+		this.capture_canvas_ctx = this.capture_canvas.getContext('2d', {
+			alpha: false,
+		});
+		this.capture_canvas_ctx.imageSmoothingEnabled = false;
+
+		// On top of the capture context, we need one more canvas for the scaled field
+		// because the performance of OffScreenCanvas are horrible, and same gvoes for the bicubic lib for any image that's not super small :(
+
+		// TODO: get rid of this additional canvas when we can T_T
+		this.scaled_field_canvas = document.createElement('canvas');
+
+		this.scaled_field_canvas.width = TASK_RESIZE.field[0];
+		this.scaled_field_canvas.height = TASK_RESIZE.field[1];
+
+		this.scaled_field_canvas_ctx = this.scaled_field_canvas.getContext('2d', {
+			alpha: false,
+		});
+		this.scaled_field_canvas_ctx.imageSmoothingEnabled = true;
+		this.scaled_field_canvas_ctx.imageSmoothingQuality = 'medium';
+	}
+
+	async processFrame(frame, half_height) {
+		if (!this.capture_canvas_ctx) {
+			this.initCaptureContext(frame, half_height);
+		}
+
+		const res = {};
+
+		performance.mark('start');
+		this.capture_canvas_ctx.drawImage(
+			frame,
+			0,
+			0,
+			frame.width,
+			frame.height >> (half_height ? 1 : 0)
+		);
+		performance.mark('draw_end');
+		performance.measure('draw_frame', 'start', 'draw_end');
+
+		const source_img = this.getSourceImageData();
+
+		res.score = this.scanScore(source_img);
+		res.level = this.scanLevel(source_img);
+		res.lines = this.scanLines(source_img);
+
+		const level_units = res.level == null ? 0 : res.level[1];
+
+		// WARNING: We need to use the level for color and board reads
+		// WARNING: level *may* be read incorrectly when changing value
+		// TODO: Store source_img, and level and board should be read after the 1-frame sanitization pipeline
+
+		// color are either supplied from palette or read, there's no other choice
+		if (this.palette) {
+			[res.color1, res.color2, res.color3] = this.palette[level_units];
+		} else {
+			// assume tasks color1 and color2 are set
+			res.color2 = this.scanColor2(source_img);
+			res.color3 = this.scanColor3(source_img);
+
+			if (this.config.tasks.color1) {
+				res.color1 = this.scanColor1(source_img);
+			} else {
+				res.color1 = DEFAULT_COLOR_1;
+			}
+		}
+
+		const colors = [res.color1, res.color2, res.color3];
+
+		if (level_units != 6 && level_units != 7) {
+			colors.unshift(DEFAULT_COLOR_0); // add black
+		}
+
+		res.field = await this.scanField(source_img, colors);
+		res.preview = this.scanPreview(source_img);
+
+		if (this.config.tasks.instant_das) {
+			// assumes all 3 das tasks are a unit
+			res.instant_das = this.scanInstantDas(source_img);
+			res.cur_piece_das = this.scanCurPieceDas(source_img);
+			res.cur_piece = this.scanCurPiece(source_img);
+		}
+
+		if (this.config.tasks.T) {
+			Object.assign(res, this.scanPieceStats(source_img));
+		}
+
+		// round the colors if needed
+		if (res.color2) {
+			res.color2 = res.color2.map(v => Math.round(v));
+			res.color3 = res.color3.map(v => Math.round(v));
+		}
+
+		this.onMessage(res);
+	}
+
+	scanScore(source_img) {
+		return this.ocrDigits(source_img, this.config.tasks.score);
+	}
+
+	scanLevel(source_img) {
+		return this.ocrDigits(source_img, this.config.tasks.level);
+	}
+
+	scanLines(source_img) {
+		return this.ocrDigits(source_img, this.config.tasks.lines);
+	}
+
+	scanColor2(source_img) {
+		return this.scanColor(source_img, this.config.tasks.color2);
+	}
+
+	scanColor3(source_img) {
+		return this.scanColor(source_img, this.config.tasks.color3);
+	}
+
+	scanInstantDas(source_img) {
+		return this.ocrDigits(source_img, this.config.tasks.instant_das);
+	}
+
+	scanCurPieceDas(source_img) {
+		return this.ocrDigits(source_img, this.config.tasks.cur_piece_das);
+	}
+
+	scanPieceStats(source_img) {
+		return {
+			T: this.ocrDigits(source_img, this.config.tasks.T),
+			J: this.ocrDigits(source_img, this.config.tasks.J),
+			Z: this.ocrDigits(source_img, this.config.tasks.Z),
+			O: this.ocrDigits(source_img, this.config.tasks.O),
+			S: this.ocrDigits(source_img, this.config.tasks.S),
+			L: this.ocrDigits(source_img, this.config.tasks.L),
+			I: this.ocrDigits(source_img, this.config.tasks.I),
+		};
+	}
+
+	getSourceImageData() {
+		const pixels = this.capture_canvas_ctx.getImageData(
+			this.config.capture_area.x,
+			this.config.capture_area.y,
+			this.config.capture_area.w,
+			this.config.capture_area.h
+		);
+
+		/*
+	const pixels_per_rows = this.config.capture_area.w * 4;
+	const max_rows = this.config.capture_bounds.bottom;
+
+	for (let row_idx = 1; row_idx < max_rows; row_idx++) {
+		pixels.data.copyWithin(
+			pixels_per_rows * row_idx,
+			pixels_per_rows * row_idx * 2,
+			pixels_per_rows * (row_idx * 2 + 1)
+		);
+	}
+	/**/
+
+		this.config.source_img = pixels;
+
+		return pixels;
+	}
+
+	getCropCoordinates(task) {
+		const [raw_x, raw_y, w, h] = task.crop;
+
+		return [
+			raw_x - this.config.capture_area.x,
+			raw_y - this.config.capture_area.y,
+			w,
+			h,
+		];
+	}
+
+	ocrDigits(source_img, task) {
+		const [x, y, w, h] = this.getCropCoordinates(task);
+		const digits = Array(task.pattern.length);
+
+		crop(source_img, x, y, w, h, task.crop_img);
+		bicubic(task.crop_img, task.scale_img);
+
+		for (let idx = digits.length; idx--; ) {
+			const char = task.pattern[idx];
+
+			crop(task.scale_img, idx * 16, 0, 14, 14, this.digit_img);
+
+			const digit = this.getDigit(
+				this.digit_img.data,
+				PATTERN_MAX_INDEXES[char],
+				task.red
+			);
+
+			if (!digit) return null;
+
+			digits[idx] = digit - 1;
+		}
+
+		return digits;
+	}
+
+	/*
+	 * Returns true if at least one of the pixel has a luma higher than threshold
+	 */
+	hasShine(img, block_x, block_y) {
+		// extract the shine area at the location supplied
+		const shine_width = 2;
+		crop(img, block_x, block_y, shine_width, 3, this.shine_img);
+
+		const img_data = this.shine_img.data;
+		const shine_pix_ref = [
+			[0, 0],
+			[1, 1],
+			[1, 2],
+		];
+
+		return shine_pix_ref.some(([x, y]) => {
+			const offset_idx = (y * shine_width + x) << 2;
+			const pixel_luma = luma(
+				img_data[offset_idx],
+				img_data[offset_idx + 1],
+				img_data[offset_idx + 2]
+			);
+
+			return pixel_luma > SHINE_LUMA_THRESHOLD;
+		});
+	}
+
+	scanPreview(source_img) {
+		const task = this.config.tasks.preview;
+		const [x, y, w, h] = this.getCropCoordinates(task);
+
+		crop(source_img, x, y, w, h, task.crop_img);
+		bicubic(task.crop_img, task.scale_img);
+
+		// Trying side i blocks
+		if (
+			this.hasShine(task.scale_img, 0, 4) &&
+			this.hasShine(task.scale_img, 28, 4) // not top-left corner, but since I block are white, should work
+		) {
+			return 'I';
+		}
+
+		// now trying the 3x2 matrix for T, L, J, S, Z
+		const top_row = [
+			this.hasShine(task.scale_img, 4, 0),
+			this.hasShine(task.scale_img, 12, 0),
+			this.hasShine(task.scale_img, 20, 0),
+		];
+
+		if (top_row[0] && top_row[1] && top_row[2]) {
+			// J, T, L
+			if (this.hasShine(task.scale_img, 4, 8)) {
+				return 'L';
+			}
+			if (this.hasShine(task.scale_img, 12, 8)) {
+				return 'T';
+			}
+			if (this.hasShine(task.scale_img, 20, 8)) {
+				return 'J';
+			}
+
+			return null;
+		}
+
+		if (top_row[1] && top_row[2]) {
+			if (
+				this.hasShine(task.scale_img, 4, 8) &&
+				this.hasShine(task.scale_img, 12, 8)
+			) {
+				return 'S';
+			}
+		}
+
+		if (top_row[0] && top_row[1]) {
+			if (
+				this.hasShine(task.scale_img, 12, 8) &&
+				this.hasShine(task.scale_img, 20, 8)
+			) {
+				return 'Z';
+			}
+		}
+
+		// lastly check for O
+		if (
+			this.hasShine(task.scale_img, 8, 0) &&
+			this.hasShine(task.scale_img, 16, 0) &&
+			this.hasShine(task.scale_img, 8, 8) &&
+			this.hasShine(task.scale_img, 16, 8)
+		) {
+			return 'O';
+		}
+
+		return null;
+	}
+
+	scanCurPiece(source_img) {
+		const task = this.config.tasks.cur_piece;
+		const [x, y, w, h] = this.getCropCoordinates(task);
+
+		// curPieces are not vertically aligned on the top row
+		// L and J are rendered 1 pixel higher than S, Z, T, O
+
+		crop(source_img, x, y, w, h, task.crop_img);
+		bicubic(task.crop_img, task.scale_img);
+
+		// Trying side i blocks
+		if (
+			this.hasShine(task.scale_img, 0, 4) &&
+			this.hasShine(task.scale_img, 20, 4)
+		) {
+			return 'I';
+		}
+
+		// now trying for L, J (top pixel alignment)
+		let top_row = [
+			this.hasShine(task.scale_img, 2, 0),
+			this.hasShine(task.scale_img, 8, 0),
+			this.hasShine(task.scale_img, 14, 0),
+		];
+
+		if (top_row[0] && top_row[1] && top_row[2]) {
+			if (this.hasShine(task.scale_img, 2, 6)) {
+				return 'L';
+			}
+			if (this.hasShine(task.scale_img, 14, 6)) {
+				return 'J';
+			}
+		}
+
+		// checking S, Z, T
+		top_row = [
+			this.hasShine(task.scale_img, 2, 1),
+			this.hasShine(task.scale_img, 8, 1),
+			this.hasShine(task.scale_img, 14, 1),
+		];
+
+		if (top_row[0] && top_row[1] && top_row[2]) {
+			if (this.hasShine(task.scale_img, 8, 7)) {
+				return 'T';
+			}
+
+			return null;
+		}
+
+		if (top_row[1] && top_row[2]) {
+			if (
+				this.hasShine(task.scale_img, 2, 7) &&
+				this.hasShine(task.scale_img, 8, 7)
+			) {
+				return 'S';
+			}
+		}
+
+		if (top_row[0] && top_row[1]) {
+			if (
+				this.hasShine(task.scale_img, 8, 7) &&
+				this.hasShine(task.scale_img, 14, 7)
+			) {
+				return 'Z';
+			}
+		}
+
+		// lastly check for O
+		if (
+			this.hasShine(task.scale_img, 5, 1) &&
+			this.hasShine(task.scale_img, 11, 1) &&
+			this.hasShine(task.scale_img, 5, 7) &&
+			this.hasShine(task.scale_img, 11, 7)
+		) {
+			return 'O';
+		}
+
+		return null;
+	}
+
+	scanColor1(source_img) {
+		const task = this.config.tasks.color1;
+		const xywh_coordinates = this.getCropCoordinates(task);
+
+		crop(source_img, ...xywh_coordinates, task.crop_img);
+		bicubic(task.crop_img, task.scale_img);
+
+		// I tried selecting the pixel with highest luma but that didn't work.
+		// On capture cards with heavy color bleeding, it's inaccurate.
+
+		// we select the brightest pixel in the center 3x3 square of the
+		const row_width = task.scale_img.width;
+
+		let composite_white = [0, 0, 0];
+
+		// we check luma pixels on the inside only
+		for (let y = task.scale_img.height - 1; --y; ) {
+			for (let x = task.scale_img.width - 1; --x; ) {
+				const pix_offset = (y * row_width + x) << 2;
+				const cur_color = task.scale_img.data.subarray(
+					pix_offset,
+					pix_offset + 3
+				);
+
+				composite_white[0] = Math.max(composite_white[0], cur_color[0]);
+				composite_white[1] = Math.max(composite_white[1], cur_color[1]);
+				composite_white[2] = Math.max(composite_white[2], cur_color[2]);
+			}
+		}
+
+		return composite_white;
+
+		/*
+	// possible alternative:
+	// compute color average for pixel references
+	[[1, 3], [2, 2], [3, 1], [3, 3]]
+	OR
+	[[1, 2], [2, 2], [3, 2], [3, 1], [3, 3]]
+	/**/
+	}
+
+	scanColor(source_img, task) {
+		// to get the average color, we take the average of squares, or it might be too dark
+		// see: https://www.youtube.com/watch?v=LKnqECcg6Gw
+
+		const xywh_coordinates = this.getCropCoordinates(task);
+
+		crop(source_img, ...xywh_coordinates, task.crop_img);
+		bicubic(task.crop_img, task.scale_img);
+
+		const row_width = task.scale_img.width;
+		const pix_refs = [
+			[3, 2],
+			[3, 3],
+			[2, 3],
+		];
+
+		return pix_refs
+			.map(([x, y]) => {
+				const col_idx = (y * row_width + x) << 2;
+				return task.scale_img.data.subarray(col_idx, col_idx + 3);
+			})
+			.reduce(
+				(acc, col) => {
+					acc[0] += col[0] * col[0];
+					acc[1] += col[1] * col[1];
+					acc[2] += col[2] * col[2];
+					return acc;
+				},
+				[0, 0, 0]
+			)
+			.map(v => Math.sqrt(v / pix_refs.length));
+	}
+
+	async scanField(source_img, _colors) {
+		// Note: We work in the square of colors domain
+		// see: https://www.youtube.com/watch?v=LKnqECcg6Gw
+		const task = this.config.tasks.field;
+		const xywh_coordinates = this.getCropCoordinates(task);
+		const colors = _colors.map(rgb2lab); // we operate in Lab color space
+		const index_offset = _colors.length == 4 ? 0 : 1; // length of colors is either 3 or 4
+
+		// crop is not needed, but done anyway to share task captured area with caller app
+		crop(source_img, ...xywh_coordinates, task.crop_img);
+
+		/*
+	// the 2 lines below show what's actually needed: a simple crop and scale on the source image
+	// but cubic scaling in JS is MUCH slower than with native code, so we use canvas instead
+	bicubic(task.crop_img, task.scale_img);
+	const field_img = task.scale_img;
+	/**/
+
+		/**/
+		// crop and scale with canva
+		const original_field_img = await createImageBitmap(
+			source_img,
+			...xywh_coordinates
+		);
+
+		this.scaled_field_canvas_ctx.drawImage(
+			original_field_img,
+			0,
+			0,
+			...TASK_RESIZE.field
+		);
+
+		const field_img = this.scaled_field_canvas_ctx.getImageData(
+			0,
+			0,
+			...TASK_RESIZE.field
+		);
+
+		// writing into scale_img is not needed, but done anyway to share area with caller app
+		task.scale_img.data.set(field_img.data);
+		/**/
+
+		// Make a memory efficient array for our needs
+		const field = new Uint8Array(200);
+
+		// shine pixels
+		const shine_pix_refs = [
+			[1, 1],
+			[1, 2],
+			[2, 1],
+		];
+
+		// we read 4 judiciously positionned logical pixels per block
+		const pix_refs = [
+			[2, 4],
+			[3, 3],
+			[4, 4],
+			[4, 2],
+		];
+
+		const row_width = 9 * 8 + 7; // the last block in a row is one pixel less!
+
+		for (let ridx = 0; ridx < 20; ridx++) {
+			for (let cidx = 0; cidx < 10; cidx++) {
+				const block_offset = (ridx * row_width * 8 + cidx * 8) * 4;
+
+				const has_shine = shine_pix_refs.some(([x, y]) => {
+					const col_idx = block_offset + y * row_width * 4 + x * 4;
+					const col = field_img.data.subarray(col_idx, col_idx + 3);
+
+					return luma(...col) > SHINE_LUMA_THRESHOLD;
+				});
+
+				if (!has_shine) {
+					field[ridx * 10 + cidx] = 0; // we have black for sure!
+					continue;
+				}
+
+				const channels = rgb2lab(
+					pix_refs
+						.map(([x, y]) => {
+							const col_idx = block_offset + y * row_width * 4 + x * 4;
+							return field_img.data.subarray(col_idx, col_idx + 3);
+						})
+						.reduce(
+							(acc, col) => {
+								acc[0] += col[0] * col[0];
+								acc[1] += col[1] * col[1];
+								acc[2] += col[2] * col[2];
+								return acc;
+							},
+							[0, 0, 0]
+						)
+						.map(v => Math.sqrt(v / pix_refs.length))
+				);
+
+				let min_diff = 0xffffffff;
+				let min_idx = -1;
+
+				colors.forEach((col, col_idx) => {
+					const sum = col.reduce(
+						(acc, c, idx) => acc + (c - channels[idx]) * (c - channels[idx]),
+						0
+					);
+
+					if (sum < min_diff) {
+						min_diff = sum;
+						min_idx = col_idx;
+					}
+				});
+
+				field[ridx * 10 + cidx] = min_idx + index_offset;
+			}
+		}
+		/**/
+
+		return field;
+	}
+}

--- a/public/ocr/calibration.js
+++ b/public/ocr/calibration.js
@@ -1,4 +1,4 @@
-function getCaptureCoordinates(template_id, capture_id) {
+export function getCaptureCoordinates(ocv, template_id, capture_id) {
 	const template = ocv.imread(template_id);
 	const capture = ocv.imread(capture_id);
 

--- a/public/ocr/image_tools.js
+++ b/public/ocr/image_tools.js
@@ -1,7 +1,7 @@
 // bicubic interpolation taken from
 // https://www.strauss-engineering.ch/js-bilinear-interpolation.html
 
-function TERP(t, a, b, c, d) {
+export function TERP(t, a, b, c, d) {
 	return (
 		0.5 *
 			(c -
@@ -12,7 +12,7 @@ function TERP(t, a, b, c, d) {
 	);
 }
 
-function BicubicInterpolation(x, y, values) {
+export function BicubicInterpolation(x, y, values) {
 	const i0 = TERP(x, values[0], values[1], values[2], values[3]);
 	const i1 = TERP(x, values[4], values[5], values[6], values[7]);
 	const i2 = TERP(x, values[8], values[9], values[10], values[11]);
@@ -22,7 +22,7 @@ function BicubicInterpolation(x, y, values) {
 }
 
 //
-function getBicubicPixels(srcImg, [dw, dh], destCoords) {
+export function getBicubicPixels(srcImg, [dw, dh], destCoords) {
 	const sdata = srcImg.data;
 	const sw = srcImg.width;
 	const sh = srcImg.height;
@@ -94,7 +94,7 @@ function getBicubicPixels(srcImg, [dw, dh], destCoords) {
 	});
 }
 
-function bicubic(srcImg, destImg) {
+export function bicubic(srcImg, destImg) {
 	const sdata = srcImg.data;
 	const sw = srcImg.width;
 	const sh = srcImg.height;
@@ -175,7 +175,7 @@ function bicubic(srcImg, destImg) {
 	}
 }
 
-function crop(source, x, y, w, h, target = null) {
+export function crop(source, x, y, w, h, target = null) {
 	if (!target) {
 		target = new ImageData(w, h);
 	}
@@ -195,7 +195,7 @@ function crop(source, x, y, w, h, target = null) {
 
 // if target is not supplied, modifies source image in place
 // with resulting top half being the deinterlaced copy
-function deinterlace(source, target) {
+export function deinterlace(source, target) {
 	const row_len = source.width << 2;
 	const max_rows = source.height >>> 1;
 
@@ -222,10 +222,10 @@ function deinterlace(source, target) {
 	}
 }
 
-function luma(r, g, b) {
+export function luma(r, g, b) {
 	return r * 0.299 + g * 0.587 + b * 0.114;
 }
 
-function roundedLuma(r, g, b) {
+export function roundedLuma(r, g, b) {
 	return Math.round(luma(r, g, b));
 }

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -251,20 +251,6 @@
 		<div id="templates"></div>
 
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/ocr/calibration.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/ocr/image_tools.js"></script>
-		<script src="/ocr/templates.js"></script>
-		<script src="/ocr/palettes.js"></script>
-		<script src="/ocr/utils.js"></script>
-		<script src="/ocr/ScoreFixer.js"></script>
-		<script src="/ocr/LevelFixer.js"></script>
-		<script src="/ocr/OCRSanitizer.js"></script>
-		<script src="/ocr/TetrisOCR.js"></script>
-		<script src="/views/tts.js"></script>
-		<script src="/ocr/ocr_main.js"></script>
+		<script type="module" src="/ocr/ocr_main.js"></script>
 	</body>
 </html>

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1,3 +1,12 @@
+import QueryString from '/js/QueryString.js';
+import Connection from '/js/connection.js';
+import BinaryFrame from '/js/BinaryFrame.js';
+import loadDigitTemplates from '/ocr/templates.js';
+import loadPalettes from '/ocr/palettes.js';
+import TetrisOCR from '/ocr/TetrisOCR.js';
+import OCRSanitizer from '/ocr/OCRSanitizer.js';
+import { getCaptureCoordinates } from '/ocr/calibration.js';
+
 // NTSC NES resolution: 256x224 -> 512x448
 const LEVEL_COLORS = [
 	['#4A32FF', '#4AAFFE'],
@@ -366,7 +375,11 @@ go_btn.addEventListener('click', async evt => {
 		setTimeout(resolve, 0); // wait one tick for everything to be drawn nicely... just in case
 	});
 
-	let [ox, oy, ow, oh] = getCaptureCoordinates('reference_ui', 'video_capture');
+	let [ox, oy, ow, oh] = getCaptureCoordinates(
+		ocv,
+		'reference_ui',
+		'video_capture'
+	);
 
 	if (ow <= 0 || oh <= 0) {
 		console.log('Unable to match template');

--- a/public/ocr/palettes.js
+++ b/public/ocr/palettes.js
@@ -10,7 +10,7 @@ async function getPalette(name) {
 	]);
 }
 
-async function loadPalettes() {
+export default async function loadPalettes() {
 	return (await Promise.all(LIST.map(getPalette))).reduce(
 		(acc, palette, idx) => {
 			acc[LIST[idx]] = palette;

--- a/public/ocr/templates.js
+++ b/public/ocr/templates.js
@@ -1,3 +1,5 @@
+import { bicubic, crop, luma } from '/ocr/image_tools.js';
+
 const DIGITS = '0123456789ABCDEF'.split('');
 
 DIGITS.unshift('null');
@@ -9,7 +11,7 @@ async function getTemplateData(digit) {
 	return createImageBitmap(blob);
 }
 
-async function loadDigitTemplates() {
+export default async function loadDigitTemplates() {
 	const imgs = await Promise.all(DIGITS.map(getTemplateData));
 
 	// we write all the templates in a row in a canva with 1px spacing in between

--- a/public/ocr/utils.js
+++ b/public/ocr/utils.js
@@ -1,4 +1,4 @@
-function timingDecorator(name, func) {
+export function timingDecorator(name, func) {
 	// func must be prebound
 	return function (...args) {
 		performance.mark(`start_${name}`);
@@ -12,7 +12,7 @@ function timingDecorator(name, func) {
 	};
 }
 
-function rgb2lab_normalizeRgbChannel(channel) {
+export function rgb2lab_normalizeRgbChannel(channel) {
 	channel /= 255;
 
 	return (
@@ -23,13 +23,13 @@ function rgb2lab_normalizeRgbChannel(channel) {
 	);
 }
 
-function rgb2lab_normalizeXyzChannel(channel) {
+export function rgb2lab_normalizeXyzChannel(channel) {
 	return channel > 0.008856
 		? Math.pow(channel, 1 / 3)
 		: 7.787 * channel + 16 / 116;
 }
 
-function rgb2lab([r, g, b]) {
+export function rgb2lab([r, g, b]) {
 	r = rgb2lab_normalizeRgbChannel(r);
 	g = rgb2lab_normalizeRgbChannel(g);
 	b = rgb2lab_normalizeRgbChannel(b);

--- a/public/views/1p/champions.html
+++ b/public/views/1p/champions.html
@@ -228,17 +228,11 @@
 
 		<!-- Audio -->
 
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
 
-		<script>
 			(async function init() {
 				// START ASYNC FUNC WRAPPER
 

--- a/public/views/1p/champions.html
+++ b/public/views/1p/champions.html
@@ -229,7 +229,7 @@
 		<!-- Audio -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
 

--- a/public/views/1p/classic.html
+++ b/public/views/1p/classic.html
@@ -475,15 +475,6 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/Board.js"></script>
-		<script src="/views/Game.js"></script>
-		<script src="/views/DomRefs.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/main.js"></script>
+		<script type="module" src="/views/main.js"></script>
 	</body>
 </html>

--- a/public/views/1p/das_trainer.html
+++ b/public/views/1p/das_trainer.html
@@ -415,15 +415,6 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/Board.js"></script>
-		<script src="/views/Game.js"></script>
-		<script src="/views/DomRefs.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/main.js"></script>
+		<script type="module" src="/views/main.js"></script>
 	</body>
 </html>

--- a/public/views/1p/invisible_tetris.html
+++ b/public/views/1p/invisible_tetris.html
@@ -56,16 +56,12 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
 			// Game Genie code: OXYOUO VNIPZN VNTPYN
+
+			import bg from '/views/bg.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
 
 			const player = new Player(
 				{

--- a/public/views/1p/invisible_tetris.html
+++ b/public/views/1p/invisible_tetris.html
@@ -61,6 +61,7 @@
 			import '/views/bg.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
+			import { peek } from '/views/utils.js';
 
 			const player = new Player(
 				{

--- a/public/views/1p/invisible_tetris.html
+++ b/public/views/1p/invisible_tetris.html
@@ -58,8 +58,7 @@
 
 		<script type="module">
 			// Game Genie code: OXYOUO VNIPZN VNTPYN
-
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
 

--- a/public/views/1p/plaintext.html
+++ b/public/views/1p/plaintext.html
@@ -103,16 +103,10 @@
 
 		<!-- Audio -->
 
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
+		<script type="module">
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
 
-		<script>
 			const board_content = document.querySelector(`#board .content`);
 			const stats_dl = document.querySelector(`#stats dl`);
 			const player_fields = {};

--- a/public/views/1p/plaintext.html
+++ b/public/views/1p/plaintext.html
@@ -172,7 +172,7 @@
 					let rows = Array(20);
 
 					for (let i = 0; i < 20; i++) {
-						row = plaintext_field.slice(i * 10, (i + 1) * 10).join('');
+						const row = plaintext_field.slice(i * 10, (i + 1) * 10).join('');
 
 						rows[i] = row;
 					}

--- a/public/views/1p/simple_1p.html
+++ b/public/views/1p/simple_1p.html
@@ -58,17 +58,11 @@
 
 		<!-- Audio -->
 
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
 
-		<script>
 			const player = new Player(
 				{
 					score: document.querySelector(`.score .content`),

--- a/public/views/1p/simple_1p.html
+++ b/public/views/1p/simple_1p.html
@@ -59,7 +59,7 @@
 		<!-- Audio -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
 

--- a/public/views/1p/stencil.html
+++ b/public/views/1p/stencil.html
@@ -73,15 +73,12 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script>
+		<script type="module">
+			import QueryString from '/js/QueryString.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
+			import { PIECES } from '/views/constants.js';
+
 			const init_time = Date.now();
 
 			if (QueryString.get('bg') === '0') {

--- a/public/views/1p/stencil.html
+++ b/public/views/1p/stencil.html
@@ -75,6 +75,7 @@
 
 		<script type="module">
 			import QueryString from '/js/QueryString.js';
+			import BinaryFrame from '/js/BinaryFrame.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
 			import { PIECES } from '/views/constants.js';

--- a/public/views/1p/stencil_ctwc_sing_21.html
+++ b/public/views/1p/stencil_ctwc_sing_21.html
@@ -125,6 +125,7 @@
 
 		<script type="module">
 			import QueryString from '/js/QueryString.js';
+			import BinaryFrame from '/js/BinaryFrame.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
 			import { PIECES } from '/views/constants.js';

--- a/public/views/1p/stencil_ctwc_sing_21.html
+++ b/public/views/1p/stencil_ctwc_sing_21.html
@@ -122,15 +122,13 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script>
+
+		<script type="module">
+			import QueryString from '/js/QueryString.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
+			import { PIECES } from '/views/constants.js';
+
 			// client side time is not reliable, supply a date from the future
 			let received_time_from_server = false;
 			let init_time = new Date(2030, 1, 1).getTime();

--- a/public/views/1p/stencilplus.html
+++ b/public/views/1p/stencilplus.html
@@ -81,15 +81,12 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script>
+		<script type="module">
+			import QueryString from '/js/QueryString.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
+			import { PIECES } from '/views/constants.js';
+
 			const init_time = Date.now();
 
 			if (QueryString.get('bg') === '0') {

--- a/public/views/1p/stencilplus.html
+++ b/public/views/1p/stencilplus.html
@@ -83,6 +83,7 @@
 
 		<script type="module">
 			import QueryString from '/js/QueryString.js';
+			import BinaryFrame from '/js/BinaryFrame.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';
 			import { PIECES } from '/views/constants.js';

--- a/public/views/1p/tomellosoulman.html
+++ b/public/views/1p/tomellosoulman.html
@@ -639,18 +639,14 @@
 		</div>
 		<!-- End Stream BG -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/Board.js"></script>
-		<script src="/views/Game.js"></script>
-		<script src="/views/DomRefs.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/main.js"></script>
-		<script src="/views/bg.js"></script>
-		<script>
+		<script type="module" src="/views/main.js"></script>
+		<script type="module">
+			import _ from '/views/bg.js';
+			import QueryString from '/js/QueryString.js';
+			import Connection from '/js/connection.js';
+			import Player from '/views/Player.js';
+			import { PIECES } from '/views/constants.js';
+
 			const stream_bg = document.querySelector('#stream_bg');
 			const flash_div = document.createElement('div');
 

--- a/public/views/1p/tomellosoulman.html
+++ b/public/views/1p/tomellosoulman.html
@@ -641,7 +641,7 @@
 
 		<script type="module" src="/views/main.js"></script>
 		<script type="module">
-			import _ from '/views/bg.js';
+			import '/views/bg.js';
 			import QueryString from '/js/QueryString.js';
 			import Connection from '/js/connection.js';
 			import Player from '/views/Player.js';

--- a/public/views/Board.js
+++ b/public/views/Board.js
@@ -35,7 +35,7 @@ class Column {
 	}
 }
 
-class Board {
+export default class Board {
 	constructor(board_str) {
 		this.rows = Array();
 

--- a/public/views/CTMCompetitionPlayer.js
+++ b/public/views/CTMCompetitionPlayer.js
@@ -1,65 +1,64 @@
-const CTMCompetitionPlayer = (function () {
-	const DEFAULT_DOM_REFS = {
-		drought_box: DOM_DEV_NULL,
-		runway_box: DOM_DEV_NULL,
-		projection_box: DOM_DEV_NULL,
-	};
+import CompetitionPlayer from '/views/CompetitionPlayer.js';
+import { DOM_DEV_NULL } from '/views/constants.js';
 
-	const DEFAULT_OPTIONS = {};
+const DEFAULT_DOM_REFS = {
+	drought_box: DOM_DEV_NULL,
+	runway_box: DOM_DEV_NULL,
+	projection_box: DOM_DEV_NULL,
+};
 
-	class CTMCompetitionPlayer extends CompetitionPlayer {
-		constructor(dom, options) {
-			super(
-				{
-					...DEFAULT_DOM_REFS,
-					...dom,
-				},
-				{
-					...DEFAULT_OPTIONS,
-					...options,
-				}
-			);
+const DEFAULT_OPTIONS = {};
 
-			// hack to force elements to be invisible no matter what
-			this.dom.runway_box.onanimationend =
-				this.dom.projection_box.onanimationend = () => {
-					this.dom.runway_box.style.display = 'none';
-					this.dom.projection_box.style.display = 'none';
-				};
+export default class CTMCompetitionPlayer extends CompetitionPlayer {
+	constructor(dom, options) {
+		super(
+			{
+				...DEFAULT_DOM_REFS,
+				...dom,
+			},
+			{
+				...DEFAULT_OPTIONS,
+				...options,
+			}
+		);
 
-			// sets up custom UI behaviours
-			this.onDroughtStart = () => {
-				this.dom.drought_box.classList.add('active');
+		// hack to force elements to be invisible no matter what
+		this.dom.runway_box.onanimationend =
+			this.dom.projection_box.onanimationend = () => {
+				this.dom.runway_box.style.display = 'none';
+				this.dom.projection_box.style.display = 'none';
 			};
 
-			this.onDroughtEnd = () => {
-				this.dom.drought_box.classList.remove('active');
-			};
+		// sets up custom UI behaviours
+		this.onDroughtStart = () => {
+			this.dom.drought_box.classList.add('active');
+		};
 
-			this.onKillScreen = () => {
-				this.dom.runway_box.classList.add('past_killscreen');
-				this.dom.projection_box.classList.add('past_killscreen');
-			};
+		this.onDroughtEnd = () => {
+			this.dom.drought_box.classList.remove('active');
+		};
 
-			this.onGameStart = () => {
-				this.dom.drought_box.classList.remove('active');
+		this.onKillScreen = () => {
+			this.dom.runway_box.classList.add('past_killscreen');
+			this.dom.projection_box.classList.add('past_killscreen');
+		};
 
-				this.dom.runway_box.classList.remove('past_killscreen');
-				this.dom.projection_box.classList.remove('past_killscreen');
+		this.onGameStart = () => {
+			this.dom.drought_box.classList.remove('active');
 
-				this.dom.runway_box.style.display = null;
-				this.dom.projection_box.style.display = null;
+			this.dom.runway_box.classList.remove('past_killscreen');
+			this.dom.projection_box.classList.remove('past_killscreen');
 
-				this.dom.level.hidden = false;
-				this.dom.preview.hidden = false;
-			};
+			this.dom.runway_box.style.display = null;
+			this.dom.projection_box.style.display = null;
 
-			this.onGameOver = () => {
-				this.dom.level.hidden = true;
-				this.dom.preview.hidden = true;
-			};
-		}
+			this.dom.level.hidden = false;
+			this.dom.preview.hidden = false;
+		};
+
+		this.onGameOver = () => {
+			this.dom.level.hidden = true;
+			this.dom.preview.hidden = true;
+		};
 	}
-
-	return CTMCompetitionPlayer;
-})();
+}

--- a/public/views/CompetitionPlayer.js
+++ b/public/views/CompetitionPlayer.js
@@ -1,103 +1,104 @@
-const CompetitionPlayer = (function () {
-	const DEFAULT_DOM_REFS = {
-		diff: DOM_DEV_NULL,
-		t_diff: DOM_DEV_NULL,
-		runway_diff: DOM_DEV_NULL,
-		runway_t_diff: DOM_DEV_NULL,
-		projection_diff: DOM_DEV_NULL,
-		projection_t_diff: DOM_DEV_NULL,
-	};
+import Player from '/views/Player.js';
+import Color from '/views/color.js';
+import Gradient from '/views/gradient.js';
+import { DOM_DEV_NULL } from '/views/constants.js';
 
-	const DEFAULT_OPTIONS = {
-		diff_color_gradient: new Gradient( // green - orange - red
-			'#0eff0e',
-			new Color(255, 165, 0),
-			'#fd0009'
-		),
-		format_tetris_diff: v => {
-			// ensure result is at most 4 char long
-			if (v >= 100) {
-				return Math.round(v);
-			} else if (v >= 10) {
-				return v.toFixed(1);
-			} else {
-				return v.toFixed(2);
+const DEFAULT_DOM_REFS = {
+	diff: DOM_DEV_NULL,
+	t_diff: DOM_DEV_NULL,
+	runway_diff: DOM_DEV_NULL,
+	runway_t_diff: DOM_DEV_NULL,
+	projection_diff: DOM_DEV_NULL,
+	projection_t_diff: DOM_DEV_NULL,
+};
+
+const DEFAULT_OPTIONS = {
+	diff_color_gradient: new Gradient( // green - orange - red
+		'#0eff0e',
+		new Color(255, 165, 0),
+		'#fd0009'
+	),
+	format_tetris_diff: v => {
+		// ensure result is at most 4 char long
+		if (v >= 100) {
+			return Math.round(v);
+		} else if (v >= 10) {
+			return v.toFixed(1);
+		} else {
+			return v.toFixed(2);
+		}
+	},
+};
+
+export default class CompetitionPlayer extends Player {
+	constructor(dom, options) {
+		super(
+			{
+				...DEFAULT_DOM_REFS,
+				...dom,
+			},
+			{
+				...DEFAULT_OPTIONS,
+				...options,
 			}
-		},
-	};
+		);
 
-	class CompetitionPlayer extends Player {
-		constructor(dom, options) {
-			super(
-				{
-					...DEFAULT_DOM_REFS,
-					...dom,
-				},
-				{
-					...DEFAULT_OPTIONS,
-					...options,
-				}
-			);
-
-			this.color_memory = new Map();
-		}
-
-		reset() {
-			super.reset();
-
-			this.dom.diff.textContent = this.options.format_score(0);
-			this.dom.t_diff.textContent = this.options.format_tetris_diff(0);
-		}
-
-		getRankColor(rank_ratio) {
-			let col = this.color_memory.get(rank_ratio);
-
-			if (!col) {
-				col = this.options.diff_color_gradient
-					.getColorAt(rank_ratio)
-					.toHexString();
-
-				this.color_memory.set(rank_ratio, col);
-			}
-
-			return col;
-		}
-
-		setDiff(diff, t_diff, rank_ratio = 0) {
-			const absDiff = Math.abs(diff);
-			const color = this.getRankColor(rank_ratio);
-
-			this.dom.diff.style.color = color;
-			this.dom.t_diff.style.color = color;
-
-			this.dom.diff.textContent = this.options.format_score(absDiff);
-			this.dom.t_diff.textContent = this.options.format_tetris_diff(t_diff);
-		}
-
-		setGameRunwayDiff(diff, t_diff, rank_ratio = 0) {
-			const absDiff = Math.abs(diff);
-			const color = this.getRankColor(rank_ratio);
-
-			this.dom.runway_diff.style.color = color;
-			this.dom.runway_t_diff.style.color = color;
-
-			this.dom.runway_diff.textContent = this.options.format_score(absDiff);
-			this.dom.runway_t_diff.textContent =
-				this.options.format_tetris_diff(t_diff);
-		}
-
-		setProjectionDiff(diff, t_diff, rank_ratio = 0) {
-			const absDiff = Math.abs(diff);
-			const color = this.getRankColor(rank_ratio);
-
-			this.dom.projection_diff.style.color = color;
-			this.dom.projection_t_diff.style.color = color;
-
-			this.dom.projection_diff.textContent = this.options.format_score(absDiff);
-			this.dom.projection_t_diff.textContent =
-				this.options.format_tetris_diff(t_diff);
-		}
+		this.color_memory = new Map();
 	}
 
-	return CompetitionPlayer;
-})();
+	reset() {
+		super.reset();
+
+		this.dom.diff.textContent = this.options.format_score(0);
+		this.dom.t_diff.textContent = this.options.format_tetris_diff(0);
+	}
+
+	getRankColor(rank_ratio) {
+		let col = this.color_memory.get(rank_ratio);
+
+		if (!col) {
+			col = this.options.diff_color_gradient
+				.getColorAt(rank_ratio)
+				.toHexString();
+
+			this.color_memory.set(rank_ratio, col);
+		}
+
+		return col;
+	}
+
+	setDiff(diff, t_diff, rank_ratio = 0) {
+		const absDiff = Math.abs(diff);
+		const color = this.getRankColor(rank_ratio);
+
+		this.dom.diff.style.color = color;
+		this.dom.t_diff.style.color = color;
+
+		this.dom.diff.textContent = this.options.format_score(absDiff);
+		this.dom.t_diff.textContent = this.options.format_tetris_diff(t_diff);
+	}
+
+	setGameRunwayDiff(diff, t_diff, rank_ratio = 0) {
+		const absDiff = Math.abs(diff);
+		const color = this.getRankColor(rank_ratio);
+
+		this.dom.runway_diff.style.color = color;
+		this.dom.runway_t_diff.style.color = color;
+
+		this.dom.runway_diff.textContent = this.options.format_score(absDiff);
+		this.dom.runway_t_diff.textContent =
+			this.options.format_tetris_diff(t_diff);
+	}
+
+	setProjectionDiff(diff, t_diff, rank_ratio = 0) {
+		const absDiff = Math.abs(diff);
+		const color = this.getRankColor(rank_ratio);
+
+		this.dom.projection_diff.style.color = color;
+		this.dom.projection_t_diff.style.color = color;
+
+		this.dom.projection_diff.textContent = this.options.format_score(absDiff);
+		this.dom.projection_t_diff.textContent =
+			this.options.format_tetris_diff(t_diff);
+	}
+}

--- a/public/views/DomRefs.js
+++ b/public/views/DomRefs.js
@@ -1,6 +1,8 @@
+import { PIECES } from '/views/constants.js';
+
 // Sort of like a pageObject to have quick references to the things that matter
 
-class DomRefs {
+export default class DomRefs {
 	constructor(doc) {
 		this.stream_bg = {
 			element: doc.querySelector('#stream_bg'),

--- a/public/views/FrameBuffer.js
+++ b/public/views/FrameBuffer.js
@@ -1,65 +1,61 @@
-const FrameBuffer = (function () {
-	function noop() {}
+function noop() {}
 
-	class FrameBuffer {
-		constructor(duration_ms = 0, frame_callback = noop) {
-			this.duration_ms = duration_ms;
-			this.frame_callback = frame_callback;
-			this.buffer = [];
+export default class FrameBuffer {
+	constructor(duration_ms = 0, frame_callback = noop) {
+		this.duration_ms = duration_ms;
+		this.frame_callback = frame_callback;
+		this.buffer = [];
 
-			this.frame_to = null;
+		this.frame_to = null;
 
-			this._sendFrame = this._sendFrame.bind(this);
+		this._sendFrame = this._sendFrame.bind(this);
+	}
+
+	setFrame(frame) {
+		if (this.duration_ms <= 0) {
+			this.frame_callback(frame);
+			return;
 		}
 
-		setFrame(frame) {
-			if (this.duration_ms <= 0) {
-				this.frame_callback(frame);
-				return;
-			}
+		this.buffer.push(frame);
 
-			this.buffer.push(frame);
-
-			if (this.buffer.length == 1) {
-				this._reset();
-			}
-		}
-
-		_reset() {
-			if (this.buffer.length <= 0) return;
-
-			this.client_time_base = 0;
-			this.local_time_base = 0;
-			this.frame_to = setTimeout(this._sendFrame, this.duration_ms);
-		}
-
-		_sendFrame() {
-			if (this.buffer.length <= 0) return;
-
-			const data = this.buffer.shift();
-			const now = Date.now();
-
-			// record client-local time equivalence
-			if (!this.client_time_base) {
-				this.client_time_base = data.ctime;
-				this.local_time_base = now;
-			}
-
-			// send current frame
-			this.frame_callback(data);
-
-			// schedule next frame if needed
-			if (this.buffer.length) {
-				const next_frame_ctime = this.buffer[0].ctime;
-				const elapsed = next_frame_ctime - this.client_time_base;
-
-				this.frame_to = setTimeout(
-					this._sendFrame,
-					this.local_time_base + elapsed - now
-				);
-			}
+		if (this.buffer.length == 1) {
+			this._reset();
 		}
 	}
 
-	return FrameBuffer;
-})();
+	_reset() {
+		if (this.buffer.length <= 0) return;
+
+		this.client_time_base = 0;
+		this.local_time_base = 0;
+		this.frame_to = setTimeout(this._sendFrame, this.duration_ms);
+	}
+
+	_sendFrame() {
+		if (this.buffer.length <= 0) return;
+
+		const data = this.buffer.shift();
+		const now = Date.now();
+
+		// record client-local time equivalence
+		if (!this.client_time_base) {
+			this.client_time_base = data.ctime;
+			this.local_time_base = now;
+		}
+
+		// send current frame
+		this.frame_callback(data);
+
+		// schedule next frame if needed
+		if (this.buffer.length) {
+			const next_frame_ctime = this.buffer[0].ctime;
+			const elapsed = next_frame_ctime - this.client_time_base;
+
+			this.frame_to = setTimeout(
+				this._sendFrame,
+				this.local_time_base + elapsed - now
+			);
+		}
+	}
+}

--- a/public/views/Game.js
+++ b/public/views/Game.js
@@ -2,9 +2,11 @@ import Board from '/views/Board.js';
 import {
 	PIECES,
 	DROUGHT_PANIC_THRESHOLD,
+	SCORE_BASES,
 	DAS_THRESHOLDS,
 	RUNWAY,
 	TRANSITIONS,
+	EFF_LINE_VALUES,
 	getRunway,
 } from '/views/constants.js';
 
@@ -193,7 +195,7 @@ export default class Game {
 			PIECES.forEach(name => (counts[name] = 0));
 
 			for (let offset = 28; offset > 0; offset--) {
-				counts[game.pieces[len - offset].piece]++;
+				counts[this.pieces[len - offset].piece]++;
 			}
 
 			this.data.pieces.deviation_28 = Math.sqrt(
@@ -205,7 +207,7 @@ export default class Game {
 
 			if (this.data.pieces.count >= 56) {
 				for (let offset = 28; offset > 0; offset--) {
-					counts[game.pieces[len - 28 - offset].piece]++;
+					counts[this.pieces[len - 28 - offset].piece]++;
 				}
 
 				this.data.pieces.deviation_56 = Math.sqrt(

--- a/public/views/Game.js
+++ b/public/views/Game.js
@@ -1,4 +1,14 @@
-class Game {
+import Board from '/views/Board.js';
+import {
+	PIECES,
+	DROUGHT_PANIC_THRESHOLD,
+	DAS_THRESHOLDS,
+	RUNWAY,
+	TRANSITIONS,
+	getRunway,
+} from '/views/constants.js';
+
+export default class Game {
 	constructor(event) {
 		this.id = event.gameid;
 		this.over = false;

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -1,909 +1,887 @@
-const Player = (function () {
-	const WINNER_FACE_BLOCKS = [
-		[12, 3],
-		[12, 6],
-		[15, 2],
-		[15, 7],
-		[16, 3],
-		[16, 4],
-		[16, 5],
-		[16, 6],
-	];
+import QueryString from '/js/QueryString.js';
+import BinaryFrame from '/js/BinaryFrame.js';
+import renderBlock from '/views/renderBlock.js';
+import { css_size, clamp } from '/views/utils.js';
 
-	const LOSER_FACE_BLOCKS = [
-		[12, 3],
-		[12, 6],
-		[15, 3],
-		[15, 4],
-		[15, 5],
-		[15, 6],
-		[16, 2],
-		[16, 7],
-	];
+import {
+	DOM_DEV_NULL,
+	PIECES,
+	LINES,
+	RUNWAY,
+	getRunway,
+} from '/views/constants.js';
 
-	const BORDER_BLOCKS = [
-		[0, 0],
-		[1, 0],
-		[2, 0],
-		[3, 0],
-		[4, 0],
-		[5, 0],
-		[6, 0],
-		[7, 0],
-		[8, 0],
-		[9, 0],
-		[10, 0],
-		[11, 0],
-		[12, 0],
-		[13, 0],
-		[14, 0],
-		[15, 0],
-		[16, 0],
-		[17, 0],
-		[18, 0],
-		[19, 0],
+const WINNER_FACE_BLOCKS = [
+	[12, 3],
+	[12, 6],
+	[15, 2],
+	[15, 7],
+	[16, 3],
+	[16, 4],
+	[16, 5],
+	[16, 6],
+];
 
-		[19, 1],
-		[19, 2],
-		[19, 3],
-		[19, 4],
-		[19, 5],
-		[19, 6],
-		[19, 7],
-		[19, 8],
-		[19, 9],
+const LOSER_FACE_BLOCKS = [
+	[12, 3],
+	[12, 6],
+	[15, 3],
+	[15, 4],
+	[15, 5],
+	[15, 6],
+	[16, 2],
+	[16, 7],
+];
 
-		[18, 9],
-		[17, 9],
-		[16, 9],
-		[15, 9],
-		[14, 9],
-		[13, 9],
-		[12, 9],
-		[11, 9],
-		[10, 9],
-		[9, 9],
-		[8, 9],
-		[7, 9],
-		[6, 9],
-		[5, 9],
-		[4, 9],
-		[3, 9],
-		[2, 9],
-		[1, 9],
-		[0, 9],
+const BORDER_BLOCKS = [
+	[0, 0],
+	[1, 0],
+	[2, 0],
+	[3, 0],
+	[4, 0],
+	[5, 0],
+	[6, 0],
+	[7, 0],
+	[8, 0],
+	[9, 0],
+	[10, 0],
+	[11, 0],
+	[12, 0],
+	[13, 0],
+	[14, 0],
+	[15, 0],
+	[16, 0],
+	[17, 0],
+	[18, 0],
+	[19, 0],
 
-		[0, 8],
-		[0, 7],
-		[0, 6],
-		[0, 5],
-		[0, 4],
-		[0, 3],
-		[0, 2],
-		[0, 1],
-	];
+	[19, 1],
+	[19, 2],
+	[19, 3],
+	[19, 4],
+	[19, 5],
+	[19, 6],
+	[19, 7],
+	[19, 8],
+	[19, 9],
 
-	/*
-	dom: {
-		score:   text element
-		level:   text element
-		lines:   text element
-		trt:     text element
-		preview: div for canva
-		field:   div for canva
-	}
+	[18, 9],
+	[17, 9],
+	[16, 9],
+	[15, 9],
+	[14, 9],
+	[13, 9],
+	[12, 9],
+	[11, 9],
+	[10, 9],
+	[9, 9],
+	[8, 9],
+	[7, 9],
+	[6, 9],
+	[5, 9],
+	[4, 9],
+	[3, 9],
+	[2, 9],
+	[1, 9],
+	[0, 9],
 
-	options: {
-		preview_pixel_size: int,
-		field_pixel_size: int,
-		running_trt_rtl: bool,
-		wins_rtl: bool,
-	}
+	[0, 8],
+	[0, 7],
+	[0, 6],
+	[0, 5],
+	[0, 4],
+	[0, 3],
+	[0, 2],
+	[0, 1],
+];
+
+/*
+dom: {
+	score:   text element
+	level:   text element
+	lines:   text element
+	trt:     text element
+	preview: div for canva
+	field:   div for canva
+}
+
+options: {
+	preview_pixel_size: int,
+	field_pixel_size: int,
+	running_trt_rtl: bool,
+	wins_rtl: bool,
+}
 */
 
-	function easeOutQuart(t, b, c, d) {
-		return -c * ((t = t / d - 1) * t * t * t - 1) + b;
-	}
+function easeOutQuart(t, b, c, d) {
+	return -c * ((t = t / d - 1) * t * t * t - 1) + b;
+}
 
-	// One time check of Query String args
-	// Bit dirty to have Player.js access query String
-	// But that's the most covenient way to share the functionality
-	let buffer_time = QueryString.get('buffer_time') || '';
+// One time check of Query String args
+// Bit dirty to have Player.js access query String
+// But that's the most covenient way to share the functionality
+let buffer_time = QueryString.get('buffer_time') || '';
 
-	if (/^\d+$/.test(buffer_time)) {
-		buffer_time = parseInt(buffer_time, 10);
-	} else {
-		buffer_time = 0;
-	}
+if (/^\d+$/.test(buffer_time)) {
+	buffer_time = parseInt(buffer_time, 10);
+} else {
+	buffer_time = 0;
+}
 
-	const DEFAULT_DOM_REFS = {
-		score: DOM_DEV_NULL,
-		runway_tr: DOM_DEV_NULL,
-		runway_game: DOM_DEV_NULL,
-		projection: DOM_DEV_NULL,
-		level: DOM_DEV_NULL,
-		lines: DOM_DEV_NULL,
-		trt: DOM_DEV_NULL,
-		eff: DOM_DEV_NULL,
-		running_trt: DOM_DEV_NULL,
-		preview: document.createElement('div'),
-		field: document.createElement('div'),
-		drought: DOM_DEV_NULL,
-		burn: DOM_DEV_NULL,
-		video: DOM_DEV_NULL,
-		curtain: null,
-	};
+const DEFAULT_DOM_REFS = {
+	score: DOM_DEV_NULL,
+	runway_tr: DOM_DEV_NULL,
+	runway_game: DOM_DEV_NULL,
+	projection: DOM_DEV_NULL,
+	level: DOM_DEV_NULL,
+	lines: DOM_DEV_NULL,
+	trt: DOM_DEV_NULL,
+	eff: DOM_DEV_NULL,
+	running_trt: DOM_DEV_NULL,
+	preview: document.createElement('div'),
+	field: document.createElement('div'),
+	drought: DOM_DEV_NULL,
+	burn: DOM_DEV_NULL,
+	video: DOM_DEV_NULL,
+	curtain: null,
+};
 
-	const DEFAULT_OPTIONS = {
-		field_real_border: 0, // represents the actual border
-		field_pixel_size: 3,
-		preview_pixel_size: 3,
-		preview_align: 'c',
-		running_trt_rtl: 0,
-		wins_rtl: 0,
-		tetris_flash: 1,
-		tetris_sound: 1,
-		stereo: 0, // [-1, 1] representing left:-1 to right:1
-		reliable_field: 1,
-		draw_field: 1,
-		curtain: 1,
-		buffer_time,
-		format_score: (v, size) => {
-			if (!size) {
-				size = 7;
-			}
+const DEFAULT_OPTIONS = {
+	field_real_border: 0, // represents the actual border
+	field_pixel_size: 3,
+	preview_pixel_size: 3,
+	preview_align: 'c',
+	running_trt_rtl: 0,
+	wins_rtl: 0,
+	tetris_flash: 1,
+	tetris_sound: 1,
+	stereo: 0, // [-1, 1] representing left:-1 to right:1
+	reliable_field: 1,
+	draw_field: 1,
+	curtain: 1,
+	buffer_time,
+	format_score: (v, size) => {
+		if (!size) {
+			size = 7;
+		}
 
-			if (size == 6 && v >= 1000000) {
-				const tail = `${v % 100000}`.padStart(5, '0');
-				const head = Math.floor(v / 100000);
-				v = `${head.toString(16).toUpperCase()}${tail}`;
-			} else {
-				v = `${v}`;
-			}
+		if (size == 6 && v >= 1000000) {
+			const tail = `${v % 100000}`.padStart(5, '0');
+			const head = Math.floor(v / 100000);
+			v = `${head.toString(16).toUpperCase()}${tail}`;
+		} else {
+			v = `${v}`;
+		}
 
-			return v.padStart(size, ' ');
-		},
-		format_drought: v => v,
-	};
+		return v.padStart(size, ' ');
+	},
+	format_drought: v => v,
+};
 
-	class Player {
-		constructor(dom, options) {
-			this.dom = {
-				...DEFAULT_DOM_REFS,
-				...dom,
-			};
-			this.options = {
-				...DEFAULT_OPTIONS,
-				...options,
-			};
+export default class Player {
+	constructor(dom, options) {
+		this.dom = {
+			...DEFAULT_DOM_REFS,
+			...dom,
+		};
+		this.options = {
+			...DEFAULT_OPTIONS,
+			...options,
+		};
 
-			this.field_pixel_size =
-				this.options.field_pixel_size || this.options.pixel_size;
-			this.preview_pixel_size =
-				this.options.preview_pixel_size || this.options.pixel_size;
-			this.render_running_trt_rtl = !!this.options.running_trt_rtl;
-			this.render_wins_rtl = !!this.options.wins_rtl;
+		this.field_pixel_size =
+			this.options.field_pixel_size || this.options.pixel_size;
+		this.preview_pixel_size =
+			this.options.preview_pixel_size || this.options.pixel_size;
+		this.render_running_trt_rtl = !!this.options.running_trt_rtl;
+		this.render_wins_rtl = !!this.options.wins_rtl;
 
-			this.pieces = [];
-			this.clear_events = [];
+		this.pieces = [];
+		this.clear_events = [];
 
-			const styles = getComputedStyle(this.dom.field);
+		const styles = getComputedStyle(this.dom.field);
 
-			// getComputedStyle returns padding in Chrome,
-			// but Firefox returns 4 individual properties paddingTop, paddingLeft, etc...
+		// getComputedStyle returns padding in Chrome,
+		// but Firefox returns 4 individual properties paddingTop, paddingLeft, etc...
 
-			const field_padding = css_size(styles.paddingLeft); // we assume padding is the same on all sides
+		const field_padding = css_size(styles.paddingLeft); // we assume padding is the same on all sides
 
-			let bg_width, bg_height, bg_offset, field_canva_offset;
+		let bg_width, bg_height, bg_offset, field_canva_offset;
 
-			if (this.options.field_real_border) {
-				bg_width =
-					css_size(styles.width) +
-					2 * (field_padding - this.options.field_real_border);
-				bg_height =
-					css_size(styles.height) +
-					2 * (field_padding - this.options.field_real_border);
-				bg_offset = this.options.field_real_border;
-				field_canva_offset = field_padding - this.options.field_real_border;
-			} else {
-				// we assume the border include one NES pixel of all sides
-				bg_width = css_size(styles.width) + this.field_pixel_size * 2;
-				bg_height = css_size(styles.height) + this.field_pixel_size * 2;
-				bg_offset = field_padding - this.field_pixel_size;
-				field_canva_offset = this.field_pixel_size;
-			}
+		if (this.options.field_real_border) {
+			bg_width =
+				css_size(styles.width) +
+				2 * (field_padding - this.options.field_real_border);
+			bg_height =
+				css_size(styles.height) +
+				2 * (field_padding - this.options.field_real_border);
+			bg_offset = this.options.field_real_border;
+			field_canva_offset = field_padding - this.options.field_real_border;
+		} else {
+			// we assume the border include one NES pixel of all sides
+			bg_width = css_size(styles.width) + this.field_pixel_size * 2;
+			bg_height = css_size(styles.height) + this.field_pixel_size * 2;
+			bg_offset = field_padding - this.field_pixel_size;
+			field_canva_offset = this.field_pixel_size;
+		}
 
-			this.bg_height = bg_height; // store value for curtain animation
+		this.bg_height = bg_height; // store value for curtain animation
 
-			// Avatar Block
-			this.avatar = document.createElement('div');
-			this.avatar.classList.add('avatar');
-			Object.assign(this.avatar.style, {
-				position: 'absolute',
-				top: `${field_padding + this.field_pixel_size * 8}px`,
-				left: `${bg_offset}px`,
-				width: `${bg_width}px`,
-				height: `${bg_width}px`,
-				backgroundRepeat: 'no-repeat',
-				backgroundSize: 'cover',
-				backgroundPosition: '50% 50%',
-				filter: 'brightness(0.20)',
-			});
-			this.dom.field.appendChild(this.avatar);
+		// Avatar Block
+		this.avatar = document.createElement('div');
+		this.avatar.classList.add('avatar');
+		Object.assign(this.avatar.style, {
+			position: 'absolute',
+			top: `${field_padding + this.field_pixel_size * 8}px`,
+			left: `${bg_offset}px`,
+			width: `${bg_width}px`,
+			height: `${bg_width}px`,
+			backgroundRepeat: 'no-repeat',
+			backgroundSize: 'cover',
+			backgroundPosition: '50% 50%',
+			filter: 'brightness(0.20)',
+		});
+		this.dom.field.appendChild(this.avatar);
 
-			// Field Flash
-			this.field_bg = document.createElement('div');
-			this.field_bg.classList.add('background');
-			Object.assign(this.field_bg.style, {
-				position: 'absolute',
-				top: `${bg_offset}px`,
-				left: `${bg_offset}px`,
-				width: `${bg_width}px`,
-				height: `${bg_height}px`,
-			});
-			this.dom.field.appendChild(this.field_bg);
+		// Field Flash
+		this.field_bg = document.createElement('div');
+		this.field_bg.classList.add('background');
+		Object.assign(this.field_bg.style, {
+			position: 'absolute',
+			top: `${bg_offset}px`,
+			left: `${bg_offset}px`,
+			width: `${bg_width}px`,
+			height: `${bg_height}px`,
+		});
+		this.dom.field.appendChild(this.field_bg);
 
-			// set up field and preview canvas
-			['field', 'preview', 'running_trt'].forEach(name => {
-				console.log(name);
+		// set up field and preview canvas
+		['field', 'preview', 'running_trt'].forEach(name => {
+			console.log(name);
 
-				const styles = getComputedStyle(this.dom[name]);
-				const canvas = document.createElement('canvas');
+			const styles = getComputedStyle(this.dom[name]);
+			const canvas = document.createElement('canvas');
 
-				canvas.style.position = 'absolute';
-				canvas.style.top = styles.paddingTop;
-				canvas.style.left = styles.paddingLeft;
+			canvas.style.position = 'absolute';
+			canvas.style.top = styles.paddingTop;
+			canvas.style.left = styles.paddingLeft;
 
-				canvas.setAttribute('width', css_size(styles.width));
-				canvas.setAttribute('height', css_size(styles.height));
+			canvas.setAttribute('width', css_size(styles.width));
+			canvas.setAttribute('height', css_size(styles.height));
 
-				this.dom[name].appendChild(canvas);
+			this.dom[name].appendChild(canvas);
 
-				this[`${name}_ctx`] = canvas.getContext('2d');
-			});
+			this[`${name}_ctx`] = canvas.getContext('2d');
+		});
 
-			this.has_curtain = this.options.curtain || this.dom.curtain;
+		this.has_curtain = this.options.curtain || this.dom.curtain;
 
-			if (this.has_curtain) {
-				// start - Field curtain
-				this.curtain_viewport = document.createElement('div');
-				this.curtain_viewport.classList.add('curtain_viewport');
-				Object.assign(this.curtain_viewport.style, {
-					position: 'absolute',
-					top: `${bg_offset}px`,
-					left: `${bg_offset}px`,
-					width: `${bg_width}px`,
-					height: `${bg_height}px`,
-					overflow: 'hidden',
-				});
-				this.dom.field.appendChild(this.curtain_viewport);
-
-				this.curtain_container = document.createElement('div');
-				this.curtain_container.classList.add('curtain_container');
-				Object.assign(this.curtain_container.style, {
-					position: 'absolute',
-					top: `-${bg_height}px`,
-					left: 0,
-					width: `${bg_width}px`,
-					height: `${bg_height}px`,
-					background: 'rgba(0, 0, 0, 0.9)',
-					overflow: 'hidden',
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-				});
-				this.curtain_viewport.appendChild(this.curtain_container);
-
-				if (this.dom.curtain) {
-					this.curtain_container.appendChild(this.dom.curtain);
-				} else {
-					const img = document.createElement('img');
-
-					img.src = '/brand/logo.v3.white.2x.png';
-
-					this.curtain_container.appendChild(img);
-				}
-
-				this._hideCurtain();
-			}
-
-			this.profile_card = document.createElement('iframe');
-			Object.assign(this.profile_card.style, {
+		if (this.has_curtain) {
+			// start - Field curtain
+			this.curtain_viewport = document.createElement('div');
+			this.curtain_viewport.classList.add('curtain_viewport');
+			Object.assign(this.curtain_viewport.style, {
 				position: 'absolute',
 				top: `${bg_offset}px`,
 				left: `${bg_offset}px`,
 				width: `${bg_width}px`,
 				height: `${bg_height}px`,
-				border: 0,
-				margin: 0,
-				padding: 0,
 				overflow: 'hidden',
 			});
-			this.profile_card.hidden = true;
-			this.dom.field.appendChild(this.profile_card);
+			this.dom.field.appendChild(this.curtain_viewport);
 
-			this.field_ctx.canvas.style.top = `${field_canva_offset}px`;
-			this.field_ctx.canvas.style.left = `${field_canva_offset}px`;
-			this.field_bg.appendChild(this.field_ctx.canvas);
-
-			if (this.render_running_trt_rtl) {
-				this.running_trt_ctx.canvas.style.transform = 'scale(-1, 1)';
-			}
-
-			// buils audio objects
-			this.audioContext = new AudioContext();
-			this.sounds = {
-				tetris: new Audio('/views/Tetris_Clear.mp3'),
-			};
-
-			this.options.stereo = clamp(this.options.stereo, -1, 1);
-
-			Object.entries(this.sounds).forEach(([sound, audio]) => {
-				const track = this.audioContext.createMediaElementSource(audio);
-				const stereoNode = new StereoPannerNode(this.audioContext, {
-					pan: this.options.stereo,
-				});
-
-				track.connect(stereoNode).connect(this.audioContext.destination);
-
-				this.sounds[sound] = () => {
-					if (this.audioContext.state === 'suspended') {
-						this.audioContext.resume();
-					}
-
-					audio.play();
-				};
+			this.curtain_container = document.createElement('div');
+			this.curtain_container.classList.add('curtain_container');
+			Object.assign(this.curtain_container.style, {
+				position: 'absolute',
+				top: `-${bg_height}px`,
+				left: 0,
+				width: `${bg_width}px`,
+				height: `${bg_height}px`,
+				background: 'rgba(0, 0, 0, 0.9)',
+				overflow: 'hidden',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
 			});
+			this.curtain_viewport.appendChild(this.curtain_container);
 
-			this.renderWinnerFrame = this.renderWinnerFrame.bind(this);
-			this._setFrameOuter = this._setFrameOuter.bind(this);
+			if (this.dom.curtain) {
+				this.curtain_container.appendChild(this.dom.curtain);
+			} else {
+				const img = document.createElement('img');
 
-			this.reset();
+				img.src = '/brand/logo.v3.white.2x.png';
 
-			this.game_over = true; // we start at game over, waiting for the first good frame
-			this.curtain_down = true;
-		}
-
-		onScore() {}
-		onPiece() {}
-		onLines() {}
-		onLevel() {}
-		onTransition() {}
-		onKillScreen() {}
-		onDroughtStart() {}
-		onDroughtEnd() {}
-		onGameStart() {}
-		onGameOver() {}
-		onCurtainDown() {}
-		onTetris() {}
-
-		showProfileCard(visible) {
-			this.profile_card.hidden = !visible;
-		}
-
-		_showCurtain() {
-			if (!this.has_curtain) return;
+				this.curtain_container.appendChild(img);
+			}
 
 			this._hideCurtain();
-			this.curtain_viewport.hidden = false;
+		}
 
-			const start_ts = Date.now();
-			const duration = 1000;
+		this.profile_card = document.createElement('iframe');
+		Object.assign(this.profile_card.style, {
+			position: 'absolute',
+			top: `${bg_offset}px`,
+			left: `${bg_offset}px`,
+			width: `${bg_width}px`,
+			height: `${bg_height}px`,
+			border: 0,
+			margin: 0,
+			padding: 0,
+			overflow: 'hidden',
+		});
+		this.profile_card.hidden = true;
+		this.dom.field.appendChild(this.profile_card);
+
+		this.field_ctx.canvas.style.top = `${field_canva_offset}px`;
+		this.field_ctx.canvas.style.left = `${field_canva_offset}px`;
+		this.field_bg.appendChild(this.field_ctx.canvas);
+
+		if (this.render_running_trt_rtl) {
+			this.running_trt_ctx.canvas.style.transform = 'scale(-1, 1)';
+		}
+
+		// buils audio objects
+		this.audioContext = new AudioContext();
+		this.sounds = {
+			tetris: new Audio('/views/Tetris_Clear.mp3'),
+		};
+
+		this.options.stereo = clamp(this.options.stereo, -1, 1);
+
+		Object.entries(this.sounds).forEach(([sound, audio]) => {
+			const track = this.audioContext.createMediaElementSource(audio);
+			const stereoNode = new StereoPannerNode(this.audioContext, {
+				pan: this.options.stereo,
+			});
+
+			track.connect(stereoNode).connect(this.audioContext.destination);
+
+			this.sounds[sound] = () => {
+				if (this.audioContext.state === 'suspended') {
+					this.audioContext.resume();
+				}
+
+				audio.play();
+			};
+		});
+
+		this.renderWinnerFrame = this.renderWinnerFrame.bind(this);
+		this._setFrameOuter = this._setFrameOuter.bind(this);
+
+		this.reset();
+
+		this.game_over = true; // we start at game over, waiting for the first good frame
+		this.curtain_down = true;
+	}
+
+	onScore() {}
+	onPiece() {}
+	onLines() {}
+	onLevel() {}
+	onTransition() {}
+	onKillScreen() {}
+	onDroughtStart() {}
+	onDroughtEnd() {}
+	onGameStart() {}
+	onGameOver() {}
+	onCurtainDown() {}
+	onTetris() {}
+
+	showProfileCard(visible) {
+		this.profile_card.hidden = !visible;
+	}
+
+	_showCurtain() {
+		if (!this.has_curtain) return;
+
+		this._hideCurtain();
+		this.curtain_viewport.hidden = false;
+
+		const start_ts = Date.now();
+		const duration = 1000;
+
+		const steps = () => {
+			const elapsed = Math.min(Date.now() - start_ts, duration);
+
+			const top = easeOutQuart(
+				elapsed,
+				-this.bg_height,
+				this.bg_height,
+				duration
+			);
+
+			this.curtain_container.style.top = `${top}px`;
+
+			if (elapsed < duration) {
+				this.curtain_animation_ID = window.requestAnimationFrame(steps);
+			} else {
+				this.curtain_down = true;
+				this.onCurtainDown();
+			}
+		};
+
+		this.curtain_animation_ID = window.requestAnimationFrame(steps);
+	}
+
+	_hideCurtain() {
+		if (!this.has_curtain) return;
+
+		window.cancelAnimationFrame(this.curtain_animation_ID);
+
+		this.curtain_viewport.hidden = true;
+		this.curtain_container.style.top = `-${this.bg_height}px`;
+	}
+
+	_doTetris() {
+		if (this.options.tetris_flash) {
+			const start = Date.now();
 
 			const steps = () => {
-				const elapsed = Math.min(Date.now() - start_ts, duration);
+				const elapsed = (Date.now() - start) / 1000;
+				const flashing = elapsed % (5 / 60) < 2 / 60; // flash for 2 "frame" every 5 "frames"
+				let bg_color = flashing ? 'white' : 'rgba(0,0,0,0)';
 
-				const top = easeOutQuart(
-					elapsed,
-					-this.bg_height,
-					this.bg_height,
-					duration
+				if (elapsed < 25 / 60) {
+					this.tetris_animation_ID = window.requestAnimationFrame(steps);
+				} else {
+					// make sure we don't end on white
+					bg_color = 'rgba(0,0,0,0)';
+				}
+
+				this.field_bg.style.background = bg_color;
+			};
+
+			this.tetris_animation_ID = window.requestAnimationFrame(steps);
+		}
+
+		if (this.options.tetris_sound) {
+			this.sounds.tetris();
+		}
+
+		this.onTetris();
+	}
+
+	clearTetrisAnimation() {
+		window.cancelAnimationFrame(this.tetris_animation_ID);
+		this.clear_animation_remaining_frames = -1;
+	}
+
+	reset() {
+		this.pending_piece = false;
+		this.pending_single = false;
+
+		// TODO use the Game Class T_T
+
+		this.pieces.length = 0;
+		this.clear_events.length = 0;
+		this.preview = '';
+		this.prev_preview = 'I';
+		this.score = 0;
+		this.lines = 0;
+		this.start_level = 0;
+		this.level = 0;
+		this.transition = null;
+		this.game_runway_score = this.getGameRunwayScore();
+		this.tr_runway_score = this.getTransitionRunwayScore();
+		this.drought = 0;
+		this.field_num_blocks = 0;
+		this.field_string = '';
+		this.burn = 0;
+
+		this.piece_stats = {
+			frame: PIECES.reduce((acc, p) => ((acc[p] = 0), acc), { count: 0 }),
+			board: PIECES.reduce((acc, p) => ((acc[p] = 0), acc), { count: 0 }),
+		};
+
+		this.lines_trt = 0;
+		this.total_eff = 0;
+		this.projection = 0;
+
+		this.gameid = -1;
+		this.game_over = false;
+		this.curtain_down = false;
+		this.winner_frame = 0;
+
+		this.preview_ctx.clear();
+		this.field_ctx.clear();
+		this.running_trt_ctx.clear();
+
+		this.clearTetrisAnimation();
+		this.clearWinnerAnimation();
+		this.field_bg.style.background = 'rbga(0,0,0,0)';
+
+		this.dom.score.textContent = this.options.format_score(this.score);
+		this.dom.runway_tr.textContent = this.options.format_score(
+			this.tr_runway_score,
+			6
+		);
+		this.dom.runway_game.textContent = this.options.format_score(
+			this.game_runway_score,
+			7
+		);
+		this.dom.projection.textContent = this.options.format_score(
+			this.projection,
+			7
+		);
+		this.dom.trt.textContent = '-';
+		this.dom.eff.textContent = '-';
+		this.dom.burn.textContent = 0;
+	}
+
+	getScore() {
+		return this.score;
+	}
+
+	setDiff(diff, t_diff) {
+		// implement in subclasses
+	}
+
+	setGameRunwayDiff(diff, t_diff) {
+		// implement in subclasses
+	}
+
+	setProjectionDiff(diff, t_diff) {
+		// implement in subclasses
+	}
+
+	setAvatar(url) {
+		this.avatar_url = url;
+		this.avatar.style.backgroundImage = `url('${encodeURI(url)}')`;
+	}
+
+	setName(name) {
+		this.player_name = name;
+
+		if (name) {
+			this.dom.name.textContent = name;
+		} else {
+			this.dom.name.innerHTML = '&nbsp;';
+		}
+	}
+
+	setId(id) {
+		this.id = id;
+	}
+
+	setPeerId(peerid) {
+		this.peerid = peerid;
+
+		if (!peerid) {
+			this.dom.video.srcObject = null;
+		}
+	}
+
+	setLogin(login) {
+		if (login === this.login) return;
+
+		this.login = login;
+		this.profile_card.src = `/view/profile_card/${login}`;
+	}
+
+	_getPieceStats(data) {
+		return PIECES.reduce(
+			(acc, piece) => {
+				const num = data[piece];
+
+				acc[piece] = num === null ? this.piece_stats.frame[piece] : num;
+				acc.count += acc[piece];
+
+				return acc;
+			},
+			{ count: 0 }
+		);
+	}
+
+	_isTopRowFull(data) {
+		for (let cell_idx = 10; cell_idx--; ) {
+			if (!data.field[cell_idx]) return false;
+		}
+		return true;
+	}
+
+	setFrame(data) {
+		if (this.options.buffer_time) {
+			if (!this.frame_buffer) {
+				this.frame_buffer = new FrameBuffer(
+					this.options.buffer_time,
+					this._setFrameOuter
+				);
+			}
+			this.frame_buffer.setFrame(data);
+		} else {
+			this._setFrameOuter(data);
+		}
+	}
+
+	_setFrameOuter(data) {
+		const old_score = this.getScore();
+		const old_runway = this.getGameRunwayScore();
+
+		this._setFrameInner(data);
+
+		const new_score = this.getScore();
+		const new_runway = this.getGameRunwayScore();
+
+		if (new_score === old_score && new_runway === old_runway) return;
+
+		this.onScore();
+	}
+
+	_doGameOver() {
+		if (this.game_over) return;
+
+		this.game_over = true;
+		this._showCurtain();
+		this.onGameOver();
+	}
+
+	_setFrameInner(data) {
+		if (this.game_over && this.curtain_down && data.gameid == this.gameid) {
+			return;
+		}
+
+		const lines = data.lines;
+		const level = data.level;
+		const num_blocks = data.field.reduce((acc, v) => acc + (v ? 1 : 0), 0);
+		const field_string = data.field.join('');
+
+		// DO NOT DELETE... Is used by Stencil layout -_-
+		this.last_frame = data;
+
+		if (data.gameid != this.gameid) {
+			this._doGameOver();
+			// new game!
+			this.reset();
+
+			// we initialize the game state based on this first frame
+			// dangerous for field data if input is badly detected, but what to do -_-
+
+			this.gameid = data.gameid;
+			this.field_num_blocks = num_blocks;
+			this.start_level = level;
+			this.level = level;
+			this.lines = lines;
+			this.score = data.score;
+			this.pending_score = true;
+			this.prev_preview = data.cur_piece || data.preview || 'I';
+
+			this._hideCurtain();
+			this.onGameStart();
+		}
+
+		if (data.lines != null) {
+			this.dom.lines.textContent = `${data.lines}`.padStart(3, '0');
+		}
+
+		if (data.level != null) {
+			this.dom.level.textContent = `${data.level}`.padStart(2, '0');
+		}
+
+		let allow_field_piece_spawn_detection = false;
+
+		if (this.pending_piece) {
+			this.pending_piece = false;
+
+			let cur_piece = data.cur_piece || this.prev_preview;
+			let has_change = true;
+			let drought_change;
+
+			this.piece_stats.board[cur_piece]++;
+			this.piece_stats.board.count++;
+
+			if (cur_piece === 'I') {
+				drought_change = -this.drought;
+			} else {
+				drought_change = 1;
+			}
+
+			// for classic rom, we get piece data from piece stats
+			// TODO: Add more resilience here (wait for good data)
+			if (data.game_type === BinaryFrame.GAME_TYPE.CLASSIC) {
+				const piece_stats = this._getPieceStats(data);
+				const diff = piece_stats.count - this.piece_stats.frame.count;
+				const sane_state = PIECES.every(
+					piece => piece_stats[piece] >= this.piece_stats.frame[piece]
 				);
 
-				this.curtain_container.style.top = `${top}px`;
+				has_change = sane_state && diff;
 
-				if (elapsed < duration) {
-					this.curtain_animation_ID = window.requestAnimationFrame(steps);
+				if (!has_change) {
+					// frame stats are not good, we should wait a bit more for valid data to come?
+					// revert the changes
+					this.pending_piece = true;
+					this.piece_stats.board[cur_piece]--;
+					this.piece_stats.board.count--;
 				} else {
-					this.curtain_down = true;
-					this.onCurtainDown();
-				}
-			};
+					const i_diff = piece_stats.I - this.piece_stats.frame.I;
 
-			this.curtain_animation_ID = window.requestAnimationFrame(steps);
-		}
-
-		_hideCurtain() {
-			if (!this.has_curtain) return;
-
-			window.cancelAnimationFrame(this.curtain_animation_ID);
-
-			this.curtain_viewport.hidden = true;
-			this.curtain_container.style.top = `-${this.bg_height}px`;
-		}
-
-		_doTetris() {
-			if (this.options.tetris_flash) {
-				const start = Date.now();
-
-				const steps = () => {
-					const elapsed = (Date.now() - start) / 1000;
-					const flashing = elapsed % (5 / 60) < 2 / 60; // flash for 2 "frame" every 5 "frames"
-					let bg_color = flashing ? 'white' : 'rgba(0,0,0,0)';
-
-					if (elapsed < 25 / 60) {
-						this.tetris_animation_ID = window.requestAnimationFrame(steps);
+					if (i_diff === 0) {
+						drought_change = diff; // expected to be +1 in most cases
+						cur_piece = PIECES.find(
+							piece => piece_stats[piece] != this.piece_stats.frame[piece]
+						);
 					} else {
-						// make sure we don't end on white
-						bg_color = 'rgba(0,0,0,0)';
+						drought_change = -this.drought;
+						cur_piece = 'I';
 					}
 
-					this.field_bg.style.background = bg_color;
-				};
-
-				this.tetris_animation_ID = window.requestAnimationFrame(steps);
-			}
-
-			if (this.options.tetris_sound) {
-				this.sounds.tetris();
-			}
-
-			this.onTetris();
-		}
-
-		clearTetrisAnimation() {
-			window.cancelAnimationFrame(this.tetris_animation_ID);
-			this.clear_animation_remaining_frames = -1;
-		}
-
-		reset() {
-			this.pending_piece = false;
-			this.pending_single = false;
-
-			// TODO use the Game Class T_T
-
-			this.pieces.length = 0;
-			this.clear_events.length = 0;
-			this.preview = '';
-			this.prev_preview = 'I';
-			this.score = 0;
-			this.lines = 0;
-			this.start_level = 0;
-			this.level = 0;
-			this.transition = null;
-			this.game_runway_score = this.getGameRunwayScore();
-			this.tr_runway_score = this.getTransitionRunwayScore();
-			this.drought = 0;
-			this.field_num_blocks = 0;
-			this.field_string = '';
-			this.burn = 0;
-
-			this.piece_stats = {
-				frame: PIECES.reduce((acc, p) => ((acc[p] = 0), acc), { count: 0 }),
-				board: PIECES.reduce((acc, p) => ((acc[p] = 0), acc), { count: 0 }),
-			};
-
-			this.lines_trt = 0;
-			this.total_eff = 0;
-			this.projection = 0;
-
-			this.gameid = -1;
-			this.game_over = false;
-			this.curtain_down = false;
-			this.winner_frame = 0;
-
-			this.preview_ctx.clear();
-			this.field_ctx.clear();
-			this.running_trt_ctx.clear();
-
-			this.clearTetrisAnimation();
-			this.clearWinnerAnimation();
-			this.field_bg.style.background = 'rbga(0,0,0,0)';
-
-			this.dom.score.textContent = this.options.format_score(this.score);
-			this.dom.runway_tr.textContent = this.options.format_score(
-				this.tr_runway_score,
-				6
-			);
-			this.dom.runway_game.textContent = this.options.format_score(
-				this.game_runway_score,
-				7
-			);
-			this.dom.projection.textContent = this.options.format_score(
-				this.projection,
-				7
-			);
-			this.dom.trt.textContent = '-';
-			this.dom.eff.textContent = '-';
-			this.dom.burn.textContent = 0;
-		}
-
-		getScore() {
-			return this.score;
-		}
-
-		setDiff(diff, t_diff) {
-			// implement in subclasses
-		}
-
-		setGameRunwayDiff(diff, t_diff) {
-			// implement in subclasses
-		}
-
-		setProjectionDiff(diff, t_diff) {
-			// implement in subclasses
-		}
-
-		setAvatar(url) {
-			this.avatar_url = url;
-			this.avatar.style.backgroundImage = `url('${encodeURI(url)}')`;
-		}
-
-		setName(name) {
-			this.player_name = name;
-
-			if (name) {
-				this.dom.name.textContent = name;
-			} else {
-				this.dom.name.innerHTML = '&nbsp;';
-			}
-		}
-
-		setId(id) {
-			this.id = id;
-		}
-
-		setPeerId(peerid) {
-			this.peerid = peerid;
-
-			if (!peerid) {
-				this.dom.video.srcObject = null;
-			}
-		}
-
-		setLogin(login) {
-			if (login === this.login) return;
-
-			this.login = login;
-			this.profile_card.src = `/view/profile_card/${login}`;
-		}
-
-		_getPieceStats(data) {
-			return PIECES.reduce(
-				(acc, piece) => {
-					const num = data[piece];
-
-					acc[piece] = num === null ? this.piece_stats.frame[piece] : num;
-					acc.count += acc[piece];
-
-					return acc;
-				},
-				{ count: 0 }
-			);
-		}
-
-		_isTopRowFull(data) {
-			for (let cell_idx = 10; cell_idx--; ) {
-				if (!data.field[cell_idx]) return false;
-			}
-			return true;
-		}
-
-		setFrame(data) {
-			if (this.options.buffer_time) {
-				if (!this.frame_buffer) {
-					this.frame_buffer = new FrameBuffer(
-						this.options.buffer_time,
-						this._setFrameOuter
-					);
+					Object.assign(this.piece_stats.frame, piece_stats);
 				}
-				this.frame_buffer.setFrame(data);
+			}
+
+			if (has_change) {
+				const drought = this.drought + drought_change;
+
+				if (drought === 0) {
+					if (this.drought >= 13) {
+						this.onDroughtEnd(this.drought);
+					}
+				} else if (drought === 13) {
+					if (this.drought < 13) {
+						this.onDroughtStart();
+					}
+				}
+
+				this.drought = drought;
+				this.dom.drought.textContent = this.options.format_drought(
+					this.drought
+				);
+				this.prev_preview = data.preview;
+
+				this.pieces.push(cur_piece);
+				this.onPiece(cur_piece);
+			}
+		} else {
+			if (data.game_type === BinaryFrame.GAME_TYPE.CLASSIC) {
+				this.pending_piece = PIECES.some(
+					piece => this.piece_stats.frame[piece] != data[piece]
+				);
 			} else {
-				this._setFrameOuter(data);
+				allow_field_piece_spawn_detection = true;
 			}
 		}
 
-		_setFrameOuter(data) {
-			const old_score = this.getScore();
-			const old_runway = this.getGameRunwayScore();
+		if (level != null) {
+			const is_level_change = level != this.level;
 
-			this._setFrameInner(data);
+			this.level = level;
 
-			const new_score = this.getScore();
-			const new_runway = this.getGameRunwayScore();
+			if (is_level_change) {
+				this.onLevel();
 
-			if (new_score === old_score && new_runway === old_runway) return;
-
-			this.onScore();
+				if (this.level === 29) {
+					this.onKillScreen();
+				}
+			}
 		}
 
-		_doGameOver() {
-			if (this.game_over) return;
-
+		if (!this.game_over && this._isTopRowFull(data)) {
 			this.game_over = true;
+			this._lockRunWayToScore();
 			this._showCurtain();
 			this.onGameOver();
 		}
 
-		_setFrameInner(data) {
-			if (this.game_over && this.curtain_down && data.gameid == this.gameid) {
+		if (!(this.game_over && this.has_curtain)) {
+			this.renderField(this.level, data.field, field_string);
+		}
+
+		this.renderPreview(this.level, data.preview);
+
+		if (num_blocks === 200) {
+			this.curtain_down = true;
+			if (!this.has_curtain) this.onCurtainDown();
+		} else {
+			this.updateField(
+				data.field,
+				num_blocks,
+				field_string,
+				allow_field_piece_spawn_detection
+			);
+		}
+
+		if (this.pending_score) {
+			if (lines === null || data.score === null) {
 				return;
 			}
 
-			const lines = data.lines;
-			const level = data.level;
-			const num_blocks = data.field.reduce((acc, v) => acc + (v ? 1 : 0), 0);
-			const field_string = data.field.join('');
+			if (lines < this.lines) {
+				// weird reading, wait one more frame
+				return;
+			}
 
-			// DO NOT DELETE... Is used by Stencil layout -_-
-			this.last_frame = data;
+			const cleared = lines - this.lines;
+			const line_score = (SCORE_BASES[cleared] || 0) * (this.level + 1);
 
-			if (data.gameid != this.gameid) {
-				this._doGameOver();
-				// new game!
-				this.reset();
+			if (data.score === 999999 && this.score + line_score >= 999999) {
+				// Compute score beyond maxout
+				this.score += line_score;
+			} else if (data.score < this.score) {
+				const num_wraps = Math.floor((this.score + line_score) / 1600000);
 
-				// we initialize the game state based on this first frame
-				// dangerous for field data if input is badly detected, but what to do -_-
-
-				this.gameid = data.gameid;
-				this.field_num_blocks = num_blocks;
-				this.start_level = level;
-				this.level = level;
-				this.lines = lines;
+				if (num_wraps >= 1) {
+					// Using Hex score Game Genie code XNEOOGEX
+					// The GG code makes the score display wrap around to 0
+					// when reaching 1,600,000. We correct accordingly here.
+					this.score = 1600000 * num_wraps + data.score;
+				} else {
+					// weird readings... wait one more frame
+					return;
+				}
+			} else {
 				this.score = data.score;
-				this.pending_score = true;
-				this.prev_preview = data.cur_piece || data.preview || 'I';
-
-				this._hideCurtain();
-				this.onGameStart();
 			}
 
-			if (data.lines != null) {
-				this.dom.lines.textContent = `${data.lines}`.padStart(3, '0');
-			}
+			this.dom.score.textContent = this.options.format_score(this.score);
+			this.pending_score = false;
 
-			if (data.level != null) {
-				this.dom.level.textContent = `${data.level}`.padStart(2, '0');
-			}
+			if (lines > this.lines) {
+				if (cleared === 4) {
+					this.lines_trt += 4;
 
-			let allow_field_piece_spawn_detection = false;
-
-			if (this.pending_piece) {
-				this.pending_piece = false;
-
-				let cur_piece = data.cur_piece || this.prev_preview;
-				let has_change = true;
-				let drought_change;
-
-				this.piece_stats.board[cur_piece]++;
-				this.piece_stats.board.count++;
-
-				if (cur_piece === 'I') {
-					drought_change = -this.drought;
+					if (!this.options.reliable_field) {
+						this._doTetris();
+					}
+					this.burn = 0;
 				} else {
-					drought_change = 1;
+					this.burn += cleared;
 				}
 
-				// for classic rom, we get piece data from piece stats
-				// TODO: Add more resilience here (wait for good data)
-				if (data.game_type === BinaryFrame.GAME_TYPE.CLASSIC) {
-					const piece_stats = this._getPieceStats(data);
-					const diff = piece_stats.count - this.piece_stats.frame.count;
-					const sane_state = PIECES.every(
-						piece => piece_stats[piece] >= this.piece_stats.frame[piece]
-					);
+				const line_value =
+					cleared <= 4 ? EFF_LINE_VALUES[cleared] : EFF_LINE_VALUES[1];
 
-					has_change = sane_state && diff;
+				this.total_eff += line_value * cleared;
 
-					if (!has_change) {
-						// frame stats are not good, we should wait a bit more for valid data to come?
-						// revert the changes
-						this.pending_piece = true;
-						this.piece_stats.board[cur_piece]--;
-						this.piece_stats.board.count--;
-					} else {
-						const i_diff = piece_stats.I - this.piece_stats.frame.I;
+				const trt = this.lines_trt / lines;
+				const eff = this.total_eff / lines;
 
-						if (i_diff === 0) {
-							drought_change = diff; // expected to be +1 in most cases
-							cur_piece = PIECES.find(
-								piece => piece_stats[piece] != this.piece_stats.frame[piece]
-							);
-						} else {
-							drought_change = -this.drought;
-							cur_piece = 'I';
-						}
+				this.clear_events.push({ trt, eff, cleared });
+				this.dom.burn.textContent = this.burn;
+				this.dom.trt.textContent = getPercent(trt);
+				this.dom.eff.textContent = (Math.round(eff) || 0)
+					.toString()
+					.padStart(3, '0');
+				this.renderRunningTRT();
+				this.lines = lines;
 
-						Object.assign(this.piece_stats.frame, piece_stats);
-					}
+				if (level != this.start_level && this.transition === null) {
+					this.transition = this.score;
+					this.tr_runway_score = this.score;
+					this.onTransition();
 				}
 
-				if (has_change) {
-					const drought = this.drought + drought_change;
-
-					if (drought === 0) {
-						if (this.drought >= 13) {
-							this.onDroughtEnd(this.drought);
-						}
-					} else if (drought === 13) {
-						if (this.drought < 13) {
-							this.onDroughtStart();
-						}
-					}
-
-					this.drought = drought;
-					this.dom.drought.textContent = this.options.format_drought(
-						this.drought
-					);
-					this.prev_preview = data.preview;
-
-					this.pieces.push(cur_piece);
-					this.onPiece(cur_piece);
-				}
-			} else {
-				if (data.game_type === BinaryFrame.GAME_TYPE.CLASSIC) {
-					this.pending_piece = PIECES.some(
-						piece => this.piece_stats.frame[piece] != data[piece]
-					);
-				} else {
-					allow_field_piece_spawn_detection = true;
-				}
+				this.onLines(cleared);
 			}
 
-			if (level != null) {
-				const is_level_change = level != this.level;
-
-				this.level = level;
-
-				if (is_level_change) {
-					this.onLevel();
-
-					if (this.level === 29) {
-						this.onKillScreen();
-					}
-				}
-			}
-
-			if (!this.game_over && this._isTopRowFull(data)) {
-				this.game_over = true;
-				this._lockRunWayToScore();
-				this._showCurtain();
-				this.onGameOver();
-			}
-
-			if (!(this.game_over && this.has_curtain)) {
-				this.renderField(this.level, data.field, field_string);
-			}
-
-			this.renderPreview(this.level, data.preview);
-
-			if (num_blocks === 200) {
-				this.curtain_down = true;
-				if (!this.has_curtain) this.onCurtainDown();
-			} else {
-				this.updateField(
-					data.field,
-					num_blocks,
-					field_string,
-					allow_field_piece_spawn_detection
+			if (this.transition === null) {
+				this.tr_runway_score = this.getTransitionRunwayScore();
+				this.dom.runway_tr.textContent = this.options.format_score(
+					this.tr_runway_score,
+					6
 				);
 			}
-
-			if (this.pending_score) {
-				if (lines === null || data.score === null) {
-					return;
-				}
-
-				if (lines < this.lines) {
-					// weird reading, wait one more frame
-					return;
-				}
-
-				const cleared = lines - this.lines;
-				const line_score = (SCORE_BASES[cleared] || 0) * (this.level + 1);
-
-				if (data.score === 999999 && this.score + line_score >= 999999) {
-					// Compute score beyond maxout
-					this.score += line_score;
-				} else if (data.score < this.score) {
-					const num_wraps = Math.floor((this.score + line_score) / 1600000);
-
-					if (num_wraps >= 1) {
-						// Using Hex score Game Genie code XNEOOGEX
-						// The GG code makes the score display wrap around to 0
-						// when reaching 1,600,000. We correct accordingly here.
-						this.score = 1600000 * num_wraps + data.score;
-					} else {
-						// weird readings... wait one more frame
-						return;
-					}
-				} else {
-					this.score = data.score;
-				}
-
-				this.dom.score.textContent = this.options.format_score(this.score);
-				this.pending_score = false;
-
-				if (lines > this.lines) {
-					if (cleared === 4) {
-						this.lines_trt += 4;
-
-						if (!this.options.reliable_field) {
-							this._doTetris();
-						}
-						this.burn = 0;
-					} else {
-						this.burn += cleared;
-					}
-
-					const line_value =
-						cleared <= 4 ? EFF_LINE_VALUES[cleared] : EFF_LINE_VALUES[1];
-
-					this.total_eff += line_value * cleared;
-
-					const trt = this.lines_trt / lines;
-					const eff = this.total_eff / lines;
-
-					this.clear_events.push({ trt, eff, cleared });
-					this.dom.burn.textContent = this.burn;
-					this.dom.trt.textContent = getPercent(trt);
-					this.dom.eff.textContent = (Math.round(eff) || 0)
-						.toString()
-						.padStart(3, '0');
-					this.renderRunningTRT();
-					this.lines = lines;
-
-					if (level != this.start_level && this.transition === null) {
-						this.transition = this.score;
-						this.tr_runway_score = this.score;
-						this.onTransition();
-					}
-
-					this.onLines(cleared);
-				}
-
-				if (this.transition === null) {
-					this.tr_runway_score = this.getTransitionRunwayScore();
-					this.dom.runway_tr.textContent = this.options.format_score(
-						this.tr_runway_score,
-						6
-					);
-				}
-
-				this.game_runway_score = this.getGameRunwayScore();
-				this.dom.runway_game.textContent = this.options.format_score(
-					this.game_runway_score,
-					7
-				);
-
-				this.projection = this.getProjection();
-				this.dom.projection.textContent = this.options.format_score(
-					this.projection,
-					7
-				);
-			} else if (data.score != null) {
-				// added extra checks here due to data.score always being different to this.score after maxout
-				if (data.score === 999999) {
-					this.pending_score = lines != this.lines;
-				} else {
-					const high_score = this.score / 1600000;
-
-					if (high_score >= 1) {
-						this.pending_score = data.score != this.score % 1600000;
-					} else {
-						this.pending_score = data.score != this.score;
-					}
-				}
-			}
-		}
-
-		_lockRunWayToScore() {
-			this.tr_runway_score = this.getTransitionRunwayScore();
-			this.dom.runway_tr.textContent = this.options.format_score(
-				this.tr_runway_score,
-				7
-			);
 
 			this.game_runway_score = this.getGameRunwayScore();
 			this.dom.runway_game.textContent = this.options.format_score(
@@ -916,411 +894,440 @@ const Player = (function () {
 				this.projection,
 				7
 			);
-		}
-
-		getGameRunwayScore() {
-			if (this.game_over) {
-				return this.score;
-			}
-
-			return this.score + getRunway(this.start_level, RUNWAY.GAME, this.lines);
-		}
-
-		getTransitionRunwayScore() {
-			if (this.transition) {
-				return this.transition;
-			} else if (this.game_over) {
-				return this.score;
+		} else if (data.score != null) {
+			// added extra checks here due to data.score always being different to this.score after maxout
+			if (data.score === 999999) {
+				this.pending_score = lines != this.lines;
 			} else {
-				return (
-					this.score +
-					getRunway(this.start_level, RUNWAY.TRANSITION, this.lines)
-				);
-			}
-		}
+				const high_score = this.score / 1600000;
 
-		// TODO: Use a exponentially smoothed
-		getProjection() {
-			if (this.game_over) {
-				return this.score;
-			}
-
-			const eff = (this.lines ? this.total_eff / this.lines : 300) / 300;
-
-			return Math.floor(
-				this.score + eff * getRunway(this.start_level, RUNWAY.GAME, this.lines)
-			);
-		}
-
-		renderPreview(level, preview) {
-			const piece_id = `${level}${preview}`;
-
-			if (piece_id === this.current_preview) return;
-
-			this.current_preview = piece_id;
-
-			const ctx = this.preview_ctx,
-				col_index = PIECE_COLORS[preview],
-				pixels_per_block = this.preview_pixel_size * (7 + 1),
-				positions = [];
-
-			ctx.clear();
-
-			let pos_x, pos_y, x_offset_3;
-
-			if (this.options.preview_align == 'tr') {
-				// top-right alignment
-				pos_y = 0;
-				x_offset_3 = Math.ceil(ctx.canvas.width - pixels_per_block * 3);
-			} else {
-				// default is center
-				pos_y = Math.ceil((ctx.canvas.height - pixels_per_block * 2) / 2);
-				x_offset_3 = Math.ceil((ctx.canvas.width - pixels_per_block * 3) / 2);
-			}
-
-			let x_idx = 0;
-
-			switch (preview) {
-				case 'I':
-					if (this.options.preview_align == 'tr') {
-						pos_x = Math.ceil(ctx.canvas.width - pixels_per_block * 4);
-					} else {
-						pos_x = Math.ceil((ctx.canvas.width - pixels_per_block * 4) / 2);
-						pos_y = Math.ceil((ctx.canvas.height - pixels_per_block) / 2);
-					}
-
-					positions.push([pos_x + pixels_per_block * 0, pos_y]);
-					positions.push([pos_x + pixels_per_block * 1, pos_y]);
-					positions.push([pos_x + pixels_per_block * 2, pos_y]);
-					positions.push([pos_x + pixels_per_block * 3, pos_y]);
-					break;
-
-				case 'O':
-					if (this.options.preview_align == 'tr') {
-						pos_x = Math.ceil(ctx.canvas.width - pixels_per_block * 2);
-					} else {
-						pos_x = Math.ceil(
-							(ctx.canvas.width -
-								pixels_per_block * 2 +
-								this.preview_pixel_size) /
-								2
-						);
-					}
-
-					positions.push([pos_x, pos_y]);
-					positions.push([pos_x, pos_y + pixels_per_block]);
-					positions.push([pos_x + pixels_per_block, pos_y]);
-					positions.push([pos_x + pixels_per_block, pos_y + pixels_per_block]);
-					break;
-
-				case 'T':
-				case 'J':
-				case 'L':
-					// top line is the same for both pieces
-					positions.push([x_offset_3 + x_idx++ * pixels_per_block, pos_y]);
-					positions.push([x_offset_3 + x_idx++ * pixels_per_block, pos_y]);
-					positions.push([x_offset_3 + x_idx * pixels_per_block, pos_y]);
-
-					if (preview == 'L') {
-						x_idx = 0;
-					} else if (preview == 'T') {
-						x_idx = 1;
-					} else {
-						x_idx = 2;
-					}
-
-					positions.push([
-						x_offset_3 + x_idx * pixels_per_block,
-						pos_y + pixels_per_block,
-					]);
-					break;
-
-				case 'Z':
-				case 'S':
-					positions.push([x_offset_3 + pixels_per_block, pos_y]);
-					positions.push([
-						x_offset_3 + pixels_per_block,
-						pos_y + pixels_per_block,
-					]);
-
-					if (preview == 'Z') {
-						positions.push([x_offset_3, pos_y]);
-						positions.push([
-							x_offset_3 + pixels_per_block * 2,
-							pos_y + pixels_per_block,
-						]);
-					} else {
-						positions.push([x_offset_3, pos_y + pixels_per_block]);
-						positions.push([x_offset_3 + pixels_per_block * 2, pos_y]);
-					}
-			}
-
-			positions.forEach(([pos_x, pos_y]) => {
-				renderBlock(
-					level,
-					col_index,
-					this.preview_pixel_size,
-					ctx,
-					pos_x,
-					pos_y,
-					true
-				);
-			});
-		}
-
-		updateField(field, num_blocks, field_string, allow_setting_pending_piece) {
-			if (field_string == this.field_string) return;
-
-			// state is considered valid, track data
-			this.field_string = field_string;
-
-			if (this.clear_animation_remaining_frames-- > 0) return;
-
-			const block_diff = num_blocks - (this.field_num_blocks || 0);
-
-			if (block_diff === 4) {
-				this.field_num_blocks = num_blocks;
-
-				if (allow_setting_pending_piece) {
-					this.pending_piece = true;
-				}
-
-				return;
-			}
-
-			const CLEAR_ANIMATION_NUM_FRAMES = 7;
-
-			// assuming we aren't dropping any frame, the number of blocks only reduces when the
-			// line animation starts, the diff is twice the number of lines being cleared.
-			//
-			// Note: diff.stage_blocks can be negative at weird amounts when the piece is rotated
-			// while still being at the top of the field with some block moved out of view
-
-			switch (block_diff) {
-				case -8:
-					if (this.options.reliable_field) {
-						this._doTetris();
-					}
-				case -6:
-					// indicate animation for triples and tetris
-					this.clear_animation_remaining_frames =
-						CLEAR_ANIMATION_NUM_FRAMES - 1;
-					this.field_num_blocks += block_diff * 5; // equivalent to fast forward on how many blocks will have gone after the animation
-
-					break;
-
-				case -4:
-					if (this.pending_single) {
-						// verified single (second frame of clear animation)
-						this.clear_animation_remaining_frames =
-							CLEAR_ANIMATION_NUM_FRAMES - 2;
-						this.field_num_blocks -= 10;
-					} else {
-						// genuine double
-						this.clear_animation_remaining_frames =
-							CLEAR_ANIMATION_NUM_FRAMES - 1;
-						this.field_num_blocks -= 20;
-					}
-
-					this.pending_single = false;
-					break;
-
-				case -2:
-					// -2 can happen on the first clear animation frame of a single
-					// -2 can also happen when the piece is at the top of the field and gets rotated and is then partially off field
-					// to differentiate the 2, we must wait for the next frame, if it goes to -4, then it is the clear animation continuing
-					this.pending_single = true;
-					break;
-
-				default:
-					this.pending_single = false;
-			}
-		}
-
-		renderField(level, field, field_string) {
-			const stage_id = `${level}${field_string}`;
-
-			if (stage_id === this.current_field) return;
-
-			this.current_field = stage_id;
-
-			if (!this.options.draw_field) return;
-
-			const pixels_per_block = this.field_pixel_size * (7 + 1);
-
-			this.field_ctx.clear();
-
-			for (let x = 0; x < 10; x++) {
-				for (let y = 0; y < 20; y++) {
-					renderBlock(
-						level,
-						field[y * 10 + x],
-						this.field_pixel_size,
-						this.field_ctx,
-						x * pixels_per_block,
-						y * pixels_per_block,
-						true
-					);
-				}
-			}
-		}
-
-		renderRunningTRT() {
-			const ctx = this.running_trt_ctx,
-				current_trt = peek(this.clear_events).trt,
-				pixel_size_line_clear = 4,
-				pixel_size_baseline = 2;
-
-			let pixel_size, max_pixels, y_scale;
-
-			ctx.clear();
-
-			// show the current tetris rate baseline
-			// always vertically centered on the line clear event dot
-			pixel_size = pixel_size_baseline;
-			max_pixels = Math.floor(ctx.canvas.width / (pixel_size + 1));
-			y_scale = (ctx.canvas.height - pixel_size_line_clear) / pixel_size;
-
-			const pos_y = Math.round(
-				(1 - current_trt) * y_scale * pixel_size +
-					(pixel_size_line_clear - pixel_size_baseline) / 2
-			);
-
-			ctx.fillStyle = 'grey'; // '#686868';
-
-			for (let idx = max_pixels; idx--; ) {
-				ctx.fillRect(idx * (pixel_size + 1), pos_y, pixel_size, pixel_size);
-			}
-
-			// Show the individual line clear events
-			pixel_size = pixel_size_line_clear;
-			max_pixels = Math.floor(ctx.canvas.width / (pixel_size + 1));
-			y_scale = (ctx.canvas.height - pixel_size) / pixel_size;
-
-			let to_draw = this.clear_events.slice(-1 * max_pixels),
-				len = to_draw.length;
-
-			for (let idx = len; idx--; ) {
-				const { cleared, trt } = to_draw[idx];
-				const color = LINES[cleared] ? LINES[cleared].color : 'grey';
-
-				ctx.fillStyle = color;
-				ctx.fillRect(
-					idx * (pixel_size + 1),
-					Math.round((1 - trt) * y_scale * pixel_size),
-					pixel_size,
-					pixel_size
-				);
-			}
-		}
-
-		clearField() {
-			this.field_ctx.clear();
-			this.clearWinnerAnimation();
-			this._hideCurtain();
-		}
-
-		setGameOver() {
-			this._doGameOver();
-			this._lockRunWayToScore();
-			this.curtain_down = true; // set early to force all frames to be ignored from that point on
-		}
-
-		cancelGameOver() {
-			this.clearField();
-			this.curtain_down = false;
-			this.game_over = false;
-		}
-
-		showLoserFrame() {
-			this.winner_frame = 0;
-			this.clearField();
-			this.renderLoserFace();
-			this.renderBorder(false);
-		}
-
-		playWinnerAnimation() {
-			// cancel rendering for current game
-			this.game_over = this.curtain_down = true;
-
-			this.winner_frame = 0;
-			this.clearField();
-			this.winner_animation_id = setInterval(this.renderWinnerFrame, 1000 / 18);
-		}
-
-		clearWinnerAnimation() {
-			this.winner_animation_id = clearInterval(this.winner_animation_id);
-		}
-
-		renderWinnerFrame() {
-			this.winner_frame++;
-			this.renderWinnerFace();
-			this.renderBorder(true);
-		}
-
-		renderWinnerFace() {
-			const pixels_per_block = this.field_pixel_size * (7 + 1);
-			const level = Math.floor(this.winner_frame / 3) % 10;
-
-			WINNER_FACE_BLOCKS.forEach(([y, x]) => {
-				renderBlock(
-					level,
-					1,
-					this.field_pixel_size,
-					this.field_ctx,
-					x * pixels_per_block,
-					y * pixels_per_block,
-					true
-				);
-			});
-		}
-
-		renderLoserFace() {
-			const pixels_per_block = this.field_pixel_size * (7 + 1);
-			const level = 6;
-
-			LOSER_FACE_BLOCKS.forEach(([y, x]) => {
-				renderBlock(
-					level,
-					3,
-					this.field_pixel_size,
-					this.field_ctx,
-					x * pixels_per_block,
-					y * pixels_per_block,
-					true
-				);
-			});
-		}
-
-		renderBorder(is_winner) {
-			const pixels_per_block = this.field_pixel_size * (7 + 1);
-
-			BORDER_BLOCKS.forEach(([y, x], idx) => {
-				const offset = this.winner_frame + idx;
-
-				let level, color;
-
-				if (is_winner) {
-					level = Math.floor(offset / 3) % 10;
-					color = (offset % 3) + 1;
+				if (high_score >= 1) {
+					this.pending_score = data.score != this.score % 1600000;
 				} else {
-					// ugly grey piece
-					level = 6;
-					color = 3;
+					this.pending_score = data.score != this.score;
 				}
-
-				renderBlock(
-					level,
-					color,
-					this.field_pixel_size,
-					this.field_ctx,
-					x * pixels_per_block,
-					y * pixels_per_block,
-					true
-				);
-			});
+			}
 		}
 	}
 
-	return Player;
-})();
+	_lockRunWayToScore() {
+		this.tr_runway_score = this.getTransitionRunwayScore();
+		this.dom.runway_tr.textContent = this.options.format_score(
+			this.tr_runway_score,
+			7
+		);
+
+		this.game_runway_score = this.getGameRunwayScore();
+		this.dom.runway_game.textContent = this.options.format_score(
+			this.game_runway_score,
+			7
+		);
+
+		this.projection = this.getProjection();
+		this.dom.projection.textContent = this.options.format_score(
+			this.projection,
+			7
+		);
+	}
+
+	getGameRunwayScore() {
+		if (this.game_over) {
+			return this.score;
+		}
+
+		return this.score + getRunway(this.start_level, RUNWAY.GAME, this.lines);
+	}
+
+	getTransitionRunwayScore() {
+		if (this.transition) {
+			return this.transition;
+		} else if (this.game_over) {
+			return this.score;
+		} else {
+			return (
+				this.score + getRunway(this.start_level, RUNWAY.TRANSITION, this.lines)
+			);
+		}
+	}
+
+	// TODO: Use a exponentially smoothed
+	getProjection() {
+		if (this.game_over) {
+			return this.score;
+		}
+
+		const eff = (this.lines ? this.total_eff / this.lines : 300) / 300;
+
+		return Math.floor(
+			this.score + eff * getRunway(this.start_level, RUNWAY.GAME, this.lines)
+		);
+	}
+
+	renderPreview(level, preview) {
+		const piece_id = `${level}${preview}`;
+
+		if (piece_id === this.current_preview) return;
+
+		this.current_preview = piece_id;
+
+		const ctx = this.preview_ctx,
+			col_index = PIECE_COLORS[preview],
+			pixels_per_block = this.preview_pixel_size * (7 + 1),
+			positions = [];
+
+		ctx.clear();
+
+		let pos_x, pos_y, x_offset_3;
+
+		if (this.options.preview_align == 'tr') {
+			// top-right alignment
+			pos_y = 0;
+			x_offset_3 = Math.ceil(ctx.canvas.width - pixels_per_block * 3);
+		} else {
+			// default is center
+			pos_y = Math.ceil((ctx.canvas.height - pixels_per_block * 2) / 2);
+			x_offset_3 = Math.ceil((ctx.canvas.width - pixels_per_block * 3) / 2);
+		}
+
+		let x_idx = 0;
+
+		switch (preview) {
+			case 'I':
+				if (this.options.preview_align == 'tr') {
+					pos_x = Math.ceil(ctx.canvas.width - pixels_per_block * 4);
+				} else {
+					pos_x = Math.ceil((ctx.canvas.width - pixels_per_block * 4) / 2);
+					pos_y = Math.ceil((ctx.canvas.height - pixels_per_block) / 2);
+				}
+
+				positions.push([pos_x + pixels_per_block * 0, pos_y]);
+				positions.push([pos_x + pixels_per_block * 1, pos_y]);
+				positions.push([pos_x + pixels_per_block * 2, pos_y]);
+				positions.push([pos_x + pixels_per_block * 3, pos_y]);
+				break;
+
+			case 'O':
+				if (this.options.preview_align == 'tr') {
+					pos_x = Math.ceil(ctx.canvas.width - pixels_per_block * 2);
+				} else {
+					pos_x = Math.ceil(
+						(ctx.canvas.width -
+							pixels_per_block * 2 +
+							this.preview_pixel_size) /
+							2
+					);
+				}
+
+				positions.push([pos_x, pos_y]);
+				positions.push([pos_x, pos_y + pixels_per_block]);
+				positions.push([pos_x + pixels_per_block, pos_y]);
+				positions.push([pos_x + pixels_per_block, pos_y + pixels_per_block]);
+				break;
+
+			case 'T':
+			case 'J':
+			case 'L':
+				// top line is the same for both pieces
+				positions.push([x_offset_3 + x_idx++ * pixels_per_block, pos_y]);
+				positions.push([x_offset_3 + x_idx++ * pixels_per_block, pos_y]);
+				positions.push([x_offset_3 + x_idx * pixels_per_block, pos_y]);
+
+				if (preview == 'L') {
+					x_idx = 0;
+				} else if (preview == 'T') {
+					x_idx = 1;
+				} else {
+					x_idx = 2;
+				}
+
+				positions.push([
+					x_offset_3 + x_idx * pixels_per_block,
+					pos_y + pixels_per_block,
+				]);
+				break;
+
+			case 'Z':
+			case 'S':
+				positions.push([x_offset_3 + pixels_per_block, pos_y]);
+				positions.push([
+					x_offset_3 + pixels_per_block,
+					pos_y + pixels_per_block,
+				]);
+
+				if (preview == 'Z') {
+					positions.push([x_offset_3, pos_y]);
+					positions.push([
+						x_offset_3 + pixels_per_block * 2,
+						pos_y + pixels_per_block,
+					]);
+				} else {
+					positions.push([x_offset_3, pos_y + pixels_per_block]);
+					positions.push([x_offset_3 + pixels_per_block * 2, pos_y]);
+				}
+		}
+
+		positions.forEach(([pos_x, pos_y]) => {
+			renderBlock(
+				level,
+				col_index,
+				this.preview_pixel_size,
+				ctx,
+				pos_x,
+				pos_y,
+				true
+			);
+		});
+	}
+
+	updateField(field, num_blocks, field_string, allow_setting_pending_piece) {
+		if (field_string == this.field_string) return;
+
+		// state is considered valid, track data
+		this.field_string = field_string;
+
+		if (this.clear_animation_remaining_frames-- > 0) return;
+
+		const block_diff = num_blocks - (this.field_num_blocks || 0);
+
+		if (block_diff === 4) {
+			this.field_num_blocks = num_blocks;
+
+			if (allow_setting_pending_piece) {
+				this.pending_piece = true;
+			}
+
+			return;
+		}
+
+		const CLEAR_ANIMATION_NUM_FRAMES = 7;
+
+		// assuming we aren't dropping any frame, the number of blocks only reduces when the
+		// line animation starts, the diff is twice the number of lines being cleared.
+		//
+		// Note: diff.stage_blocks can be negative at weird amounts when the piece is rotated
+		// while still being at the top of the field with some block moved out of view
+
+		switch (block_diff) {
+			case -8:
+				if (this.options.reliable_field) {
+					this._doTetris();
+				}
+			case -6:
+				// indicate animation for triples and tetris
+				this.clear_animation_remaining_frames = CLEAR_ANIMATION_NUM_FRAMES - 1;
+				this.field_num_blocks += block_diff * 5; // equivalent to fast forward on how many blocks will have gone after the animation
+
+				break;
+
+			case -4:
+				if (this.pending_single) {
+					// verified single (second frame of clear animation)
+					this.clear_animation_remaining_frames =
+						CLEAR_ANIMATION_NUM_FRAMES - 2;
+					this.field_num_blocks -= 10;
+				} else {
+					// genuine double
+					this.clear_animation_remaining_frames =
+						CLEAR_ANIMATION_NUM_FRAMES - 1;
+					this.field_num_blocks -= 20;
+				}
+
+				this.pending_single = false;
+				break;
+
+			case -2:
+				// -2 can happen on the first clear animation frame of a single
+				// -2 can also happen when the piece is at the top of the field and gets rotated and is then partially off field
+				// to differentiate the 2, we must wait for the next frame, if it goes to -4, then it is the clear animation continuing
+				this.pending_single = true;
+				break;
+
+			default:
+				this.pending_single = false;
+		}
+	}
+
+	renderField(level, field, field_string) {
+		const stage_id = `${level}${field_string}`;
+
+		if (stage_id === this.current_field) return;
+
+		this.current_field = stage_id;
+
+		if (!this.options.draw_field) return;
+
+		const pixels_per_block = this.field_pixel_size * (7 + 1);
+
+		this.field_ctx.clear();
+
+		for (let x = 0; x < 10; x++) {
+			for (let y = 0; y < 20; y++) {
+				renderBlock(
+					level,
+					field[y * 10 + x],
+					this.field_pixel_size,
+					this.field_ctx,
+					x * pixels_per_block,
+					y * pixels_per_block,
+					true
+				);
+			}
+		}
+	}
+
+	renderRunningTRT() {
+		const ctx = this.running_trt_ctx,
+			current_trt = peek(this.clear_events).trt,
+			pixel_size_line_clear = 4,
+			pixel_size_baseline = 2;
+
+		let pixel_size, max_pixels, y_scale;
+
+		ctx.clear();
+
+		// show the current tetris rate baseline
+		// always vertically centered on the line clear event dot
+		pixel_size = pixel_size_baseline;
+		max_pixels = Math.floor(ctx.canvas.width / (pixel_size + 1));
+		y_scale = (ctx.canvas.height - pixel_size_line_clear) / pixel_size;
+
+		const pos_y = Math.round(
+			(1 - current_trt) * y_scale * pixel_size +
+				(pixel_size_line_clear - pixel_size_baseline) / 2
+		);
+
+		ctx.fillStyle = 'grey'; // '#686868';
+
+		for (let idx = max_pixels; idx--; ) {
+			ctx.fillRect(idx * (pixel_size + 1), pos_y, pixel_size, pixel_size);
+		}
+
+		// Show the individual line clear events
+		pixel_size = pixel_size_line_clear;
+		max_pixels = Math.floor(ctx.canvas.width / (pixel_size + 1));
+		y_scale = (ctx.canvas.height - pixel_size) / pixel_size;
+
+		let to_draw = this.clear_events.slice(-1 * max_pixels),
+			len = to_draw.length;
+
+		for (let idx = len; idx--; ) {
+			const { cleared, trt } = to_draw[idx];
+			const color = LINES[cleared] ? LINES[cleared].color : 'grey';
+
+			ctx.fillStyle = color;
+			ctx.fillRect(
+				idx * (pixel_size + 1),
+				Math.round((1 - trt) * y_scale * pixel_size),
+				pixel_size,
+				pixel_size
+			);
+		}
+	}
+
+	clearField() {
+		this.field_ctx.clear();
+		this.clearWinnerAnimation();
+		this._hideCurtain();
+	}
+
+	setGameOver() {
+		this._doGameOver();
+		this._lockRunWayToScore();
+		this.curtain_down = true; // set early to force all frames to be ignored from that point on
+	}
+
+	cancelGameOver() {
+		this.clearField();
+		this.curtain_down = false;
+		this.game_over = false;
+	}
+
+	showLoserFrame() {
+		this.winner_frame = 0;
+		this.clearField();
+		this.renderLoserFace();
+		this.renderBorder(false);
+	}
+
+	playWinnerAnimation() {
+		// cancel rendering for current game
+		this.game_over = this.curtain_down = true;
+
+		this.winner_frame = 0;
+		this.clearField();
+		this.winner_animation_id = setInterval(this.renderWinnerFrame, 1000 / 18);
+	}
+
+	clearWinnerAnimation() {
+		this.winner_animation_id = clearInterval(this.winner_animation_id);
+	}
+
+	renderWinnerFrame() {
+		this.winner_frame++;
+		this.renderWinnerFace();
+		this.renderBorder(true);
+	}
+
+	renderWinnerFace() {
+		const pixels_per_block = this.field_pixel_size * (7 + 1);
+		const level = Math.floor(this.winner_frame / 3) % 10;
+
+		WINNER_FACE_BLOCKS.forEach(([y, x]) => {
+			renderBlock(
+				level,
+				1,
+				this.field_pixel_size,
+				this.field_ctx,
+				x * pixels_per_block,
+				y * pixels_per_block,
+				true
+			);
+		});
+	}
+
+	renderLoserFace() {
+		const pixels_per_block = this.field_pixel_size * (7 + 1);
+		const level = 6;
+
+		LOSER_FACE_BLOCKS.forEach(([y, x]) => {
+			renderBlock(
+				level,
+				3,
+				this.field_pixel_size,
+				this.field_ctx,
+				x * pixels_per_block,
+				y * pixels_per_block,
+				true
+			);
+		});
+	}
+
+	renderBorder(is_winner) {
+		const pixels_per_block = this.field_pixel_size * (7 + 1);
+
+		BORDER_BLOCKS.forEach(([y, x], idx) => {
+			const offset = this.winner_frame + idx;
+
+			let level, color;
+
+			if (is_winner) {
+				level = Math.floor(offset / 3) % 10;
+				color = (offset % 3) + 1;
+			} else {
+				// ugly grey piece
+				level = 6;
+				color = 3;
+			}
+
+			renderBlock(
+				level,
+				color,
+				this.field_pixel_size,
+				this.field_ctx,
+				x * pixels_per_block,
+				y * pixels_per_block,
+				true
+			);
+		});
+	}
+}

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -2,6 +2,7 @@ import QueryString from '/js/QueryString.js';
 import BinaryFrame from '/js/BinaryFrame.js';
 import renderBlock from '/views/renderBlock.js';
 import { css_size, clamp } from '/views/utils.js';
+import { SCORE_BASES, PIECE_COLORS } from '/views/constants.js';
 
 import {
 	DOM_DEV_NULL,

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -1,14 +1,16 @@
 import QueryString from '/js/QueryString.js';
 import BinaryFrame from '/js/BinaryFrame.js';
 import renderBlock from '/views/renderBlock.js';
-import { css_size, clamp } from '/views/utils.js';
-import { SCORE_BASES, PIECE_COLORS } from '/views/constants.js';
+import { css_size, clamp, getPercent, peek } from '/views/utils.js';
 
 import {
+	SCORE_BASES,
+	PIECE_COLORS,
 	DOM_DEV_NULL,
 	PIECES,
 	LINES,
 	RUNWAY,
+	EFF_LINE_VALUES,
 	getRunway,
 } from '/views/constants.js';
 

--- a/public/views/bg.js
+++ b/public/views/bg.js
@@ -1,124 +1,118 @@
-(function () {
-	if (QueryString.get('bg') === '0') {
-		return;
+import QueryString from '/js/QueryString.js';
+import { PIECES } from '/views/constants.js';
+import { shuffle } from '/views/utils.js';
+
+const parent = document.querySelector('#stream_bg');
+
+if (QueryString.get('bg') === '0') {
+} else if (QueryString.get('bg') === '5') {
+	const bg = document.createElement('div');
+	parent.style.backgroundColor = 'black';
+	bg.classList.add('bg');
+
+	const bounds = parent.getBoundingClientRect();
+
+	const spacer_w = 160;
+	const spacer_h = 40;
+	const canvas_w = bounds.width + spacer_w * 2;
+	const canvas_h = bounds.height + spacer_h * 2;
+
+	const trophy_base_uri = '/brand/trophies/';
+	const trophy_nums = Array(20)
+		.fill()
+		.map((_, idx) => idx + 1);
+
+	const columns = Math.ceil(canvas_w / spacer_w);
+	const rows = Math.ceil(canvas_h / spacer_h);
+
+	let num_trophy_set = Math.ceil((columns * rows) / trophy_nums.length);
+
+	const trophies = [];
+
+	while (num_trophy_set--) {
+		trophies.push(...shuffle(trophy_nums.concat()));
 	}
 
-	const parent = document.querySelector('#stream_bg');
+	shuffle(trophies);
 
-	if (QueryString.get('bg') === '5') {
-		const bg = document.createElement('div');
-		parent.style.backgroundColor = 'black';
-		bg.classList.add('bg');
+	trophies.length = columns * rows;
 
-		const bounds = parent.getBoundingClientRect();
+	for (let y = rows; y--; ) {
+		const offset_x = -(y % 2 === 0 ? 0 : spacer_w / 2);
+		const offset_y = -(y % 2 === 0 ? 0 : spacer_h / 2) - spacer_h;
 
-		const spacer_w = 160;
-		const spacer_h = 40;
-		const canvas_w = bounds.width + spacer_w * 2;
-		const canvas_h = bounds.height + spacer_h * 2;
+		for (let x = columns; x--; ) {
+			const trophy_num = trophies.shift();
+			const img = new Image();
+			img.src = `${trophy_base_uri}${trophy_num}.2x.png`;
 
-		const trophy_base_uri = '/brand/trophies/';
-		const trophy_nums = Array(20)
-			.fill()
-			.map((_, idx) => idx + 1);
+			img.loc = {
+				x: offset_x + x * spacer_w,
+				y: offset_y + y * spacer_h,
+			};
 
-		const columns = Math.ceil(canvas_w / spacer_w);
-		const rows = Math.ceil(canvas_h / spacer_h);
-
-		let num_trophy_set = Math.ceil((columns * rows) / trophy_nums.length);
-
-		const trophies = [];
-
-		while (num_trophy_set--) {
-			trophies.push(...shuffle(trophy_nums.concat()));
-		}
-
-		shuffle(trophies);
-
-		trophies.length = columns * rows;
-
-		for (let y = rows; y--; ) {
-			const offset_x = -(y % 2 === 0 ? 0 : spacer_w / 2);
-			const offset_y = -(y % 2 === 0 ? 0 : spacer_h / 2) - spacer_h;
-
-			for (let x = columns; x--; ) {
-				const trophy_num = trophies.shift();
-				const img = new Image();
-				img.src = `${trophy_base_uri}${trophy_num}.2x.png`;
-
-				img.loc = {
-					x: offset_x + x * spacer_w,
-					y: offset_y + y * spacer_h,
-				};
-
-				Object.assign(img.style, {
-					left: `${img.loc.x}px`,
-					top: `${img.loc.y}px`,
-					position: 'absolute',
-				});
-
-				bg.appendChild(img);
-				trophies.push(img);
-			}
-		}
-
-		setInterval(() => {
-			trophies.forEach(img => {
-				if (++img.loc.x > canvas_w - spacer_w * 2) {
-					img.loc.x -= canvas_w;
-				}
-				if (++img.loc.y > canvas_h - spacer_h * 2) {
-					img.loc.y -= canvas_h;
-				}
-
-				img.style.left = `${img.loc.x}px`;
-				img.style.top = `${img.loc.y}px`;
+			Object.assign(img.style, {
+				left: `${img.loc.x}px`,
+				top: `${img.loc.y}px`,
+				position: 'absolute',
 			});
-		}, 1000 / 30);
 
-		parent.prepend(bg);
-		return;
+			bg.appendChild(img);
+			trophies.push(img);
+		}
 	}
 
-	if (
-		QueryString.get('bg') === '2' ||
-		QueryString.get('bg') === '3' ||
-		QueryString.get('bg') === '4'
-	) {
-		const bgs = {
-			2: 'nestrischamps_bg_green.png',
-			3: 'nestrischamps_bg.png',
-			4: 'nestrischamps_bg_green.gif',
-		};
+	setInterval(() => {
+		trophies.forEach(img => {
+			if (++img.loc.x > canvas_w - spacer_w * 2) {
+				img.loc.x -= canvas_w;
+			}
+			if (++img.loc.y > canvas_h - spacer_h * 2) {
+				img.loc.y -= canvas_h;
+			}
 
-		const img_width = 218;
-		const bg_file = bgs[QueryString.get('bg')];
-		const bg = document.createElement('div');
-
-		bg.classList.add('bg');
-
-		Object.assign(bg.style, {
-			position: 'absolute',
-			width: '121%',
-			height: '133%',
-			top: '-16%',
-			left: '-15%',
-			background: `url(/views/${bg_file}) 0 0 repeat`,
-			transform: 'rotate(-11deg)',
+			img.style.left = `${img.loc.x}px`;
+			img.style.top = `${img.loc.y}px`;
 		});
+	}, 1000 / 30);
 
-		let pos = 0;
+	parent.prepend(bg);
+} else if (
+	QueryString.get('bg') === '2' ||
+	QueryString.get('bg') === '3' ||
+	QueryString.get('bg') === '4'
+) {
+	const bgs = {
+		2: 'nestrischamps_bg_green.png',
+		3: 'nestrischamps_bg.png',
+		4: 'nestrischamps_bg_green.gif',
+	};
 
-		setInterval(() => {
-			pos = ++pos % img_width;
-			bg.style.backgroundPositionX = `${pos}px`;
-		}, 1000 / 30);
+	const img_width = 218;
+	const bg_file = bgs[QueryString.get('bg')];
+	const bg = document.createElement('div');
 
-		parent.prepend(bg);
+	bg.classList.add('bg');
 
-		return;
-	}
+	Object.assign(bg.style, {
+		position: 'absolute',
+		width: '121%',
+		height: '133%',
+		top: '-16%',
+		left: '-15%',
+		background: `url(/views/${bg_file}) 0 0 repeat`,
+		transform: 'rotate(-11deg)',
+	});
 
+	let pos = 0;
+
+	setInterval(() => {
+		pos = ++pos % img_width;
+		bg.style.backgroundPositionX = `${pos}px`;
+	}, 1000 / 30);
+
+	parent.prepend(bg);
+} else {
 	// bg=1 (default pieces)
 	const bounds = parent.getBoundingClientRect();
 
@@ -175,4 +169,6 @@
 	parent.style.backgroundColor = 'black';
 
 	parent.prepend(bg);
-})();
+}
+
+export default {};

--- a/public/views/color.js
+++ b/public/views/color.js
@@ -1,35 +1,87 @@
-/*jshint boss:true, smarttabs:true, laxcomma:true, laxbreak:true, bitwise:false */
+const _min = Math.min;
+const _max = Math.max;
+const isNumber = v => typeof v === 'number';
+const isInt = v => isNumber(v) && v % 1 === 0;
+const isInRange = (v, min, max) => v >= min && v <= max;
+const clamp = (v, min, max) => _max(min, _min(v, max));
 
-var module_setup = function (undefined) {
-	'use strict';
+const named_cache = {};
+const named = {
+	aqua: '#0ff',
+	black: '#0',
+	blue: '#00f',
+	fuchsia: '#f0f',
+	grey: '#80',
+	gray: '#80',
+	green: '#008000',
+	lime: '#0f0',
+	maroon: '#800000',
+	navy: '#000080',
+	olive: '#808000',
+	purple: '#800080',
+	red: '#f00',
+	silver: '#c0',
+	teal: '#008080',
+	white: '#f',
+	yellow: '#ff0',
+};
 
-	// ===================================================
-	// Private Statics
-	// ===================================================
-
-	var _min = Math.min,
-		_max = Math.max,
-		isNumber = function (v) {
-			return typeof v === 'number';
+const color_format = [
+	[
+		new RegExp('^#([0-9a-f])$'),
+		function (m) {
+			const v = parseInt(m[1] + m[1], 16);
+			return new Color(v, v, v);
 		},
-		isInt = function (v) {
-			return isNumber(v) && v % 1 === 0;
+	],
+
+	[
+		new RegExp('^#([0-9a-f]{2})$'),
+		function (m) {
+			const v = parseInt(m[1], 16);
+			return new Color(v, v, v);
 		},
-		isInRange = function (v, min, max) {
-			return v >= min && v <= max;
+	],
+
+	[
+		new RegExp('^#([0-9a-f]{3})$'),
+		function (m) {
+			const s = m[1];
+			return new Color(
+				parseInt(s.charAt(0) + s.charAt(0), 16),
+				parseInt(s.charAt(1) + s.charAt(1), 16),
+				parseInt(s.charAt(2) + s.charAt(2), 16)
+			);
 		},
-		clamp = function (v, min, max) {
-			return _max(min, _min(v, max));
-		};
+	],
 
-	// ===================================================
-	// Constructor
-	// ===================================================
+	[
+		new RegExp('^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$'),
+		function (m) {
+			return new Color(
+				parseInt(m[1], 16),
+				parseInt(m[2], 16),
+				parseInt(m[3], 16)
+			);
+		},
+	],
+];
 
-	var Color = function (r, g, b, a) {
-		// a is optional, if it not defined, we set up default NOW
-		if (a === undefined) a = 1;
+// hex string regexps will be lazy-initialized
+function localCreateFromHexString(str) {
+	let m;
 
+	for (let idx = res.length; idx-- > 0; ) {
+		if ((m = res[idx][0].exec(str))) {
+			return res[idx][1](m);
+		}
+	}
+
+	throw new SyntaxError('Not a valid hex color: ' + s);
+}
+
+export default class Color {
+	constructor(r, g, b, a = 1) {
 		// all color components MUST be valid to be accepted
 		if (
 			!(
@@ -43,20 +95,16 @@ var module_setup = function (undefined) {
 				isInRange(a, 0, 1)
 			)
 		) {
-			throw new Error('invalid arguments: ' + [r, g, b, a]);
+			throw new RangeError('invalid arguments: ' + [r, g, b, a]);
 		}
 
 		this.r = r;
 		this.g = g;
 		this.b = b;
 		this.a = a;
-	};
+	}
 
-	// ===================================================
-	// Static Color methods below
-	// ===================================================
-
-	Color.create = function (entry) {
+	static create(entry) {
 		if (entry instanceof Color) {
 			return entry.clone();
 		}
@@ -73,86 +121,9 @@ var module_setup = function (undefined) {
 		}
 
 		throw new Error('Not a color: ' + entry);
-	};
+	}
 
-	// hex string regexps will be lazy-initialized
-	var res = null;
-	var localCreateFromHexString = function (str) {
-		if (!res) {
-			res = [
-				[
-					new RegExp('^#([0-9a-f])$'),
-					function (m) {
-						var v = parseInt(m[1] + m[1], 16);
-						return new Color(v, v, v);
-					},
-				],
-
-				[
-					new RegExp('^#([0-9a-f]{2})$'),
-					function (m) {
-						var v = parseInt(m[1], 16);
-						return new Color(v, v, v);
-					},
-				],
-
-				[
-					new RegExp('^#([0-9a-f]{3})$'),
-					function (m) {
-						var s = m[1];
-						return new Color(
-							parseInt(s.charAt(0) + s.charAt(0), 16),
-							parseInt(s.charAt(1) + s.charAt(1), 16),
-							parseInt(s.charAt(2) + s.charAt(2), 16)
-						);
-					},
-				],
-
-				[
-					new RegExp('^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$'),
-					function (m) {
-						return new Color(
-							parseInt(m[1], 16),
-							parseInt(m[2], 16),
-							parseInt(m[3], 16)
-						);
-					},
-				],
-			];
-		}
-
-		var m;
-		for (var idx = res.length; idx-- > 0; ) {
-			if ((m = res[idx][0].exec(str))) {
-				return res[idx][1](m);
-			}
-		}
-
-		throw new Error('Not a valid hex color: ' + s);
-	};
-
-	var named_cache = {},
-		named = {
-			aqua: '#0ff',
-			black: '#0',
-			blue: '#00f',
-			fuchsia: '#f0f',
-			grey: '#80',
-			gray: '#80',
-			green: '#008000',
-			lime: '#0f0',
-			maroon: '#800000',
-			navy: '#000080',
-			olive: '#808000',
-			purple: '#800080',
-			red: '#f00',
-			silver: '#c0',
-			teal: '#008080',
-			white: '#f',
-			yellow: '#ff0',
-		};
-
-	Color.createFromHexString = function (entry) {
+	static createFromHexString(entry) {
 		entry = entry.toLowerCase();
 
 		// check local cache to reduce repeat parsing
@@ -164,19 +135,19 @@ var module_setup = function (undefined) {
 		}
 
 		return localCreateFromHexString(entry);
-	};
+	}
 
-	Color.createFromInt = function (entry) {
+	static createFromInt(entry) {
 		entry = Math.round(entry);
 		return new Color(
 			(entry & 0xff0000) >> 16,
 			(entry & 0xff00) >> 8,
 			entry & 0xff
 		);
-	};
+	}
 
-	Color.createFromObject = function (entry) {
-		var r, g, b, a;
+	static createFromObject(entry) {
+		let r, g, b, a;
 
 		if (isInt(entry.r) && isInt(entry.g) && isInt(entry.b)) {
 			// basic check for ints at named fields passed
@@ -217,35 +188,30 @@ var module_setup = function (undefined) {
 		}
 
 		return new Color(clamp(r, 0, 255), clamp(g, 0, 255), clamp(b, 0, 255), a);
-	};
+	}
 
-	Color.getMidChannel = function (start, end, ratio) {
+	static getMidChannel(start, end, ratio) {
 		// Channel blending needs to be done in square space
 		// See: https://www.youtube.com/watch?v=LKnqECcg6Gw
-		var value = start * start + (end * end - start * start) * ratio;
+		const value = start * start + (end * end - start * start) * ratio;
 
 		return Math.round(Math.sqrt(value));
-	};
+	}
 
-	// ===================================================
-	// Instance methods below
-	// ===================================================
-
-	var p = Color.prototype;
-
-	p.toRGBAString = function () {
-		var channels = [this.r, this.g, this.b];
+	toRGBAString() {
+		const channels = [this.r, this.g, this.b];
 		return (
 			(this.a >= 1 ? 'rgb(' : (channels.push(this.a), 'rgba(')) +
 			channels.join(',') +
 			')'
 		);
-	};
+	}
 
-	p.toHexString = function () {
-		var r = this.r.toString(16);
-		var g = this.g.toString(16);
-		var b = this.b.toString(16);
+	toHexString() {
+		const r = this.r.toString(16);
+		const g = this.g.toString(16);
+		const b = this.b.toString(16);
+
 		return (
 			'#' +
 			(r.length < 2 ? '0' : '') +
@@ -255,23 +221,21 @@ var module_setup = function (undefined) {
 			(b.length < 2 ? '0' : '') +
 			b
 		);
-	};
+	}
 
-	p.toString = p.toHexString;
-
-	p.toInt = function () {
+	toInt() {
 		return (this.r << 16) | (this.g << 8) | this.b;
-	};
+	}
 
-	p.toArray = function () {
+	toArray() {
 		return [this.r, this.g, this.b, this.a];
-	};
+	}
 
-	p.clone = function () {
+	clone() {
 		return new Color(this.r, this.g, this.b, this.a);
-	};
+	}
 
-	p.getMidColor = function (targetCol, ratio) {
+	getMidColor(targetCol, ratio) {
 		ratio = !isNumber(ratio) ? 0.5 : clamp(ratio, 0, 1);
 
 		return new Color(
@@ -280,22 +244,7 @@ var module_setup = function (undefined) {
 			Color.getMidChannel(this.b, targetCol.b, ratio),
 			this.a + (targetCol.a - this.a) * ratio // does this need to be done in square space too?
 		);
-	};
-
-	return Color;
-};
-
-// ===================================================
-// Access control
-// ===================================================
-
-if (typeof define !== 'undefined') {
-	// AMD compatibility
-	define([], module_setup);
-} else if (typeof module !== 'undefined' && module.exports) {
-	// exports
-	module.exports = module_setup();
-} else {
-	// brings class to current context
-	this.Color = module_setup();
+	}
 }
+
+Color.prototype.toString = Color.prototype.toHexString;

--- a/public/views/color.js
+++ b/public/views/color.js
@@ -26,9 +26,9 @@ const named = {
 	yellow: '#ff0',
 };
 
-const color_format = [
+const colorFormats = [
 	[
-		new RegExp('^#([0-9a-f])$'),
+		/^#([0-9a-f])$/i,
 		function (m) {
 			const v = parseInt(m[1] + m[1], 16);
 			return new Color(v, v, v);
@@ -36,7 +36,7 @@ const color_format = [
 	],
 
 	[
-		new RegExp('^#([0-9a-f]{2})$'),
+		/^#([0-9a-f]{2})$/i,
 		function (m) {
 			const v = parseInt(m[1], 16);
 			return new Color(v, v, v);
@@ -44,7 +44,7 @@ const color_format = [
 	],
 
 	[
-		new RegExp('^#([0-9a-f]{3})$'),
+		/^#([0-9a-f]{3})$/i,
 		function (m) {
 			const s = m[1];
 			return new Color(
@@ -56,7 +56,7 @@ const color_format = [
 	],
 
 	[
-		new RegExp('^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$'),
+		/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i,
 		function (m) {
 			return new Color(
 				parseInt(m[1], 16),
@@ -71,13 +71,13 @@ const color_format = [
 function localCreateFromHexString(str) {
 	let m;
 
-	for (let idx = res.length; idx-- > 0; ) {
-		if ((m = res[idx][0].exec(str))) {
-			return res[idx][1](m);
+	for (const [formatRegex, parse] of colorFormats) {
+		if ((m = `${str}`.match(formatRegex))) {
+			return parse(m);
 		}
 	}
 
-	throw new SyntaxError('Not a valid hex color: ' + s);
+	throw new SyntaxError('Not a valid hex color: ' + str);
 }
 
 export default class Color {

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -1,4 +1,8 @@
+import Connection from '/js/connection.js';
+
 // very simple RPC system to allow server to send data to client
+
+let players;
 
 function getPlayer(idx) {
 	return players[idx];
@@ -232,30 +236,33 @@ function onPlayerScoreChanged() {
 	computeScoreDifferentials(players);
 }
 
-players.forEach(player => {
-	player.onScore = onPlayerScoreChanged;
-});
+// TODO: modularize this file better
+export default class Competition {
+	constructor(_players) {
+		players = _players;
 
-const API = new TetrisCompetitionAPI();
+		players.forEach(player => {
+			player.onScore = onPlayerScoreChanged;
+		});
 
-let connection;
+		this.API = new TetrisCompetitionAPI();
 
-try {
-	connection = new Connection(null, view_meta); // sort of gross T_T
-} catch (_err) {
-	connection = new Connection();
-}
+		try {
+			this.connection = new Connection(null, view_meta); // sort of gross T_T
+		} catch (_err) {
+			this.connection = new Connection();
+		}
 
-connection.onMessage = function (frame) {
-	try {
-		const [method, ...args] = frame;
+		this.connection.onMessage = frame => {
+			try {
+				const [method, ...args] = frame;
 
-		// urgh, API is instantiated outside of this file -_-
-		// encapsulation totally broken T_T
-		API[method](...args);
-	} catch (e) {
-		// socket.close();
-		console.error(e);
-		console.log(frame);
+				this.API[method](...args);
+			} catch (e) {
+				// socket.close();
+				console.error(e);
+				console.log(frame);
+			}
+		};
 	}
-};
+}

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -1,4 +1,5 @@
 import Connection from '/js/connection.js';
+import { TRANSITIONS } from '/views/constants.js';
 
 // very simple RPC system to allow server to send data to client
 
@@ -24,7 +25,7 @@ function getSortedPlayers(players, getter = 'getScore') {
 	});
 }
 
-function getTetrisDiff(leader, laggard, getter = 'getScore') {
+export function getTetrisDiff(leader, laggard, getter = 'getScore') {
 	const leader_score = leader[getter]();
 	const laggard_score = laggard[getter]();
 
@@ -193,8 +194,10 @@ export default class Competition {
 	constructor(_players) {
 		this.players = players = _players;
 
+		this._onPlayerScoreChanged = this._onPlayerScoreChanged.bind(this);
+
 		players.forEach(player => {
-			player.onScore = this.onPlayerScoreChanged;
+			player.onScore = this._onPlayerScoreChanged;
 		});
 
 		this.API = new TetrisCompetitionAPI();

--- a/public/views/competition_admin.html
+++ b/public/views/competition_admin.html
@@ -186,7 +186,6 @@
 		</template>
 
 		<script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/competition_admin.js"></script>
+		<script type="module" src="/views/competition_admin.js"></script>
 	</body>
 </html>

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -1,3 +1,5 @@
+import Connection from '/js/connection.js';
+
 const dom = {
 	roomid: document.querySelector('#roomid'),
 	producer_count: document.querySelector('#producer_count'),

--- a/public/views/constants.js
+++ b/public/views/constants.js
@@ -1,99 +1,110 @@
-const DOM_DEV_NULL = document.createElement('div'),
-	PIECES = ['T', 'J', 'Z', 'O', 'S', 'L', 'I'],
-	// generate colors at https://paletton.com/
+export const DOM_DEV_NULL = document.createElement('div');
 
-	LINES = {
-		1: { name: 'singles', color: '#1678FF' },
-		2: { name: 'doubles', color: '#FF9F00' },
-		3: { name: 'triples', color: '#FF00B9' },
-		4: { name: 'tetris', color: '#FFFFFF' },
-	},
-	BOARD_COLORS = {
-		floor: '#747474',
-		height: '#747474', // BBBBBB',
-		tetris_ready: '#9F5DC3',
-		clean_slope: '#53BAB2',
-		double_well: '#F8F81B',
-		drought: 'orange',
-	},
-	DAS_COLORS = {
-		absent: 'white',
-		great: 'limegreen',
-		ok: 'orange',
-		bad: 'red',
-	},
-	DAS_THRESHOLDS = {
-		0: 'bad',
-		1: 'bad',
-		2: 'bad',
-		3: 'bad',
-		4: 'bad',
-		5: 'bad',
-		6: 'bad',
-		7: 'bad',
-		8: 'bad',
-		9: 'bad',
-		10: 'ok',
-		11: 'ok',
-		12: 'ok',
-		13: 'ok',
-		14: 'ok',
-		15: 'great',
-		16: 'great',
-	},
-	DROUGHT_PANIC_THRESHOLD = 13,
-	SCORE_BASES = [0, 40, 100, 300, 1200],
-	EFF_LINE_VALUES = [0, 40, 50, 100, 300],
-	// arrays of color 1 and color 2
-	LEVEL_COLORS = [
-		['#4A32FF', '#4AAFFE'],
-		['#009600', '#6ADC00'],
-		['#B000D4', '#FF56FF'],
-		['#4A32FF', '#00E900'],
-		['#C8007F', '#00E678'],
-		['#00E678', '#968DFF'],
-		['#C41E0E', '#666666'],
-		['#8200FF', '#780041'],
-		['#4A32FF', '#C41E0E'],
-		['#C41E0E', '#F69B00'],
-	],
-	TRANSITIONS = {
-		0: 10,
-		1: 20,
-		2: 30,
-		3: 40,
-		4: 50,
-		5: 60,
-		6: 70,
-		7: 80,
-		8: 90,
-		9: 100,
-		10: 100,
-		11: 100,
-		12: 100,
-		13: 100,
-		14: 100,
-		15: 100,
-		16: 110,
-		17: 120,
-		18: 130,
-		19: 140,
-	},
-	BLOCK_PIXEL_SIZE = 3,
-	PIECE_COLORS = {
-		T: 1,
-		J: 2,
-		Z: 3,
-		O: 1,
-		S: 2,
-		L: 3,
-		I: 1,
-	},
-	RUNWAY = {
-		GAME: 0,
-		TRANSITION: 1,
-	},
-	RUNWAYS = _getRunways();
+export const PIECES = ['T', 'J', 'Z', 'O', 'S', 'L', 'I'];
+
+// generate colors at https://paletton.com/
+export const LINES = {
+	1: { name: 'singles', color: '#1678FF' },
+	2: { name: 'doubles', color: '#FF9F00' },
+	3: { name: 'triples', color: '#FF00B9' },
+	4: { name: 'tetris', color: '#FFFFFF' },
+};
+
+export const BOARD_COLORS = {
+	floor: '#747474',
+	height: '#747474', // BBBBBB',
+	tetris_ready: '#9F5DC3',
+	clean_slope: '#53BAB2',
+	double_well: '#F8F81B',
+	drought: 'orange',
+};
+
+export const DAS_COLORS = {
+	absent: 'white',
+	great: 'limegreen',
+	ok: 'orange',
+	bad: 'red',
+};
+
+export const DAS_THRESHOLDS = {
+	0: 'bad',
+	1: 'bad',
+	2: 'bad',
+	3: 'bad',
+	4: 'bad',
+	5: 'bad',
+	6: 'bad',
+	7: 'bad',
+	8: 'bad',
+	9: 'bad',
+	10: 'ok',
+	11: 'ok',
+	12: 'ok',
+	13: 'ok',
+	14: 'ok',
+	15: 'great',
+	16: 'great',
+};
+
+export const DROUGHT_PANIC_THRESHOLD = 13;
+export const SCORE_BASES = [0, 40, 100, 300, 1200];
+export const EFF_LINE_VALUES = [0, 40, 50, 100, 300];
+
+// arrays of color 1 and color 2
+export const LEVEL_COLORS = [
+	['#4A32FF', '#4AAFFE'],
+	['#009600', '#6ADC00'],
+	['#B000D4', '#FF56FF'],
+	['#4A32FF', '#00E900'],
+	['#C8007F', '#00E678'],
+	['#00E678', '#968DFF'],
+	['#C41E0E', '#666666'],
+	['#8200FF', '#780041'],
+	['#4A32FF', '#C41E0E'],
+	['#C41E0E', '#F69B00'],
+];
+
+export const TRANSITIONS = {
+	0: 10,
+	1: 20,
+	2: 30,
+	3: 40,
+	4: 50,
+	5: 60,
+	6: 70,
+	7: 80,
+	8: 90,
+	9: 100,
+	10: 100,
+	11: 100,
+	12: 100,
+	13: 100,
+	14: 100,
+	15: 100,
+	16: 110,
+	17: 120,
+	18: 130,
+	19: 140,
+};
+
+export const BLOCK_PIXEL_SIZE = 3;
+
+export const PIECE_COLORS = {
+	T: 1,
+	J: 2,
+	Z: 3,
+	O: 1,
+	S: 2,
+	L: 3,
+	I: 1,
+};
+
+export const RUNWAY = {
+	GAME: 0,
+	TRANSITION: 1,
+};
+
+export const RUNWAYS = _getRunways();
 
 DAS_THRESHOLDS[-1] = 'absent';
 
@@ -182,7 +193,7 @@ function _getRunwayForLevel(start_level, transition_lines, kill_screen_lines) {
 	};
 }
 
-function getRunway(start_level, type, lines) {
+export function getRunway(start_level, type, lines) {
 	try {
 		return RUNWAYS[start_level][type][lines] || 0;
 	} catch (err) {

--- a/public/views/gradient.js
+++ b/public/views/gradient.js
@@ -1,31 +1,32 @@
-var module_setup = function (Color, undefined) {
-	'use strict';
+import Color from './color.js';
 
-	var Gradient = function (/*variable length Color objects*/) {
-		var len = arguments.length;
+export default class Gradient {
+	constructor(/*variable length Color objects*/) {
+		const len = arguments.length;
+
 		if (len <= 1) {
 			throw new Error('A Gradient needs at least 2 colors');
 		}
 
 		// constructor assume equidistant colors
-		var divisor = len - 1;
-		var m = (this._markers = []);
-		for (var idx = 0; idx < len; idx++) {
+		const divisor = len - 1;
+		const m = (this._markers = []);
+
+		for (let idx = 0; idx < len; idx++) {
 			m.push({ val: idx / divisor, col: Color.create(arguments[idx]) });
 		}
 
 		// to prevent potential float errors, we set last entry explicitely as 1;
 		m[divisor].val = 1;
-	};
+	}
 
-	var p = Gradient.prototype;
-	p.addColor = function (val, col) {
+	addColor(val, col) {
 		// add a color, garanteeing the markers array is ordered by value
-		var m = this._markers;
+		const m = this._markers;
 		val = Math.max(0, Math.min(val, 1));
 		col = Color.create(col);
 
-		for (var idx = m.length; idx--; ) {
+		for (let idx = m.length; idx--; ) {
 			// there can be no duplicate values in the markers
 			// so if value already exists, we overwrite
 			if (val === m[idx].val) {
@@ -36,42 +37,26 @@ var module_setup = function (Color, undefined) {
 				break;
 			}
 		}
-	};
+	}
 
-	p.getColorAt = function (ratio) {
+	getColorAt(ratio) {
 		// 1. find slice where ratio falls
-		var m = this._markers;
+		const m = this._markers;
 		ratio = Math.max(0, Math.min(ratio, 1));
 
-		for (var idx = m.length; idx--; ) {
+		for (let idx = m.length; idx--; ) {
 			if (ratio === m[idx].val) {
 				return m[idx].col;
 			}
 			if (ratio > m[idx].val) {
 				// 2. normalize ratio within slice
-				var slice_ratio = (ratio - m[idx].val) / (m[idx + 1].val - m[idx].val);
+				const slice_ratio =
+					(ratio - m[idx].val) / (m[idx + 1].val - m[idx].val);
 				return m[idx].col.getMidColor(m[idx + 1].col, slice_ratio);
 			}
 		}
 
 		// should never reach here!
 		return new Color(0, 0, 0, 0);
-	};
-
-	return Gradient;
-};
-
-// ===================================================
-// Visibility control
-// ===================================================
-
-if (typeof define !== 'undefined') {
-	// AMD compatibility
-	define(['color'], module_setup);
-} else if (typeof module !== 'undefined' && module.exports) {
-	// sets up a hard dependency on color.js; providing Color class
-	module.exports = module_setup(require('./color.js'));
-} else {
-	// Assumes Color is available within same context
-	this.Gradient = module_setup(this.Color);
+	}
 }

--- a/public/views/main.js
+++ b/public/views/main.js
@@ -518,7 +518,7 @@ function reportGame(game) {
 	game.setGameOver();
 	game.reported = true;
 
-	this.getStats();
+	getStats();
 }
 
 function clearStage() {

--- a/public/views/main.js
+++ b/public/views/main.js
@@ -1,3 +1,4 @@
+import '/views/utils.js';
 import QueryString from '/js/QueryString.js';
 import Connection from '/js/connection.js';
 import DomRefs from '/views/DomRefs.js';
@@ -9,6 +10,7 @@ import {
 	LINES,
 	DAS_COLORS,
 	BOARD_COLORS,
+	PIECE_COLORS,
 	DROUGHT_PANIC_THRESHOLD,
 	DAS_THRESHOLDS,
 	BLOCK_PIXEL_SIZE,

--- a/public/views/main.js
+++ b/public/views/main.js
@@ -1,3 +1,19 @@
+import QueryString from '/js/QueryString.js';
+import Connection from '/js/connection.js';
+import DomRefs from '/views/DomRefs.js';
+import renderBlock from '/views/renderBlock.js';
+import Game from '/views/Game.js';
+
+import {
+	PIECES,
+	LINES,
+	DAS_COLORS,
+	BOARD_COLORS,
+	DROUGHT_PANIC_THRESHOLD,
+	DAS_THRESHOLDS,
+	BLOCK_PIXEL_SIZE,
+} from '/views/constants.js';
+
 const dom = new DomRefs(document);
 
 // initial setup for colors based con constants.js

--- a/public/views/mp/compact2to4.html
+++ b/public/views/mp/compact2to4.html
@@ -189,10 +189,9 @@
 		<!-- Audio -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import QueryString from '/js/QueryString.js';
-			import Connection from '/js/connection.js';
 			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
 			import Competition from '/views/competition.js';
 

--- a/public/views/mp/compact2to4.html
+++ b/public/views/mp/compact2to4.html
@@ -188,20 +188,14 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import QueryString from '/js/QueryString.js';
+			import Connection from '/js/connection.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const TEMPLATE_WIDTH = 1280;
 			const PLAYER_WIDTH = 320;
 			const players_node = document.querySelector('#players');
@@ -278,10 +272,11 @@
 				}
 			}
 
-			for (idx = 0; idx < num_players; idx++) {
+			for (let idx = num_players; idx--; ) {
 				addPlayer();
 			}
+
+			const competition = new Competition(players);
 		</script>
-		<script src="/views/competition.js"></script>
 	</body>
 </html>

--- a/public/views/mp/ctg21.html
+++ b/public/views/mp/ctg21.html
@@ -306,20 +306,13 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import QueryString from '/js/QueryString.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			function easeInOutBack(t, b, c, d, s) {
 				if (s == undefined) s = 1.70158;
 				if ((t /= d / 2) < 1)
@@ -456,7 +449,8 @@
 
 				return player;
 			});
+
+			const competition = new Competition(players);
 		</script>
-		<script src="/views/competition.js"></script>
 	</body>
 </html>

--- a/public/views/mp/ctg21.html
+++ b/public/views/mp/ctg21.html
@@ -307,7 +307,7 @@
 		<!-- Audio -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import QueryString from '/js/QueryString.js';
 			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';

--- a/public/views/mp/ctg21_2matches.html
+++ b/public/views/mp/ctg21_2matches.html
@@ -349,7 +349,7 @@
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
 			import Competition from '/views/competition.js';

--- a/public/views/mp/ctg21_2matches.html
+++ b/public/views/mp/ctg21_2matches.html
@@ -567,24 +567,28 @@
 				peer.on('call', call => {
 					console.log(`Received media call from ${call.peer}`);
 
-					const players = competition.getPlayersByPeerId(call.peer);
+					if (!competition.getPlayersByPeerId(call.peer).length) return;
 
-					if (players.length) {
-						call.answer();
+					call.on('stream', remoteStream => {
+						competition
+							.getPlayersByPeerId(call.peer) // rechecking because async!
+							.forEach(player => {
+								const video = player.dom.video;
 
-						call.on('stream', remoteStream => {
-							competition
-								.getPlayersByPeerId(call.peer) // rechecking because async!
-								.forEach(player => {
-									const video = player.dom.video;
-
-									video.srcObject = remoteStream;
-									video.addEventListener('loadedmetadata', video.play, {
+								video.srcObject = remoteStream;
+								video.addEventListener(
+									'loadedmetadata',
+									() => {
+										video.play();
+									},
+									{
 										once: true,
-									});
-								});
-						});
-					}
+									}
+								);
+							});
+					});
+
+					call.answer();
 				});
 			};
 		</script>

--- a/public/views/mp/ctg21_2matches.html
+++ b/public/views/mp/ctg21_2matches.html
@@ -348,20 +348,12 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			function easeInOutBack(t, b, c, d, s) {
 				if (s == undefined) s = 1.70158;
 				if ((t /= d / 2) < 1)
@@ -491,20 +483,25 @@
 					players.push(player);
 				});
 			});
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
+
+			const competition = new Competition(players);
+
+			// ========================================
+			// code to below to update competition behaviour to handle 2 independent matches
+
 			let is_secondary = false;
 			let peer = null;
 
-			API.setSecondary = function () {
+			competition.API.setSecondary = function () {
 				if (peer) {
 					peer.destroy();
 					peer = null;
 				}
+
+				is_secondary = true;
 			};
 
-			API.setMatch = function (match_idx) {
+			competition.API.setMatch = function (match_idx) {
 				if (match_idx !== 0 && match_idx !== 1) {
 					document.querySelectorAll('.match').forEach(match_node => {
 						match_node.classList.add('small');
@@ -529,13 +526,13 @@
 				show_match.hidden = false;
 			};
 
-			API.showProfileCard = function (visible, match_idx) {
+			competition.API.showProfileCard = function (visible, match_idx) {
 				players
 					.slice(2 * match_idx, 2 * match_idx + 2)
 					.forEach(player => player.showProfileCard(visible));
 			};
 
-			API.setWinner = function (player_idx) {
+			competition.API.setWinner = function (player_idx) {
 				const match_index = player_idx < 2 ? 0 : 1;
 
 				players
@@ -553,11 +550,11 @@
 						2 * match_index + 2
 					);
 
-					computeScoreDifferentials(match_players);
+					competition.computeScoreDifferentials(match_players);
 				};
 			});
 
-			connection.onInit = () => {
+			competition.connection.onInit = () => {
 				if (is_secondary) return;
 
 				if (peer) {
@@ -565,35 +562,27 @@
 					peer = null;
 				}
 
-				peer = new Peer(connection.id);
+				peer = new Peer(competition.connection.id);
 
 				peer.on('call', call => {
 					console.log(`Received media call from ${call.peer}`);
 
-					const player_idx = getPlayerIndexByPeerId(call.peer);
+					const players = competition.getPlayersByPeerId(call.peer);
 
-					if (player_idx > -1) {
-						// at least one match
-
+					if (players.length) {
 						call.answer();
 
 						call.on('stream', remoteStream => {
-							players.forEach((player, player_idx) => {
-								console.log(player_idx, player.peerid, call.peer);
+							competition
+								.getPlayersByPeerId(call.peer) // rechecking because async!
+								.forEach(player => {
+									const video = player.dom.video;
 
-								if (player.peerid != call.peer) return;
-
-								const video = player.dom.video;
-
-								video.srcObject = remoteStream;
-								video.addEventListener(
-									'loadedmetadata',
-									() => {
-										video.play();
-									},
-									{ once: true }
-								);
-							});
+									video.srcObject = remoteStream;
+									video.addEventListener('loadedmetadata', video.play, {
+										once: true,
+									});
+								});
 						});
 					}
 				});

--- a/public/views/mp/ctjc.html
+++ b/public/views/mp/ctjc.html
@@ -106,7 +106,7 @@
 		<!-- End Stream BG -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import Player from '/views/Player.js';
 			import Competition from '/views/competition.js';

--- a/public/views/mp/ctjc.html
+++ b/public/views/mp/ctjc.html
@@ -109,7 +109,7 @@
 			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import Player from '/views/Player.js';
-			import Competition from '/views/competition.js';
+			import Competition, { getTetrisDiff } from '/views/competition.js';
 
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(

--- a/public/views/mp/ctjc.html
+++ b/public/views/mp/ctjc.html
@@ -105,16 +105,12 @@
 		</div>
 		<!-- End Stream BG -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import Player from '/views/Player.js';
+			import Competition from '/views/competition.js';
+
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(
 				num =>
@@ -159,14 +155,14 @@
 					player.drought_box.classList.remove('active');
 				};
 			});
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
-			API.setLogo = function (url) {
+
+			const competition = new Competition(players);
+
+			competition.API.setLogo = function (url) {
 				document.querySelector(`#logo`).style.backgroundImage = `url(${url})`;
 			};
 
-			function computeScoreDifferentials() {
+			competition.computeScoreDifferentials = function () {
 				const score_p1 = players[0].getScore(),
 					score_p2 = players[1].getScore();
 
@@ -204,7 +200,7 @@
 						tdiff_elem.textContent = `${tfmt}T>`;
 					}
 				}
-			}
+			};
 		</script>
 	</body>
 </html>

--- a/public/views/mp/ctjc_pace.html
+++ b/public/views/mp/ctjc_pace.html
@@ -99,16 +99,12 @@
 		</div>
 		<!-- End Stream BG -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import Player from '/views/Player.js';
+			import Competition from '/views/competition.js';
+
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(
 				num =>
@@ -153,14 +149,14 @@
 					player.drought_box.classList.remove('active');
 				};
 			});
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
-			API.setLogo = function (url) {
+
+			const competition = new Competition(players);
+
+			competition.API.setLogo = function (url) {
 				document.querySelector(`#logo`).style.backgroundImage = `url(${url})`;
 			};
 
-			function computeScoreDifferentials() {
+			competition.computeScoreDifferentials = function () {
 				const score_p1 = players[0].getScore(),
 					score_p2 = players[1].getScore();
 
@@ -232,7 +228,7 @@
 						tdiff_elem.textContent = `${tfmt}T>`;
 					}
 				}
-			}
+			};
 		</script>
 	</body>
 </html>

--- a/public/views/mp/ctjc_pace.html
+++ b/public/views/mp/ctjc_pace.html
@@ -100,7 +100,7 @@
 		<!-- End Stream BG -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import Player from '/views/Player.js';
 			import Competition from '/views/competition.js';

--- a/public/views/mp/ctjc_pace.html
+++ b/public/views/mp/ctjc_pace.html
@@ -103,7 +103,7 @@
 			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import Player from '/views/Player.js';
-			import Competition from '/views/competition.js';
+			import Competition, { getTetrisDiff } from '/views/competition.js';
 
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(
@@ -208,7 +208,7 @@
 				} else {
 					const player1_leading = diff > 0;
 					const abs_diff = Math.abs(diff);
-					const fmt = player.options.format_score(abs_diff);
+					const fmt = players[0].options.format_score(abs_diff);
 
 					let tdiff;
 
@@ -218,7 +218,7 @@
 						tdiff = getTetrisDiff(players[1], players[0], 'getGameRunwayScore');
 					}
 
-					const tfmt = player.options.format_tetris_diff(tdiff);
+					const tfmt = tdiff > 100 ? Math.round(tdiff) : tdiff.toFixed(1);
 
 					if (player1_leading) {
 						diff_elem.textContent = `<${fmt}`;

--- a/public/views/mp/ctm.html
+++ b/public/views/mp/ctm.html
@@ -137,7 +137,7 @@
 		<!-- Audio -->
 
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
 			import Competition from '/views/competition.js';

--- a/public/views/mp/ctm.html
+++ b/public/views/mp/ctm.html
@@ -136,20 +136,12 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const players = [1, 2].map(
 				num =>
 					new CTMCompetitionPlayer(
@@ -195,7 +187,8 @@
 						}
 					)
 			);
+
+			const competition = new Competition(players);
 		</script>
-		<script src="/views/competition.js"></script>
 	</body>
 </html>

--- a/public/views/mp/ctm_2matches.html
+++ b/public/views/mp/ctm_2matches.html
@@ -233,20 +233,12 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const players = [];
 
 			[1, 2].forEach(match_num => {
@@ -306,20 +298,20 @@
 					players.push(player);
 				});
 			});
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
+
+			const competition = new Competition(players);
+
 			let is_secondary = false;
 			let peer = null;
 
-			API.setSecondary = function () {
+			competition.API.setSecondary = function () {
 				if (peer) {
 					peer.destroy();
 					peer = null;
 				}
 			};
 
-			API.setMatch = function (match_idx) {
+			competition.API.setMatch = function (match_idx) {
 				if (match_idx !== 0 && match_idx !== 1) {
 					document.querySelectorAll('.match').forEach(match_node => {
 						match_node.classList.add('small');
@@ -344,13 +336,13 @@
 				show_match.hidden = false;
 			};
 
-			API.showProfileCard = function (visible, match_idx) {
+			competition.API.showProfileCard = function (visible, match_idx) {
 				players
 					.slice(2 * match_idx, 2 * match_idx + 2)
 					.forEach(player => player.showProfileCard(visible));
 			};
 
-			API.setWinner = function (player_idx) {
+			competition.API.setWinner = function (player_idx) {
 				const match_index = player_idx < 2 ? 0 : 1;
 
 				players
@@ -368,11 +360,11 @@
 						2 * match_index + 2
 					);
 
-					computeScoreDifferentials(match_players);
+					competition.computeScoreDifferentials(match_players);
 				};
 			});
 
-			connection.onInit = () => {
+			competition.connection.onInit = () => {
 				if (is_secondary) return;
 
 				if (peer) {
@@ -380,35 +372,27 @@
 					peer = null;
 				}
 
-				peer = new Peer(connection.id);
+				peer = new Peer(competition.connection.id);
 
 				peer.on('call', call => {
 					console.log(`Received media call from ${call.peer}`);
 
-					const player_idx = getPlayerIndexByPeerId(call.peer);
+					const players = competition.getPlayersByPeerId(call.peer);
 
-					if (player_idx > -1) {
-						// at least one match
-
+					if (players.length) {
 						call.answer();
 
 						call.on('stream', remoteStream => {
-							players.forEach((player, player_idx) => {
-								console.log(player_idx, player.peerid, call.peer);
+							competition
+								.getPlayersByPeerId(call.peer) // rechecking because async!
+								.forEach(player => {
+									const video = player.dom.video;
 
-								if (player.peerid != call.peer) return;
-
-								const video = player.dom.video;
-
-								video.srcObject = remoteStream;
-								video.addEventListener(
-									'loadedmetadata',
-									() => {
-										video.play();
-									},
-									{ once: true }
-								);
-							});
+									video.srcObject = remoteStream;
+									video.addEventListener('loadedmetadata', video.play, {
+										once: true,
+									});
+								});
 						});
 					}
 				});

--- a/public/views/mp/ctm_2matches.html
+++ b/public/views/mp/ctm_2matches.html
@@ -377,24 +377,22 @@
 				peer.on('call', call => {
 					console.log(`Received media call from ${call.peer}`);
 
-					const players = competition.getPlayersByPeerId(call.peer);
+					if (!competition.getPlayersByPeerId(call.peer).length) return;
 
-					if (players.length) {
-						call.answer();
+					call.on('stream', remoteStream => {
+						competition
+							.getPlayersByPeerId(call.peer) // rechecking because async!
+							.forEach(player => {
+								const video = player.dom.video;
 
-						call.on('stream', remoteStream => {
-							competition
-								.getPlayersByPeerId(call.peer) // rechecking because async!
-								.forEach(player => {
-									const video = player.dom.video;
-
-									video.srcObject = remoteStream;
-									video.addEventListener('loadedmetadata', video.play, {
-										once: true,
-									});
+								video.srcObject = remoteStream;
+								video.addEventListener('loadedmetadata', video.play, {
+									once: true,
 								});
-						});
-					}
+							});
+					});
+
+					call.answer();
 				});
 			};
 		</script>

--- a/public/views/mp/ctm_2matches.html
+++ b/public/views/mp/ctm_2matches.html
@@ -234,7 +234,7 @@
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
 			import Competition from '/views/competition.js';

--- a/public/views/mp/ctm_video.html
+++ b/public/views/mp/ctm_video.html
@@ -234,24 +234,15 @@
 				peer = new Peer(competition.connection.id);
 
 				peer.on('call', call => {
-					querySelector;
 					console.log(`Received media call from ${call.peer}`);
 
-					const player_idx = competition.getPlayerIndexByPeerId(call.peer);
+					if (!competition.getPlayersByPeerId(call.peer).length) return;
 
-					if (player_idx > -1) {
-						// at least one match
-
-						call.answer();
-
-						call.on('stream', remoteStream => {
-							players.forEach((player, player_idx) => {
-								console.log(player_idx, player.peerid, call.peer);
-
-								if (player.peerid != call.peer) return;
-
-								const player_num = player_idx + 1;
-								const video = document.querySelector(`video.p${player_num}`);
+					call.on('stream', remoteStream => {
+						competition
+							.getPlayersByPeerId(call.peer) // rechecking because async!
+							.forEach(player => {
+								const video = player.dom.video;
 
 								video.srcObject = remoteStream;
 								video.addEventListener(
@@ -259,11 +250,14 @@
 									() => {
 										video.play();
 									},
-									{ once: true }
+									{
+										once: true,
+									}
 								);
 							});
-						});
-					}
+					});
+
+					call.answer();
 				});
 			};
 		</script>

--- a/public/views/mp/ctm_video.html
+++ b/public/views/mp/ctm_video.html
@@ -159,7 +159,7 @@
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
 		<script type="module">
-			import bg from '/views/bg.js';
+			import '/views/bg.js';
 			import { translate } from '/views/utils.js';
 			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
 			import Competition from '/views/competition.js';

--- a/public/views/mp/ctm_video.html
+++ b/public/views/mp/ctm_video.html
@@ -158,20 +158,12 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import bg from '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const players = [1, 2].map(
 				num =>
 					new CTMCompetitionPlayer(
@@ -218,20 +210,20 @@
 						}
 					)
 			);
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
+
+			const competition = new Competition(players);
+
 			let is_secondary = false;
 			let peer = null;
 
-			API.setSecondary = function () {
+			competition.API.setSecondary = function () {
 				if (peer) {
 					peer.destroy();
 					peer = null;
 				}
 			};
 
-			connection.onInit = () => {
+			competition.connection.onInit = () => {
 				if (is_secondary) return;
 
 				if (peer) {
@@ -239,12 +231,13 @@
 					peer = null;
 				}
 
-				peer = new Peer(connection.id);
+				peer = new Peer(competition.connection.id);
 
 				peer.on('call', call => {
+					querySelector;
 					console.log(`Received media call from ${call.peer}`);
 
-					const player_idx = getPlayerIndexByPeerId(call.peer);
+					const player_idx = competition.getPlayerIndexByPeerId(call.peer);
 
 					if (player_idx > -1) {
 						// at least one match

--- a/public/views/mp/ctwc.html
+++ b/public/views/mp/ctwc.html
@@ -231,21 +231,13 @@
 
 		<!-- Audio -->
 
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import QueryString from '/js/QueryString.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(num => {
 				const player = new CTMCompetitionPlayer(
@@ -275,7 +267,8 @@
 
 				return player;
 			});
+
+			const competition = new Competition(players);
 		</script>
-		<script src="/views/competition.js"></script>
 	</body>
 </html>

--- a/public/views/mp/garage.html
+++ b/public/views/mp/garage.html
@@ -326,6 +326,8 @@
 						drought_box: document.querySelector(`.drought.p${num}`),
 						runway_tr_box: document.querySelector(`.runway.transition.p${num}`),
 						runway_box: document.querySelector(`.runway.game.p${num}`),
+
+						video: document.querySelector(`.player_vid.p${num}`),
 					},
 					{
 						preview_pixel_size: 2,

--- a/public/views/mp/garage.html
+++ b/public/views/mp/garage.html
@@ -289,21 +289,14 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		z
+		<script type="module">
+			import '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import QueryString from '/js/QueryString.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(num => {
 				const player = new CTMCompetitionPlayer(
@@ -361,14 +354,14 @@
 
 				return player;
 			});
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
+
+			const competition = new Competition(players);
+
 			if (QueryString.get('video') === '1') {
 				let is_secondary = false;
 				let peer = null;
 
-				API.setSecondary = function () {
+				competition.API.setSecondary = function () {
 					if (peer) {
 						peer.destroy();
 						peer = null;
@@ -377,7 +370,7 @@
 					is_secondary = true;
 				};
 
-				connection.onInit = () => {
+				competition.connection.onInit = () => {
 					if (is_secondary) return;
 
 					if (peer) {
@@ -385,28 +378,18 @@
 						peer = null;
 					}
 
-					peer = new Peer(connection.id);
+					peer = new Peer(competition.connection.id);
 
 					peer.on('call', call => {
-						if (is_secondary) return;
-
 						console.log(`Received media call from ${call.peer}`);
 
-						const player_idx = getPlayerIndexByPeerId(call.peer);
+						if (!competition.getPlayersByPeerId(call.peer).length) return;
 
-						if (player_idx > -1) {
-							// at least one match
-
-							call.answer();
-
-							call.on('stream', remoteStream => {
-								players.forEach((player, player_idx) => {
-									console.log(player_idx, player.peerid, call.peer);
-
-									if (player.peerid != call.peer) return;
-
-									const player_num = player_idx + 1;
-									const video = document.querySelector(`video.p${player_num}`);
+						call.on('stream', remoteStream => {
+							competition
+								.getPlayersByPeerId(call.peer) // rechecking because async!
+								.forEach(player => {
+									const video = player.dom.video;
 
 									video.srcObject = remoteStream;
 									video.addEventListener(
@@ -414,11 +397,14 @@
 										() => {
 											video.play();
 										},
-										{ once: true }
+										{
+											once: true,
+										}
 									);
 								});
-							});
-						}
+						});
+
+						call.answer();
 					});
 				};
 			}

--- a/public/views/mp/garage2.html
+++ b/public/views/mp/garage2.html
@@ -292,21 +292,13 @@
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.3.2/dist/peerjs.min.js"></script>
-		<script src="/js/QueryString.js"></script>
-		<script src="/views/color.js"></script>
-		<script src="/views/gradient.js"></script>
-		<script src="/views/constants.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/bg.js"></script>
-		<script src="/views/utils.js"></script>
-		<script src="/views/renderBlock.js"></script>
-		<script src="/views/FrameBuffer.js"></script>
-		<script src="/views/Player.js"></script>
-		<script src="/js/connection.js"></script>
-		<script src="/views/CompetitionPlayer.js"></script>
-		<script src="/views/CTMCompetitionPlayer.js"></script>
-		<script src="/js/BinaryFrame.js"></script>
-		<script>
+		<script type="module">
+			import '/views/bg.js';
+			import { translate } from '/views/utils.js';
+			import QueryString from '/js/QueryString.js';
+			import CTMCompetitionPlayer from '/views/CTMCompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+
 			const numberFormatter = new Intl.NumberFormat();
 			const players = [1, 2].map(num => {
 				const player = new CTMCompetitionPlayer(
@@ -364,14 +356,14 @@
 
 				return player;
 			});
-		</script>
-		<script src="/views/competition.js"></script>
-		<script>
+
+			const competition = new Competition(players);
+
 			if (QueryString.get('video') === '1') {
 				let is_secondary = false;
 				let peer = null;
 
-				API.setSecondary = function () {
+				competition.API.setSecondary = function () {
 					if (peer) {
 						peer.destroy();
 						peer = null;
@@ -380,7 +372,7 @@
 					is_secondary = true;
 				};
 
-				connection.onInit = () => {
+				competition.connection.onInit = () => {
 					if (is_secondary) return;
 
 					if (peer) {
@@ -388,40 +380,31 @@
 						peer = null;
 					}
 
-					peer = new Peer(connection.id);
+					peer = new Peer(competition.connection.id);
 
 					peer.on('call', call => {
 						if (is_secondary) return;
 
 						console.log(`Received media call from ${call.peer}`);
 
-						const player_idx = getPlayerIndexByPeerId(call.peer);
+						if (!competition.getPlayersByPeerId(call.peer).length) return;
 
-						if (player_idx > -1) {
-							// at least one match
+						call.answer();
+						call.on('stream', remoteStream => {
+							competition.getPlayersByPeerId(call.peer).forEach(player => {
+								const player_num = player_idx + 1;
+								const video = document.querySelector(`video.p${player_num}`);
 
-							call.answer();
-
-							call.on('stream', remoteStream => {
-								players.forEach((player, player_idx) => {
-									console.log(player_idx, player.peerid, call.peer);
-
-									if (player.peerid != call.peer) return;
-
-									const player_num = player_idx + 1;
-									const video = document.querySelector(`video.p${player_num}`);
-
-									video.srcObject = remoteStream;
-									video.addEventListener(
-										'loadedmetadata',
-										() => {
-											video.play();
-										},
-										{ once: true }
-									);
-								});
+								video.srcObject = remoteStream;
+								video.addEventListener(
+									'loadedmetadata',
+									() => {
+										video.play();
+									},
+									{ once: true }
+								);
 							});
-						}
+						});
 					});
 				};
 			}

--- a/public/views/mp/garage2.html
+++ b/public/views/mp/garage2.html
@@ -328,6 +328,7 @@
 						drought_box: document.querySelector(`.drought.p${num}`),
 						runway_tr_box: document.querySelector(`.runway.transition.p${num}`),
 						runway_box: document.querySelector(`.runway.game.p${num}`),
+						video: document.querySelector(`.player_vid.p${num}`),
 					},
 					{
 						preview_pixel_size: 2,
@@ -392,8 +393,7 @@
 						call.answer();
 						call.on('stream', remoteStream => {
 							competition.getPlayersByPeerId(call.peer).forEach(player => {
-								const player_num = player_idx + 1;
-								const video = document.querySelector(`video.p${player_num}`);
+								const video = player.dom.video;
 
 								video.srcObject = remoteStream;
 								video.addEventListener(

--- a/public/views/renderBlock.js
+++ b/public/views/renderBlock.js
@@ -1,3 +1,5 @@
+import { LEVEL_COLORS } from '/views/constants.js';
+
 export default function renderBlock(
 	level,
 	block_index,

--- a/public/views/renderBlock.js
+++ b/public/views/renderBlock.js
@@ -1,4 +1,4 @@
-function renderBlock(
+export default function renderBlock(
 	level,
 	block_index,
 	pixel_size,

--- a/public/views/utils.js
+++ b/public/views/utils.js
@@ -13,24 +13,24 @@ if (!CanvasRenderingContext2D.prototype.clear) {
 	};
 }
 
-function getPercent(ratio) {
+export function getPercent(ratio) {
 	const percent = Math.round(ratio * 100);
 
 	return percent >= 100 ? '100' : percent.toString().padStart(2, '0') + '%';
 }
 
-function css_size(css_pixel_width) {
+export function css_size(css_pixel_width) {
 	return parseInt(css_pixel_width.replace(/px$/, ''), 10);
 }
 
-function peek(arr, offset) {
+export function peek(arr, offset) {
 	if (offset === undefined) offset = 0;
 
 	return arr[arr.length - (offset + 1)];
 }
 
 // see https://stackoverflow.com/a/12646864/361295
-function shuffle(array) {
+export function shuffle(array) {
 	for (let i = array.length - 1; i > 0; i--) {
 		const j = Math.floor(Math.random() * (i + 1));
 		[array[i], array[j]] = [array[j], array[i]];
@@ -39,13 +39,13 @@ function shuffle(array) {
 	return array;
 }
 
-function clamp(val, min, max) {
+export function clamp(val, min, max) {
 	if (val < min) return min;
 	if (val > max) return max;
 	return val;
 }
 
-function translate(iRange, oRange, value) {
+export function translate(iRange, oRange, value) {
 	// not adding validation of ranges and value... Assume callers have done it
 	ratio = (value - iRange[0]) / (iRange[1] - iRange[0]);
 	return oRange[0] + ratio * (oRange[1] - oRange[0]);

--- a/public/views/utils.js
+++ b/public/views/utils.js
@@ -47,6 +47,6 @@ export function clamp(val, min, max) {
 
 export function translate(iRange, oRange, value) {
 	// not adding validation of ranges and value... Assume callers have done it
-	ratio = (value - iRange[0]) / (iRange[1] - iRange[0]);
+	const ratio = (value - iRange[0]) / (iRange[1] - iRange[0]);
 	return oRange[0] + ratio * (oRange[1] - oRange[0]);
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,8 +1,8 @@
-const express = require('express');
-const ULID = require('ulid');
-const got = require('got');
+import express from 'express';
+import ULID from 'ulid';
+import got from 'got';
 
-const UserDAO = require('../daos/UserDAO');
+import UserDAO from '../daos/UserDAO.js';
 
 const router = express.Router();
 
@@ -133,4 +133,4 @@ router.get('/twitch/callback', async (req, res) => {
 	}
 });
 
-module.exports = router;
+export default router;

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -22,7 +22,7 @@ router.get(
 	middlewares.checkToken,
 	(req, res) => {
 		res.sendFile(
-			path.join(__dirname, '../public/views/competition_admin.html')
+			path.join(path.resolve(), 'public/views/competition_admin.html')
 		);
 	}
 );
@@ -40,7 +40,7 @@ router.get(
 		}
 
 		res.sendFile(
-			path.join(__dirname, '../public/views/competition_admin.html')
+			path.join(path.resolve(), 'public/views/competition_admin.html')
 		);
 	}
 );
@@ -50,7 +50,7 @@ router.get(
 	middlewares.assertSession,
 	middlewares.checkToken,
 	(req, res) => {
-		res.sendFile(path.join(__dirname, '../public/ocr/ocr.html'));
+		res.sendFile(path.join(path.resolve(), 'public/ocr/ocr.html'));
 	}
 );
 
@@ -66,7 +66,7 @@ router.get(
 			return;
 		}
 
-		res.sendFile(path.join(__dirname, '../public/ocr/ocr.html'));
+		res.sendFile(path.join(path.resolve(), 'public/ocr/ocr.html'));
 	}
 );
 
@@ -91,7 +91,10 @@ router.get(
 		}
 
 		res.sendFile(
-			path.join(__dirname, `../public/views/${layout.type}/${layout.file}.html`)
+			path.join(
+				path.resolve(),
+				`public/views/${layout.type}/${layout.file}.html`
+			)
 		);
 	}
 );
@@ -151,7 +154,7 @@ router.get('/view/:layout/:secret', (req, res) => {
 	}
 
 	res.sendFile(
-		path.join(__dirname, `../public/views/${layout.type}/${layout.file}.html`)
+		path.join(path.resolve(), `public/views/${layout.type}/${layout.file}.html`)
 	);
 });
 
@@ -164,7 +167,7 @@ router.get('/replay/:layout/:gamedef', (req, res) => {
 	}
 
 	res.sendFile(
-		path.join(__dirname, `../public/views/${layout.type}/${layout.file}.html`)
+		path.join(path.resolve(), `public/views/${layout.type}/${layout.file}.html`)
 	);
 });
 

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -1,11 +1,12 @@
-const path = require('path');
-const express = require('express');
-const router = express.Router();
+import path from 'path';
+import express from 'express';
 
-const middlewares = require('../modules/middlewares');
-const layouts = require('../modules/layouts');
-const UserDAO = require('../daos/UserDAO');
-const ScoreDAO = require('../daos/ScoreDAO');
+import middlewares from '../modules/middlewares.js';
+import layouts from '../modules/layouts.js';
+import UserDAO from '../daos/UserDAO.js';
+import ScoreDAO from '../daos/ScoreDAO.js';
+
+const router = express.Router();
 
 router.get('/debug/session', (req, res) => {
 	res.send(JSON.stringify(req.session));
@@ -167,4 +168,4 @@ router.get('/replay/:layout/:gamedef', (req, res) => {
 	);
 });
 
-module.exports = router;
+export default router;

--- a/routes/score.js
+++ b/routes/score.js
@@ -1,11 +1,10 @@
-const express = require('express');
+import express from 'express';
+import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import middlewares from '../modules/middlewares.js';
+import UserDAO from '../daos/UserDAO.js';
+import ScoreDAO from '../daos/ScoreDAO.js';
+
 const router = express.Router();
-
-const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
-
-const middlewares = require('../modules/middlewares');
-const UserDAO = require('../daos/UserDAO');
-const ScoreDAO = require('../daos/ScoreDAO');
 
 router.get('/get_stats/:secret', async (req, res) => {
 	const user = await UserDAO.getUserBySecret(req.params.secret);
@@ -361,4 +360,4 @@ router.get(
 	}
 );
 
-module.exports = router;
+export default router;

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -1,16 +1,16 @@
-const express = require('express');
-const router = express.Router();
-const ULID = require('ulid');
-const nocache = require('nocache');
-const _ = require('lodash');
+import express from 'express';
+import ULID from 'ulid';
+import nocache from 'nocache';
+import _ from 'lodash';
 
-const middlewares = require('../modules/middlewares');
-const UserDAO = require('../daos/UserDAO');
-const ScoreDAO = require('../daos/ScoreDAO');
+import middlewares from '../modules/middlewares.js';
+import UserDAO from '../daos/UserDAO.js';
+import ScoreDAO from '../daos/ScoreDAO.js';
+import timezones from '../modules/timezones.js';
 
 // Country Management
 
-const { overwrite, getData } = require('country-list');
+import { overwrite, getData } from 'country-list';
 
 overwrite([
 	{
@@ -24,7 +24,8 @@ overwrite([
 ]);
 
 const countries = getData().sort((a, b) => (a.name < b.name ? -1 : 1)); // Sort by country name
-const timezones = require('../modules/timezones');
+
+const router = express.Router();
 
 router.use(middlewares.assertSession);
 router.use(middlewares.checkToken);
@@ -197,4 +198,4 @@ router.post('/set_pb', express.json(), async (req, res) => {
 	res.status(400).json({ errors: ['Bad Request'] });
 });
 
-module.exports = router;
+export default router;

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -1,10 +1,10 @@
-const middlewares = require('../modules/middlewares');
-const layouts = require('../modules/layouts');
-const UserDAO = require('../daos/UserDAO');
-const Replay = require('../domains/Replay');
-const Connection = require('../modules/Connection');
+import middlewares from '../modules/middlewares.js';
+import layouts from '../modules/layouts.js';
+import UserDAO from '../daos/UserDAO.js';
+import Replay from '../domains/Replay.js';
+import Connection from '../modules/Connection.js';
 
-module.exports = function init(server, wss) {
+export default function init(server, wss) {
 	server.on('upgrade', async function (request, socket, head) {
 		console.log(`WS: ${request.url}`);
 
@@ -308,4 +308,4 @@ module.exports = function init(server, wss) {
 			connection.kick('invalid_url');
 		}
 	});
-};
+}

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
-const WebSocket = require('ws');
+import WebSocket from 'ws';
+import app from './modules/app.js';
+import { Server } from 'http';
 
-const app = require('./modules/app');
-
-const server = require('http').Server(app);
+const server = Server(app);
 const wss = new WebSocket.Server({
 	clientTracking: false,
 	noServer: true,

--- a/server.js
+++ b/server.js
@@ -1,13 +1,16 @@
-import WebSocket from 'ws';
-import app from './modules/app.js';
+import WebSocket, { WebSocketServer } from 'ws';
 import { Server } from 'http';
 
+import app from './modules/app.js';
+
 const server = Server(app);
-const wss = new WebSocket.Server({
+const wss = new WebSocketServer({
 	clientTracking: false,
 	noServer: true,
 });
 
-require('./routes/websocket.js')(server, wss);
+import websocketInitializer from './routes/websocket.js';
+
+websocketInitializer(server, wss);
 
 server.listen(process.env.PORT || 5000);

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-import WebSocket, { WebSocketServer } from 'ws';
+import { WebSocketServer } from 'ws';
 import { Server } from 'http';
 
 import app from './modules/app.js';


### PR DESCRIPTION
Decided to upgrade to all dependencies, and the latest [got](https://www.npmjs.com/package/got) is now [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) only so I figured I'd take the plunge. 

ESM has been natively supported on chrome and firefox for a while, so there's no difference in browser support. 

My code was already mostly modularized, but it was putting stuff all over the global scope, so it took some effort to move everything to ESM properly. There will likely still be breakages in there that I will fix as I go.

I would have liked to move just the frontend, but because the module `BinaryFrame` is shared with frontend and backend, I decided to big bang update everything.

Because most of my module files were using functions for provate scope, relying on modules instead meant changing the indentations. The changeset is mostly whitespace and so it helps to read the [PR with whitespace ignored](https://github.com/timotheeg/nestrischamps/pull/106/files?w=1).