### PR TITLE
Allow saving color palette on classic rom

### DIFF
--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -242,6 +242,11 @@
 				<div>
 					<button id="clear_config">Clear config and Restart</button>
 				</div>
+				<div>
+					<button id="save_game_palette" disabled>
+						Save Last Game's Palette
+					</button>
+				</div>
 				<div id="timer_control">
 					<button id="start_timer">Start Timer</button>
 					for

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -123,6 +123,8 @@ const reference_ui = document.querySelector('#reference_ui'),
 	show_parts = document.querySelector('#show_parts'),
 	score7 = document.querySelector('#score7'),
 	focus_alarm = document.querySelector('#focus_alarm'),
+	clear_config = document.querySelector('#clear_config'),
+	save_game_palette = document.querySelector('#save_game_palette'),
 	timer_control = document.querySelector('#timer_control'),
 	start_timer = document.querySelector('#start_timer'),
 	conn_host = document.querySelector('#conn_host'),
@@ -391,8 +393,20 @@ conn_host.addEventListener('change', connect);
 conn_port.addEventListener('change', connect);
 
 clear_config.addEventListener('click', evt => {
-	localStorage.clear();
+	localStorage.removeItem('config');
 	location.reload();
+});
+
+save_game_palette.addEventListener('click', evt => {
+	if (palettes && game_tracker && config) {
+		localStorage.setItem('palette', JSON.stringify(save_game_palette.palette));
+
+		palettes._saved = palette;
+		config.palette = '_saved';
+
+		saveConfig(config);
+		location.reload();
+	}
 });
 
 start_timer.addEventListener('click', evt => {
@@ -1235,6 +1249,8 @@ async function showParts(data) {
 	const y_offset = config.capture_area.y;
 
 	for (const name of Object.keys(data)) {
+		if (config.palette && name.startsWith('color')) continue;
+
 		const task = config.tasks[name];
 		const scale_factor = name.startsWith('color') ? 4 : 2;
 
@@ -1489,6 +1505,16 @@ function trackAndSendFrames() {
 
 	let start_time = Date.now();
 	let last_frame = { field: [] };
+
+	game_tracker.onNewGame = () => {
+		save_game_palette.disabled = true;
+	};
+
+	// Palette is ready to be used
+	game_tracker.onPalette = () => {
+		save_game_palette.palette = game_tracker.palette;
+		save_game_palette.disabled = false;
+	};
 
 	// TODO: better event system and name for frame data events
 	game_tracker.onMessage = async function (data) {

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -174,18 +174,35 @@ palette_selector.addEventListener('change', evt => {
 });
 
 rom_selector.addEventListener('change', evt => {
-	if (rom_selector.value === 'classic') {
-		color_matching.style.display = 'block';
-		palette_selector.value = '';
-		palette_selector.disabled = false;
-	} else {
-		// TODO, load user palette!
+	const first_option = palette_selector.querySelector('option:first-child');
+
+	function hideAndResetColorMatching() {
 		color_matching.style.display = 'none';
 		palette_selector.disabled = true;
-		palette_selector.value = Object.keys(palettes)[0];
 	}
 
-	config.game_type = configs[rom_selector.value].game_type;
+	palette_selector.value = palettes._saved ? '_saved' : '';
+
+	if (rom_selector.value === '') {
+		hideAndResetColorMatching();
+	} else {
+		config.game_type = configs[rom_selector.value].game_type;
+
+		color_matching.style.display = 'block';
+		palette_selector.disabled = false;
+
+		if (rom_selector.value === 'classic') {
+			first_option.hidden = false;
+		} else {
+			first_option.hidden = true;
+
+			if (palettes.length <= 1) {
+				hideAndResetColorMatching();
+				palette_selector.value = Object.keys(palettes)[0];
+			}
+		}
+	}
+
 	config.palette = palette_selector.value;
 
 	checkReadyToCalibrate();

--- a/public/ocr/palettes.js
+++ b/public/ocr/palettes.js
@@ -11,11 +11,17 @@ async function getPalette(name) {
 }
 
 export default async function loadPalettes() {
-	return (await Promise.all(LIST.map(getPalette))).reduce(
+	const palettes = (await Promise.all(LIST.map(getPalette))).reduce(
 		(acc, palette, idx) => {
 			acc[LIST[idx]] = palette;
 			return acc;
 		},
 		{}
 	);
+
+	try {
+		palettes._saved = JSON.parse(localStorage.getItem('palette'));
+	} catch (err) {}
+
+	return palettes;
 }

--- a/public/ocr/palettes.js
+++ b/public/ocr/palettes.js
@@ -11,17 +11,15 @@ async function getPalette(name) {
 }
 
 export default async function loadPalettes() {
-	const palettes = (await Promise.all(LIST.map(getPalette))).reduce(
-		(acc, palette, idx) => {
-			acc[LIST[idx]] = palette;
-			return acc;
-		},
-		{}
-	);
+	const palettes = {};
 
 	try {
 		palettes._saved = JSON.parse(localStorage.getItem('palette'));
 	} catch (err) {}
+
+	(await Promise.all(LIST.map(getPalette))).forEach((palette, idx) => {
+		palettes[LIST[idx]] = palette;
+	});
 
 	return palettes;
 }


### PR DESCRIPTION
## Context

In classic mode, the board is scanned using the colors read form the right side. This guarantees colors are in sync.

A capture setup for any Tetris player doesn't change however, so while each combination of console and capture hardware is sort of unique, the setup itself is very stable, so it would be much more efficient to store the color range across all levels once, and then use that palette in all games thereafter.

This will reduce the overall capture size required, and remove the need to scan the color.

## Approach

In classic mode, NTC now tracks the colors for the 10 levels (colors read from the piece stats). When all 10 levels colors are captured, a new button `Save Last Game's Palette` is enabled. 

When clicking it, the color palette is saved locally in [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), the producer page reloaded, and the palette is used again right away.

A NTC user may then switch to a different rom (e.g. Das Trainer or Tetris Gym), select the saved palette, and recalibrate from it.

## Caveat and Side effect:

* The color palette cannot be used to match games beyond the color glitch bug
* Color captured from the piece stats panel are not perfect, especially for crappy capture setup which "bleed" their colors (white becomes tainted by the color of the surrounding border). A more accurate palette creation tool should be more sophisticated: use the side pieces to identify the blocks, but then read the colors from the block themselves to extract the color values. That has not been done in this PR because it's a heavier process that requires a dedicated more of operation, rather be running during standard game OCR.


