### PR TITLE
Derive Lines and Piece Stats from local computation instead of OCR

### DIFF
--- a/public/ocr/GameTracker.js
+++ b/public/ocr/GameTracker.js
@@ -205,7 +205,8 @@ export default class GameTracker {
 
 		if (dispatch_frame.lines === null) {
 			lines = null;
-		} else {
+		} else if (this.cur_lines >= 300) {
+			// booohoo hardcoded value T_T
 			const new_lines_units = peek(dispatch_frame.lines);
 			const cur_lines_units = this.cur_lines % 10;
 
@@ -216,6 +217,8 @@ export default class GameTracker {
 			}
 
 			lines = this.cur_lines;
+		} else {
+			lines = this.cur_lines = GameTracker.digitsToValue(dispatch_frame.lines);
 		}
 
 		const level = this._getLevelFromLines(lines, dispatch_frame.level); // this is no longer OCR!
@@ -243,8 +246,8 @@ export default class GameTracker {
 				let value;
 
 				if (dispatch_frame[p] === null) {
-					value === null;
-				} else {
+					value = null;
+				} else if (this[`cur_${p}`] >= 100) {
 					const new_units = peek(dispatch_frame[p]);
 					const cur_units = this[`cur_${p}`] % 10;
 
@@ -256,6 +259,10 @@ export default class GameTracker {
 					}
 
 					value = this[`cur_${p}`];
+				} else {
+					value = this[`cur_${p}`] = GameTracker.digitsToValue(
+						dispatch_frame[p]
+					);
 				}
 
 				pojo[p] = value;

--- a/public/ocr/GameTracker.js
+++ b/public/ocr/GameTracker.js
@@ -1,7 +1,6 @@
 import ScoreFixer from '/ocr/ScoreFixer.js';
-import { TRANSITIONS } from '/views/constants.js';
+import { PIECES, TRANSITIONS } from '/views/constants.js';
 import TetrisOCR from '/ocr/TetrisOCR.js';
-import { PIECES } from '/views/constants.js';
 
 const BUFFER_MAXSIZE = 2; // all tracked changes are stable over 2 frames
 

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -31,7 +31,7 @@ const reference_locations = {
 	score: { crop: [384, 112, 94, 14], pattern: 'ADDDDD' },
 	score7: { crop: [384, 112, 110, 14], pattern: 'DDDDDDD' },
 	level: { crop: [416, 320, 30, 14], pattern: 'TD' }, // TD, because we only care about start level, which is 29 or lower
-	lines: { crop: [304, 32, 46, 14], pattern: 'DDD' },
+	lines: { crop: [304, 32, 46, 14], pattern: 'TTD' },
 	field_w_borders: { crop: [190, 78, 162, 324] },
 	field: { crop: [192, 80, 158, 318] },
 	preview: { crop: [384, 224, 62, 30] },
@@ -41,13 +41,13 @@ const reference_locations = {
 	instant_das: { crop: [80, 64, 30, 14], pattern: 'BD' },
 	cur_piece_das: { crop: [112, 96, 30, 14], pattern: 'BD' },
 	cur_piece: { crop: [30, 89, 45, 23] },
-	T: { crop: [96, 176, 46, 14], pattern: 'QDD', red: true },
-	J: { crop: [96, 208, 46, 14], pattern: 'QDD', red: true },
-	Z: { crop: [96, 240, 46, 14], pattern: 'QDD', red: true },
-	O: { crop: [96, 272, 46, 14], pattern: 'QDD', red: true },
-	S: { crop: [96, 304, 46, 14], pattern: 'QDD', red: true },
-	L: { crop: [96, 336, 46, 14], pattern: 'QDD', red: true },
-	I: { crop: [96, 368, 46, 14], pattern: 'QDD', red: true },
+	T: { crop: [96, 176, 46, 14], pattern: 'TTD', red: true },
+	J: { crop: [96, 208, 46, 14], pattern: 'TTD', red: true },
+	Z: { crop: [96, 240, 46, 14], pattern: 'TTD', red: true },
+	O: { crop: [96, 272, 46, 14], pattern: 'TTD', red: true },
+	S: { crop: [96, 304, 46, 14], pattern: 'TTD', red: true },
+	L: { crop: [96, 336, 46, 14], pattern: 'TTD', red: true },
+	I: { crop: [96, 368, 46, 14], pattern: 'TTD', red: true },
 };
 
 const configs = {

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1544,7 +1544,7 @@ function trackAndSendFrames() {
 			}
 
 			// all fields equal, do a sanity check on time
-			if (data.ctime - last_frame.ctime >= 500) break;
+			if (data.ctime - last_frame.ctime >= 200) break; // max 1 in 12 frames
 
 			// no need to send frame
 			return;

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -255,6 +255,7 @@ function connect() {
 
 			API[method](...args);
 		} catch (e) {
+			console.log(`Could not process command ${frame[0]}`);
 			console.error(e);
 		}
 	};

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -31,7 +31,7 @@ const reference_locations = {
 	score: { crop: [384, 112, 94, 14], pattern: 'ADDDDD' },
 	score7: { crop: [384, 112, 110, 14], pattern: 'DDDDDDD' },
 	level: { crop: [416, 320, 30, 14], pattern: 'TD' }, // TD, because we only care about start level, which is 29 or lower
-	lines: { crop: [304, 32, 46, 14], pattern: 'TTD' },
+	lines: { crop: [304, 32, 46, 14], pattern: 'QDD' },
 	field_w_borders: { crop: [190, 78, 162, 324] },
 	field: { crop: [192, 80, 158, 318] },
 	preview: { crop: [384, 224, 62, 30] },
@@ -41,13 +41,13 @@ const reference_locations = {
 	instant_das: { crop: [80, 64, 30, 14], pattern: 'BD' },
 	cur_piece_das: { crop: [112, 96, 30, 14], pattern: 'BD' },
 	cur_piece: { crop: [30, 89, 45, 23] },
-	T: { crop: [96, 176, 46, 14], pattern: 'TTD', red: true },
-	J: { crop: [96, 208, 46, 14], pattern: 'TTD', red: true },
-	Z: { crop: [96, 240, 46, 14], pattern: 'TTD', red: true },
-	O: { crop: [96, 272, 46, 14], pattern: 'TTD', red: true },
-	S: { crop: [96, 304, 46, 14], pattern: 'TTD', red: true },
-	L: { crop: [96, 336, 46, 14], pattern: 'TTD', red: true },
-	I: { crop: [96, 368, 46, 14], pattern: 'TTD', red: true },
+	T: { crop: [96, 176, 46, 14], pattern: 'BDD', red: true },
+	J: { crop: [96, 208, 46, 14], pattern: 'BDD', red: true },
+	Z: { crop: [96, 240, 46, 14], pattern: 'BDD', red: true },
+	O: { crop: [96, 272, 46, 14], pattern: 'BDD', red: true },
+	S: { crop: [96, 304, 46, 14], pattern: 'BDD', red: true },
+	L: { crop: [96, 336, 46, 14], pattern: 'BDD', red: true },
+	I: { crop: [96, 368, 46, 14], pattern: 'BDD', red: true },
 };
 
 const configs = {


### PR DESCRIPTION
## Context

NestTrisChamps currently "reads" the value of `lines` and piece counters on the right., This is done by reading 3 digits per field, and in the case of lines, NestrisChamps assumes the line count will be below 500 for the majority of players, so it limits the detection of the first piece stats digits to be in (`0`, `1`, `2`, `3`, `4`)

As it turns out, Nestris players are now attempting to reach the point where the game breaks, like EricICX in [his 6.4M game](https://www.youtube.com/watch?v=SctVBfLjpLg). That game had over 1400 lines, and several piece types above 500. 

To capture values like these, NestrisChamps OCR would need to be upgraded to account for more characters (read the piece stats up to 600 or more, read `lines`, beyond 1600. Reading a greater character range takes more CPU cycle, and this only benefits a few top-level player at the detriment of the vast majority of NestrisChamps users.

An alternative to increasing the range of OCR is to realize that both `lines` and  pieces stats are values that increases continuously during a game. lines may increase by 1, 2, 3, 4, and piece stats should increase only one at a time.

It is therefore possible to derive the values by computation rather than OCR. By reading and comparing only the unit digit of the values, and comparing with the previously read value, a calculation to derive the new value in an ever increasing way is easy.

By doing this, OCR of the the full values can be done only at the beginning of a game, and for manageable ranges, say 

This PR implements the optimizations mentioned above:
1. reduce the OCR range of the hundreds and tens digits for `lines` and piece stats, to just `0`, `1`, `2`
2. produces final value from computation by inspecting changes to the units digit alone

## Risk and drawbacks

* Because OCR reports what it sees, if calibration is bad, and some values are broken, they will eventually self correct as new values are read correctly later. With computation, self-correction will be gone
* NestrisChamps doesn't have a calibration mode distinct from the live capture of the game. Having the UI show computed value rather than OCR value _might_ show values that are not expected, even thought he calibration is perfect. If a player calibrate from a video file, rather than a live stream, jumping the video playhead will not be understood by nestrischamps as a jump, and the computed value will be displayed incorrectly. 

For example, say nestrischamps currently stores lines as `023`, if the player jumps to say lines `119`, nestrischamps will notice the unit value changes, but within the same `tens` cycle, and the computed result will display `039`, rather than `119`. 

For normal games captured from a continuous video stream, that will not be a problem, but during calibration, players might be confused by the incorrect values.

