### PR TITLE
Adding a daily average score metric to the progress charts

### DIFF
--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -271,7 +271,8 @@ class ScoreDAO {
 			SELECT
 				Date(s.datetime AT TIME ZONE u.timezone) AS date,
 				count(s.id) AS num_games,
-				max(s.score) AS max_score
+				max(s.score) AS max_score,
+				round(avg(s.score)) AS avg_score
 			FROM scores s, twitch_users u
 			WHERE s.player_id=$1 AND s.player_id=u.id ${level_condition}
 			GROUP BY date

--- a/views/progress.ejs
+++ b/views/progress.ejs
@@ -200,7 +200,7 @@
 				}
 			},
 
-			colors: ['#6CF', color],
+			colors: ['#6CF', color, '#007200'],
 
 			series: [{
 				name: `Num games`,
@@ -211,6 +211,10 @@
 				name: `Max score`,
 				type: 'spline',
 				data: progress1819[level].map(({timestamp, max_score}) => [timestamp, max_score])
+			},{
+				name: `Average score`,
+				type: 'spline',
+				data: progress1819[level].map(({timestamp, avg_score}) => [timestamp, parseInt(avg_score, 10)])
 			}],
 
 			responsive: {


### PR DESCRIPTION
Added a new column in the database query for getProgress() in ScoreDAO.js and a new field for its data in progress.ejs to show a line displaying the average score in dark green. Only displayed in the 18 and 19 progress charts.

<img width="542" alt="ntc-average" src="https://user-images.githubusercontent.com/81860785/166882820-87ef7ea9-f6d3-43aa-a828-0e0b49f32d33.png">
