### PR TITLE
Drop OpenCV and do first calibration with floodfill

### DIFF
--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -186,11 +186,11 @@ export default class TetrisOCR extends EventTarget {
 
 		const filters = [];
 
-		if (this.config.brightness > 1) {
+		if (this.config.brightness && this.config.brightness > 1) {
 			filters.push(`brightness(${this.config.brightness})`);
 		}
 
-		if (this.config.contrast !== 1) {
+		if (this.config.contrast && this.config.contrast !== 1) {
 			filters.push(`contrast(${this.config.contrast})`);
 		}
 

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -142,7 +142,6 @@
 		<div class="notice"></div>
 
 		<div id="calibration">
-			<img id="reference_ui" />
 			<canvas id="video_capture" />
 		</div>
 

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -172,10 +172,18 @@
 				</div>
 
 				<div id="instructions">
-					<p>
-						Start a game at level 0, and in the video below, click somewhere
-						black in the Tetris Field.
-					</p>
+					<p><strong>Next steps:</strong></p>
+					<ol start="0">
+						<li>
+							With your selection above, your tetris capture should now be
+							visible in the video below
+						</li>
+						<li>
+							Start a game at level 0, and in the video below, click somewhere
+							BLACK in the central Tetris field.
+						</li>
+						<li>Fine-tune all the fields (location and size)</li>
+					</ol>
 				</div>
 			</fieldset>
 

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -135,6 +135,10 @@
 			.warning {
 				color: #ff8c00;
 			}
+
+			#instructions {
+				display: none;
+			}
 		</style>
 	</head>
 
@@ -167,8 +171,11 @@
 					<select id="palette"></select>
 				</div>
 
-				<div>
-					<button id="go">Calibrate and Capture</button>
+				<div id="instructions">
+					<p>
+						Start a game at level 0, and in the video below, click somewhere
+						black in the Tetris Field.
+					</p>
 				</div>
 			</fieldset>
 

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -473,6 +473,10 @@ video.addEventListener('click', async evt => {
 		brightness_slider.value = 1.65;
 		onBrightnessChange();
 	}
+
+	alert(
+		'Rough identification has been completed.\n\nYou MUST now inspect and fine tune all the fields (location and size) to make them pixel perfect.'
+	);
 });
 
 function onShowPartsChanged() {

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -468,6 +468,11 @@ video.addEventListener('click', async evt => {
 	wizard.style.display = 'none';
 	privacy.style.display = 'block';
 	controls.style.display = 'block';
+
+	if (video.ntcType === 'device') {
+		brightness_slider.value = 1.65;
+		onBrightnessChange();
+	}
 });
 
 function onShowPartsChanged() {
@@ -515,11 +520,11 @@ focus_alarm.addEventListener('change', onFocusAlarmChanged);
 function updateImageCorrection() {
 	const filters = [];
 
-	if (config.brightness > 1) {
+	if (config.brightness !== undefined && config.brightness > 1) {
 		filters.push(`brightness(${config.brightness})`);
 	}
 
-	if (config.contrast !== 1) {
+	if (config.contrast !== undefined && config.contrast !== 1) {
 		filters.push(`contrast(${config.contrast})`);
 	}
 
@@ -719,6 +724,7 @@ async function playVideoFromDevice(device_id, fps) {
 
 		// when an actual device id is supplied, we start everything
 		video.srcObject = stream;
+		video.ntcType = 'device';
 		video.play();
 	} catch (error) {
 		console.error('Error opening video camera.', error);
@@ -740,6 +746,7 @@ async function playVideoFromScreenCap(fps) {
 
 		// when an actual device id is supplied, we start everything
 		video.srcObject = stream;
+		video.ntcType = 'screencap';
 		video.play();
 	} catch (error) {
 		console.error('Error capturing window.', error);

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -8,7 +8,7 @@ import OCRSanitizer from '/ocr/OCRSanitizer.js';
 import {
 	getFieldCoordinates,
 	getCaptureCoordinates,
-} from '/ocr/calibration2.js';
+} from '/ocr/calibration.js';
 import { peerServerOptions } from '/views/constants.js';
 import speak from '/views/tts.js';
 
@@ -1494,21 +1494,6 @@ function trackAndSendFrames() {
 		await playVideoFromConfig();
 		trackAndSendFrames();
 	} else {
-		// Dynamically load openCV we need to load opencv now
-		const script = document.createElement('script');
-
-		await new Promise(resolve => {
-			script.onload = resolve;
-			script.src = '/ocr/opencv.js';
-			document.head.appendChild(script);
-		});
-
-		await resetDevices();
-
-		capture_rate.value = default_frame_rate;
-
-		ocv = await cv;
-
 		// create default dummy waiting to be populated by user selection
 		config = {
 			frame_rate: default_frame_rate,


### PR DESCRIPTION
### Context
The open CV calibration is error prone. Not working for many people, who then have to move all the fields manually, which is very tedious.

@alex-ong had [suggested long ago](https://github.com/timotheeg/nestrischamps/issues/28) to use a flood fill algorithm to detect fhe field, and then use it, and knowledge of the typical Tetris layout, to compute the capture coordinates of all the other fields.

Finding the Tetris field became the annoying part, especially when capturing from browser windows youtube replays, where the layout might not be standard, perhaps with a player cam on the side, breaking the relative position in the overall window.

### Approach
1. Drop open CV entirely (saves 8MB!)
2. Implement the [flood fill algorithm](https://en.wikipedia.org/wiki/Flood_fill) to detect edge of the tetris field
3. Update the calibration wizard steps to show instruction on what to do
4. Finally to find the starting point of the floodfill, use the most intelligent entity in the room: the user himself/herself!

After having selected the input device, and the rom type, the user will be asked to click somewhere black in the field. This will provide the starting point of the floodfill to find the edge of the field.

Bonus: For capture devices, brightness defaults to 1.65 on first calibration.
