### PR TITLE
Introduce play sessions and track stats by session

### DIFF
--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -7,7 +7,7 @@ class ScoreDAO {
 		const db_client = await dbPool.connect();
 
 		try {
-			return {
+			const data = {
 				current_player: user.login,
 				pbs: [
 					await this._getPBs(db_client, user, 18),
@@ -18,6 +18,11 @@ class ScoreDAO {
 					session: await this._getBestInSession(db_client, user),
 				},
 			};
+
+			// Temporary ... For backward compatibility - Remove after 2022-06-01
+			data.high_scores.today = data.high_scores.session;
+
+			return data;
 		} catch (err) {
 			console.log('Error getting user stats');
 			console.error(err);

--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -1,6 +1,6 @@
 import dbPool from '../modules/db.js';
 
-const SESSION_BREAK_MS = 2 * 60 * 60 * 1000; // 2hours
+const SESSION_BREAK_MS = 2 * 60 * 58 * 1000; // 2hours - 2s for the time check query
 
 class ScoreDAO {
 	async getStats(user) {
@@ -299,14 +299,15 @@ class ScoreDAO {
 		const result = await dbPool.query(
 			`
 			SELECT
-				Date(s.datetime AT TIME ZONE u.timezone) AS date,
+				session,
+				min(s.datetime) AS datetime,
 				count(s.id) AS num_games,
 				max(s.score) AS max_score,
 				round(avg(s.score)) AS avg_score
 			FROM scores s, twitch_users u
 			WHERE s.player_id=$1 AND s.player_id=u.id ${level_condition}
-			GROUP BY date
-			ORDER BY date asc
+			GROUP BY session
+			ORDER BY session asc
 			`,
 			args
 		);

--- a/public/views/1p/classic.html
+++ b/public/views/1p/classic.html
@@ -103,11 +103,11 @@
 				<div class="header">HIGH SCORES</div>
 				<table class="content">
 					<tr>
-						<th>24 HOURS</th>
+						<th>SESSION</th>
 						<th>OVERALL</th>
 					</tr>
 					<tr>
-						<td class="today">
+						<td class="session">
 							<table>
 								<thead>
 									<tr>

--- a/public/views/1p/das_trainer.html
+++ b/public/views/1p/das_trainer.html
@@ -63,11 +63,11 @@
 				<div class="header">HIGH SCORES</div>
 				<table class="content">
 					<tr>
-						<th>24 HOURS</th>
+						<th>SESSION</th>
 						<th>OVERALL</th>
 					</tr>
 					<tr>
-						<td class="today">
+						<td class="session">
 							<table>
 								<thead>
 									<tr>

--- a/public/views/1p/tomellosoulman.html
+++ b/public/views/1p/tomellosoulman.html
@@ -147,7 +147,7 @@
 				width: 0px;
 			}
 
-			#high_scores td.today,
+			#high_scores td.session,
 			#high_scores td.overall {
 				padding-right: 0px;
 				width: 190px;
@@ -263,11 +263,11 @@
 				<div class="header">HIGH SCORES</div>
 				<table class="content">
 					<tr>
-						<th>24 HOURS</th>
+						<th>SESSION</th>
 						<th>OVERALL</th>
 					</tr>
 					<tr>
-						<td class="today">
+						<td class="session">
 							<table>
 								<thead>
 									<tr>

--- a/public/views/DomRefs.js
+++ b/public/views/DomRefs.js
@@ -124,7 +124,7 @@ export default class DomRefs {
 		this.high_scores = {
 			element: high_scores,
 
-			today: high_scores.querySelector('.today tbody'),
+			session: high_scores.querySelector('.session tbody'),
 			overall: high_scores.querySelector('.overall tbody'),
 		};
 

--- a/public/views/main.js
+++ b/public/views/main.js
@@ -242,7 +242,7 @@ function renderPastGamesAndPBs(data) {
 		dom.high_scores.element.clientHeight > 200 ? 10 : 5;
 
 	// high scores
-	['today', 'overall'].forEach(category => {
+	['session', 'overall'].forEach(category => {
 		if (data.high_scores[category].length <= 0) {
 			data.high_scores[category].push(null);
 		}

--- a/public/views/stats-boxes.css
+++ b/public/views/stats-boxes.css
@@ -421,13 +421,13 @@ i {
 	padding-bottom: 6px;
 }
 
-#high_scores td.today,
+#high_scores td.session,
 #high_scores td.overall {
 	vertical-align: top;
 	width: 220px;
 }
 
-#high_scores td.today {
+#high_scores td.session {
 	padding-right: 16px;
 }
 

--- a/routes/score.js
+++ b/routes/score.js
@@ -317,7 +317,7 @@ router.get(
 		const progress = await ScoreDAO.getProgress(req.session.user);
 
 		progress.forEach(datapoint => {
-			datapoint.timestamp = datapoint.date.getTime();
+			datapoint.timestamp = datapoint.datetime.getTime();
 			delete datapoint.date;
 		});
 
@@ -333,14 +333,14 @@ router.get(
 		const progress18 = await ScoreDAO.getProgress(req.session.user, 18);
 
 		progress18.forEach(datapoint => {
-			datapoint.timestamp = datapoint.date.getTime();
+			datapoint.timestamp = datapoint.datetime.getTime();
 			delete datapoint.date;
 		});
 
 		const progress19 = await ScoreDAO.getProgress(req.session.user, 19);
 
 		progress19.forEach(datapoint => {
-			datapoint.timestamp = datapoint.date.getTime();
+			datapoint.timestamp = datapoint.datetime.getTime();
 			delete datapoint.date;
 		});
 

--- a/scripts/set_session_ids.js
+++ b/scripts/set_session_ids.js
@@ -1,0 +1,91 @@
+import dbPool from '../modules/db.js';
+import _ from 'lodash';
+
+const SESSION_BREAK_MS = 2 * 60 * 60 * 1000; // 2hours
+const MAX_IDS_PER_UPDATE = 25;
+
+async function setSessionInGames(db_client, playerid, sessionid, gameids) {
+	if (gameids.length <= 0) return;
+
+	for (const id_chunk of _.chunk(gameids, MAX_IDS_PER_UPDATE)) {
+		console.log('Updating session', playerid, sessionid);
+		console.log(id_chunk);
+
+		// return; // DRY RUN, uncomment to activate mutations
+
+		await db_client.query(
+			`
+            UPDATE scores
+            SET session=$1
+            WHERE
+                player_id=$2
+                AND id IN (${id_chunk.join(',')})
+            `,
+			[sessionid, playerid]
+		);
+	}
+}
+
+async function run() {
+	const db_client = await dbPool.connect();
+
+	let players = (
+		await db_client.query(
+			`
+        SELECT id, login from twitch_users
+        `
+		)
+	).rows;
+
+	console.log(`Retrieved ${players.length} players`);
+
+	for (const { id: playerid, login } of players) {
+		console.log(`Setting session ids for player ${login} (${playerid})`);
+
+		let scores = (
+			await db_client.query(
+				`
+            SELECT id, datetime
+            FROM scores
+            WHERE player_id=$1
+            ORDER BY datetime asc
+            `,
+				[playerid]
+			)
+		).rows;
+
+		console.log(`Retrieved ${scores.length} scores for ${login}`);
+
+		let session = 1;
+		let session_games = [];
+		let last_game_time = null;
+
+		for (const { id: scoreid, datetime } of scores) {
+			if (
+				last_game_time === null ||
+				datetime - last_game_time < SESSION_BREAK_MS
+			) {
+				session_games.push(scoreid);
+				last_game_time = datetime;
+				continue;
+			}
+
+			await setSessionInGames(db_client, playerid, session, session_games);
+
+			session += 1;
+			session_games = [scoreid];
+			last_game_time = datetime;
+		}
+
+		// save last batch
+		await setSessionInGames(db_client, playerid, session, session_games);
+	}
+}
+
+async function start() {
+	const startTime = Date.now();
+	await run();
+	console.log(`Run in ${Date.now() - startTime}ms`);
+}
+
+start().then(() => process.exit(0));

--- a/setup/20220506.sql
+++ b/setup/20220506.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scores
+  ADD COLUMN session INTEGER DEFAULT 1;

--- a/setup/db.sql
+++ b/setup/db.sql
@@ -27,6 +27,7 @@ CREATE INDEX IDX_users_email ON twitch_users (email);
 CREATE TABLE scores (
 	id SERIAL PRIMARY KEY,
 	datetime timestamptz NOT NULL,
+	session INTEGER DEFAULT 1,
 	player_id BIGINT NOT NULL,
 	start_level SMALLINT,
 	end_level SMALLINT,

--- a/setup/db.sql
+++ b/setup/db.sql
@@ -27,8 +27,8 @@ CREATE INDEX IDX_users_email ON twitch_users (email);
 CREATE TABLE scores (
 	id SERIAL PRIMARY KEY,
 	datetime timestamptz NOT NULL,
-	session INTEGER DEFAULT 1,
 	player_id BIGINT NOT NULL,
+	session INTEGER DEFAULT 1,
 	start_level SMALLINT,
 	end_level SMALLINT,
 	score INTEGER,

--- a/views/progress.ejs
+++ b/views/progress.ejs
@@ -86,7 +86,7 @@
 			zoomType: 'x',
 		},
 		title: {
-			text: 'Games per day'
+			text: 'Games per session'
 		},
 		xAxis: {
 			type: 'datetime',


### PR DESCRIPTION
This PR introduces the concept of gaming session. Games are assigned to a session and stats can be aggregated by session rather than by day or by past-24h. 

Many players play very late (past midnight), resulting in data points in the progress chart that are "weird" 

Addresses https://github.com/timotheeg/nestrischamps/issues/123

