### PR TITLE
feat: add ability to tune brightness and contrast

### DIFF
--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -130,6 +130,8 @@ export default class TetrisOCR extends EventTarget {
 			w: bounds.right - bounds.left,
 			h: bounds.bottom - bounds.top,
 		};
+
+		this.updateCaptureContextFilters();
 	}
 
 	fixPalette() {
@@ -178,6 +180,28 @@ export default class TetrisOCR extends EventTarget {
 		return min_idx;
 	}
 
+	updateCaptureContextFilters() {
+		if (!this.capture_canvas_ctx) return;
+		if (!this.config) return;
+
+		const filters = [];
+
+		if (this.config.brightness > 1) {
+			filters.push(`brightness(${this.config.brightness})`);
+		}
+
+		if (this.config.contrast !== 1) {
+			filters.push(`contrast(${this.config.contrast})`);
+		}
+
+		if (filters.length) {
+			this.capture_canvas_ctx.filter = filters.join(' ');
+		} else {
+			this.capture_canvas_ctx.filter = null;
+			delete this.capture_canvas_ctx.filter;
+		}
+	}
+
 	initCaptureContext(frame, half_height) {
 		this.capture_canvas = document.createElement('canvas');
 
@@ -203,6 +227,8 @@ export default class TetrisOCR extends EventTarget {
 		});
 		this.scaled_field_canvas_ctx.imageSmoothingEnabled = true;
 		this.scaled_field_canvas_ctx.imageSmoothingQuality = 'medium';
+
+		this.updateCaptureContextFilters();
 	}
 
 	async processFrame(frame, half_height) {

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -197,6 +197,19 @@
 					</select>
 				</div>
 
+				<div id="image_corrections">
+					<div class="brightness">
+						Brightness:
+						<input type="range" min="1" max="3" step="0.05" value="1" />
+						<span>1</span> <a href="#">Reset</a>
+					</div>
+					<div class="contrast">
+						Contrast:
+						<input type="range" min="0" max="2" step="0.05" value="1" />
+						<span>1</span> <a href="#">Reset</a>
+					</div>
+				</div>
+
 				<div>
 					<button id="clear_config">Clear config and Restart</button>
 				</div>

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -488,7 +488,7 @@ function updateImageCorrection() {
 		filters.push(`brightness(${config.brightness})`);
 	}
 
-	if (config.contrast !== 0) {
+	if (config.contrast !== 1) {
 		filters.push(`contrast(${config.contrast})`);
 	}
 


### PR DESCRIPTION
Adding manual controls for now, but his could really help OCR.

This is using native filter capabilities ([css filters](https://developer.mozilla.org/en-US/docs/Web/CSS/filter) for the video, and [canvas filter](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/filter) for the parts extraction).

New controls in UI shown below for illustration. I recommend clicking one time to activate the controls, and then using the keyboard (arrow right / arrow left to change the values)

![image](https://user-images.githubusercontent.com/935223/161385410-76023f1c-4897-48ab-ab1b-98f67718f023.png)

I need to run a few rounds of tests to check whether the impact on performance.
