### PR TITLE
Add minimal rom

### DIFF
--- a/modules/Game.js
+++ b/modules/Game.js
@@ -99,7 +99,7 @@ class Game {
 
 			this.num_blocks = this._getNumBlocks(data); // assume correct...
 			this.num_pieces = 0;
-			this.prior_preview = null;
+			this.prior_preview = 'O';
 
 			this.tetris_lines = 0;
 
@@ -334,13 +334,15 @@ class Game {
 			// record new state
 			this.num_pieces = this._getNumPieces(data);
 			PIECES.forEach(p => (this.data[p] = data[p]));
-			this.prior_preview = data.preview;
-		} else {
+		} else if (data.cur_piece_das !== null) {
 			cur_piece = data.cur_piece; // 💪
 			this.das_total += data.cur_piece_das;
+		} else {
+			cur_piece = this.prior_preview;
 		}
 
 		this.pieces.push(cur_piece);
+		this.prior_preview = data.preview;
 
 		if (cur_piece == 'I') {
 			if (this.cur_drought > this.max_drought) {

--- a/public/js/BinaryFrame.js
+++ b/public/js/BinaryFrame.js
@@ -6,9 +6,9 @@ const FRAME_SIZE_BY_VERSION = {
 };
 
 const GAME_TYPE = {
+	MINIMAL: 0,
 	CLASSIC: 1,
 	DAS_TRAINER: 2,
-	MINIMAL: 3,
 };
 
 const PIECE_TO_VALUE = {
@@ -116,7 +116,7 @@ export default class BinaryFrame {
 			((sanitized.cur_piece_das & 0b11111) << 3) |
 			(sanitized.cur_piece & 0b111);
 
-		// piece stats (9 bits each - does not lign nicely to byte boundaries 😓)
+		// piece stats (9 bits each - does not align nicely to byte boundaries 😓)
 		buffer[bidx++] = ((sanitized.T & 0b111111110) >> 1);
 		buffer[bidx++] = ((sanitized.T & 0b000000001) << 7) | ((sanitized.J & 0b111111100) >> 2);
 		buffer[bidx++] = ((sanitized.J & 0b000000011) << 6) | ((sanitized.Z & 0b111111000) >> 3);

--- a/public/js/BinaryFrame.js
+++ b/public/js/BinaryFrame.js
@@ -8,6 +8,7 @@ const FRAME_SIZE_BY_VERSION = {
 const GAME_TYPE = {
 	CLASSIC: 1,
 	DAS_TRAINER: 2,
+	MINIMAL: 3,
 };
 
 const PIECE_TO_VALUE = {

--- a/public/ocr/OCRSanitizer.js
+++ b/public/ocr/OCRSanitizer.js
@@ -232,7 +232,7 @@ export default class OCRSanitizer {
 			pojo.color1 = dispatch_frame.color1;
 			pojo.color2 = dispatch_frame.color2;
 			pojo.color3 = dispatch_frame.color3;
-		} else {
+		} else if (this.config.tasks.cur_piece_das) {
 			pojo.instant_das = OCRSanitizer.digitsToValue(dispatch_frame.instant_das);
 			pojo.cur_piece_das = OCRSanitizer.digitsToValue(
 				dispatch_frame.cur_piece_das

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -277,10 +277,12 @@ export default class TetrisOCR extends EventTarget {
 
 		const colors = [res.color1, res.color2, res.color3];
 
+		/*
 		if (level_units != 6 && level_units != 7) {
 			// TOCHECK: is this still needed now that we work in lab color space?
 			colors.unshift(DEFAULT_COLOR_0); // add black
 		}
+		/**/
 
 		res.field = await this.scanField(source_img, colors);
 		res.preview = this.scanPreview(source_img);

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -262,7 +262,8 @@ export default class TetrisOCR extends EventTarget {
 
 		// color are either supplied from palette or read, there's no other choice
 		if (this.palette) {
-			[res.color1, res.color2, res.color3] = this.palette[level_units];
+			[res.color1, res.color2, res.color3] =
+				this.palette[level_units] || this.palette[0];
 		} else {
 			// assume tasks color1 and color2 are set
 			res.color2 = this.scanColor2(source_img);

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -278,12 +278,10 @@ export default class TetrisOCR extends EventTarget {
 
 		const colors = [res.color1, res.color2, res.color3];
 
-		/*
 		if (level_units != 6 && level_units != 7) {
 			// TOCHECK: is this still needed now that we work in lab color space?
 			colors.unshift(DEFAULT_COLOR_0); // add black
 		}
-		/**/
 
 		res.field = await this.scanField(source_img, colors);
 		res.preview = this.scanPreview(source_img);

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -161,8 +161,18 @@
 					<label for="rom">ROM</label>
 					<select id="rom">
 						<option value="">-</option>
-						<option value="classic">Classic</option>
-						<option value="das_trainer">Das Trainer</option>
+						<option
+							value="minimal"
+							title="Capture score, level, lines, preview and field"
+						>
+							Minimal
+						</option>
+						<option value="classic" title="Minimal + Colors and Piece stats">
+							Classic
+						</option>
+						<option value="das_trainer" title="Minimal + DAS stats">
+							Das Trainer
+						</option>
 					</select>
 				</div>
 

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -161,17 +161,17 @@
 					<label for="rom">ROM</label>
 					<select id="rom">
 						<option value="">-</option>
-						<option
-							value="minimal"
-							title="Capture score, level, lines, preview and field"
-						>
-							Minimal
-						</option>
 						<option value="classic" title="Minimal + Colors and Piece stats">
 							Classic
 						</option>
 						<option value="das_trainer" title="Minimal + DAS stats">
 							Das Trainer
+						</option>
+						<option
+							value="minimal"
+							title="Capture score, level, lines, preview and field"
+						>
+							Minimal
 						</option>
 					</select>
 				</div>

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1420,7 +1420,7 @@ function trackAndSendFrames() {
 
 	// TODO: better event system and name for frame data events
 	ocr_corrector.onMessage = async function (data) {
-		data.game_type = config.game_type || BinaryFrame.GAME_TYPE.CLASSIC;
+		data.game_type = config.game_type ?? BinaryFrame.GAME_TYPE.CLASSIC;
 		data.ctime = Date.now() - start_time;
 
 		if (show_parts.checked) {

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -87,6 +87,12 @@ const configs = {
 			'cur_piece',
 		],
 	},
+	minimal: {
+		game_type: BinaryFrame.GAME_TYPE.MINIMAL,
+		reference: '/ocr/reference_ui_classic.png',
+		palette: 'easiercap',
+		fields: ['score', 'level', 'lines', 'field', 'preview'],
+	},
 };
 
 const send_binary = QueryString.get('binary') !== '0';
@@ -1355,7 +1361,9 @@ function loadConfig() {
 		if (!parsed.hasOwnProperty('game_type')) {
 			parsed.game_type = parsed.tasks.T
 				? BinaryFrame.GAME_TYPE.CLASSIC
-				: BinaryFrame.GAME_TYPE.DAS_TRAINER;
+				: parsed.tasks.cur_piece_das
+				? BinaryFrame.GAME_TYPE.DAS_TRAINER
+				: BinaryFrame.GAME_TYPE.MINIMAL;
 		}
 
 		return parsed;

--- a/public/views/BaseGame.js
+++ b/public/views/BaseGame.js
@@ -642,7 +642,7 @@ export default class BaseGame {
 		if (this.is_classic_rom) {
 			// fake das stats
 			this.data.das.cur = -1;
-		} else {
+		} else if (data.cur_piece_das !== null) {
 			// record real das stats
 			this.data.das.cur = data.cur_piece_das;
 			this.data.das.total += data.cur_piece_das;

--- a/public/views/BaseGame.js
+++ b/public/views/BaseGame.js
@@ -228,7 +228,7 @@ export default class BaseGame {
 			},
 
 			das: {
-				cur: 0,
+				cur: -1,
 				total: 0, // running total, used for average computation
 				avg: 0,
 				great: 0,

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -482,7 +482,7 @@ export default class Player {
 		this.pieces.length = 0;
 		this.clear_events.length = 0;
 		this.preview = '';
-		this.prev_preview = 'I';
+		this.prev_preview = 'O';
 		this.score = 0;
 		this.lines = 0;
 		this.start_level = 0;
@@ -699,7 +699,7 @@ export default class Player {
 		if (this.pending_piece) {
 			this.pending_piece = false;
 
-			let cur_piece = data.cur_piece || this.prev_preview;
+			let cur_piece = data.cur_piece || this.prev_preview || 'O';
 			let has_change = true;
 			let drought_change;
 


### PR DESCRIPTION
Add a "fake romset" for minimal capture (`score`, `level`, `lines`, `preview`, `field`). This can ride on the Binary Frame format V2 and support all romhacks where the side panel is used for whatever custom stats.

This works by hardcoding the palette from my old easiercap, which may or may not work well with different capture devices out there. Ideally, this really needs a custom palette creation tool to exist (see issue https://github.com/timotheeg/nestrischamps/issues/16)