### PR TITLE
Add an autojoin mode 

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -150,6 +150,10 @@ class MatchRoom extends Room {
 
 			if (!is_replace_flow) {
 				this.sendStateToAdmin();
+			} else {
+				// TODO: if producer was assigned to user, shou;d we remove the user too?
+				// TODO: Question especially relevant for autojoin mode?
+				// NOTE: removing the player assignment, means that if the player has a connection blips, he might be kicked form the room and not have his game data resume as soon as he reconnects
 			}
 		}
 

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -88,13 +88,13 @@ class MatchRoom extends Room {
 	}
 
 	addProducer(user) {
-		console.log('addProducer', user.id);
+		console.log('addProducer', user.id, typeof user.id);
 		const is_new_user = !this.hasProducer(user);
 
 		if (is_new_user) {
 			this.producers.add(user);
 
-			if (this.state.autjoin) {
+			if (this.state.autojoin) {
 				this.autoJoinUser(user);
 			}
 

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -284,7 +284,7 @@ class MatchRoom extends Room {
 
 		// 1. add players in order of arrival
 		const sorted_producers = [...this.producers].sort(
-			(u1, u2) => u2.match_room_join_ts - u1.match_room_join_ts // breaks encapsulation T_T
+			(u1, u2) => u1.match_room_join_ts - u2.match_room_join_ts // breaks encapsulation -_-
 		);
 
 		// 3. fill as much players as the layout allows

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -29,8 +29,6 @@ class MatchRoom extends Room {
 	constructor(owner, roomid) {
 		super(owner);
 
-		this.autojoin = false;
-
 		this.producers = new Set(); // users
 		this.admin = null;
 		this.roomid = roomid || '_default';
@@ -40,6 +38,7 @@ class MatchRoom extends Room {
 			concurrent_2_matches: undefined, // undefined|true|false
 			selected_match: null, // 0|1|null
 			curtain_logo: null, // url to image or null
+			autojoin: false,
 			players: [
 				// flat user objects - starts with 2 players
 				getBasePlayerData(),
@@ -96,7 +95,7 @@ class MatchRoom extends Room {
 			this.producers.add(user);
 			this.sendStateToAdmin();
 
-			if (this.autojoin) {
+			if (this.state.autjoin) {
 				this.autoJoinUser(user);
 			}
 		}
@@ -308,7 +307,7 @@ class MatchRoom extends Room {
 		}
 	}
 
-	setPlayer(player_num, p_id) {
+	setPlayer(p_num, p_id) {
 		console.log('setPlayer()', p_id, typeof p_id);
 
 		let player_data;
@@ -598,15 +597,15 @@ class MatchRoom extends Room {
 					break; // simple passthrough
 				}
 
-				case 'setAutoJoin': {
+				case 'allowAutoJoin': {
 					forward_to_views = false;
 					const new_autojoin = !!args[0];
 
-					if (new_autojoin && !this.autojoin) {
+					if (new_autojoin && !this.state.autjoin) {
 						this.initAutoJoin();
 					}
 
-					this.autojoin = new_autojoin;
+					this.state.autjoin = new_autojoin;
 
 					break;
 				}

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -267,10 +267,6 @@ class MatchRoom extends Room {
 			p_num < MAX_PLAYERS &&
 			!(p_num % 1)
 		) {
-			if (this.getViewMeta().players) {
-				return p_num < this.getViewMeta().players;
-			}
-
 			return true;
 		}
 

--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -46,7 +46,6 @@ class MatchRoom extends Room {
 			],
 		};
 
-		this.autoJoinUser = this.autoJoinUser.bind(this);
 		this.onAdminMessage = this.onAdminMessage.bind(this);
 	}
 
@@ -94,11 +93,12 @@ class MatchRoom extends Room {
 
 		if (is_new_user) {
 			this.producers.add(user);
-			this.sendStateToAdmin();
 
 			if (this.state.autjoin) {
 				this.autoJoinUser(user);
 			}
+
+			this.sendStateToAdmin();
 		}
 
 		// whether or not the user was new, its peer id changed
@@ -288,14 +288,20 @@ class MatchRoom extends Room {
 
 		// 2. assign as many of the "dangling" producers as possible
 		// not the most computationally efficient way to do it, but nicely readable
-		unassigned_producers.every(this.autoJoinUser);
+		let did_assign = false;
+		for (const user of unassigned_producers) {
+			did_assign ||= this.autoJoinUser(user);
+		}
+
+		if (did_assign) {
+			this.sendStateToAdmin();
+		}
 	}
 
 	autoJoinUser(user) {
 		for (let idx = 0; idx < this.getMaxPossiblePlayers(); idx++) {
 			if (!this.state.players[idx]?.id) {
 				this.setPlayer(idx, user.id);
-				this.sendStateToAdmin();
 				return true;
 			}
 		}

--- a/domains/Producer.js
+++ b/domains/Producer.js
@@ -23,7 +23,6 @@ class Producer extends EventEmitter {
 
 		connection.once('close', () => {
 			this.connection.removeAllListeners();
-			this.is_match_connection = false;
 
 			if (this.connection === connection) {
 				this.connection = null;

--- a/domains/User.js
+++ b/domains/User.js
@@ -202,14 +202,9 @@ class User extends EventEmitter {
 	_scheduleLeaveRoom() {
 		this.leave_room_to = clearTimeout(this.leave_room_to);
 		this.leave_room_to = setTimeout(
-			() => this._doLeaveRoom(),
+			() => this.leaveMatchRoom(),
 			LEAVE_ROOM_TIMEOUT
 		);
-	}
-
-	_doLeaveRoom() {
-		this.leaveMatchRoom();
-		this.leave_room_to = null;
 	}
 
 	send(msg) {

--- a/domains/User.js
+++ b/domains/User.js
@@ -42,6 +42,7 @@ class User extends EventEmitter {
 
 		// match room links this user to the host room of another user
 		this.match_room = null;
+		this.match_room_join_ts = -1;
 
 		// keep track of all socket for the user
 		// dangerous, could lead to memory if not managed well
@@ -95,6 +96,7 @@ class User extends EventEmitter {
 			this.leaveMatchRoom();
 		}
 
+		this.match_room_join_ts = Date.now();
 		this.match_room = host_user.getHostRoom();
 		this.match_room.addProducer(this);
 		this.match_room.once('close', this._handleMatchRoomClose);
@@ -112,6 +114,7 @@ class User extends EventEmitter {
 		this.match_room = null;
 
 		if (this.producer.isMatchConnection()) {
+			this.match_room_join_ts = -1;
 			this.producer.kick('match_room_closed');
 		}
 	}

--- a/domains/User.js
+++ b/domains/User.js
@@ -88,11 +88,9 @@ class User extends EventEmitter {
 	joinMatchRoom(host_user) {
 		const new_room = host_user.getHostRoom();
 
-		this.leave_room_to = clearTimeout(this.leave_room_to);
-
 		if (new_room === this.match_room) {
-			// this forces a redispatch of the peer ids
-			new_room.addProducer(this);
+			this.leave_room_to = clearTimeout(this.leave_room_to); // just in case
+			new_room.addProducer(this); // this forces a redispatch of the peer ids
 			return;
 		}
 
@@ -107,6 +105,8 @@ class User extends EventEmitter {
 	}
 
 	leaveMatchRoom() {
+		this.leave_room_to = clearTimeout(this.leave_room_to);
+
 		if (this.match_room) {
 			this.match_room.off('close', this._handleMatchRoomClose);
 			this.match_room.removeProducer(this);
@@ -116,8 +116,7 @@ class User extends EventEmitter {
 	}
 
 	_handleMatchRoomClose() {
-		this.leave_room_to = clearTimeout(this.leave_room_to);
-		this.match_room = null;
+		this.leaveMatchRoom();
 
 		if (this.producer.isMatchConnection()) {
 			this.match_room_join_ts = -1;

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -86,7 +86,7 @@ let room_data;
 let connection;
 
 function getProducer(pid) {
-	return room_data.producers.find(producer => producer.id == pid);
+	return room_data.producers.find(producer => producer.id === pid);
 }
 
 class Player {
@@ -124,7 +124,7 @@ class Player {
 		};
 
 		this.dom.producers.onchange = () =>
-			this._pickProducer(parseInt(this.dom.producers.value, 10));
+			this._pickProducer(this.dom.producers.value);
 
 		this.dom.win_btn.onclick = () => {
 			remoteAPI.setWinner(this.idx);
@@ -200,11 +200,11 @@ class Player {
 	}
 
 	_pickProducer(pid) {
-		remoteAPI.setPlayer(this.idx, parseInt(pid, 10));
+		remoteAPI.setPlayer(this.idx, pid);
 	}
 
 	setProducer(pid) {
-		const selected_pid = parseInt(this.dom.producers.value, 10);
+		const selected_pid = this.dom.producers.value;
 
 		if (selected_pid === pid) return;
 

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -10,6 +10,7 @@ const dom = {
 	show_profile_cards_controls: document.querySelector(
 		'#show_profile_cards_controls'
 	),
+	allow_autojoin: document.querySelector('#allow_autojoin'),
 	add_player: document.querySelector('#add_player'),
 	curtain_logo_url: document.querySelector('#curtain_logo_url'),
 };
@@ -74,6 +75,9 @@ const remoteAPI = {
 	},
 	showProfileCard: function (visible, match_idx) {
 		connection.send(['showProfileCard', visible, match_idx]);
+	},
+	allowAutoJoin: function (allow) {
+		connection.send(['allowAutoJoin', allow]);
 	},
 };
 
@@ -306,6 +310,8 @@ function setState(_room_data) {
 
 	dom.show_profile_cards_controls.querySelector('.matches').style.display =
 		room_data.concurrent_2_matches ? null : 'none';
+
+	dom.allow_autojoin.checked = !!room_data.autojoin;
 }
 
 function addPlayer() {
@@ -377,9 +383,13 @@ function bootstrap() {
 			});
 		});
 
+	dom.allow_autojoin.addEventListener('click', function () {
+		remoteAPI.allowAutoJoin(this.checked);
+	});
+
 	// =====
 
-	connection = new Connection();
+	window.connection = connection = new Connection();
 
 	connection.onMessage = function (message) {
 		const [command, ...args] = message;

--- a/public/views/mp/concurrent.html
+++ b/public/views/mp/concurrent.html
@@ -82,7 +82,7 @@
 			// custom view parameters which will be passed in the websocket URI
 			const view_meta = new URLSearchParams({
 				video: '352x240',
-				players: 8,
+				players: 6,
 			});
 		</script>
 		<script src="https://unpkg.com/peerjs@1.4.7/dist/peerjs.min.js"></script>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -177,6 +177,11 @@
 			</span>
 		</div>
 
+		<div class="box" id="allow_autojoin_controls">
+			Allow auto-join:
+			<input type="checkbox" id="allow_autojoin" value="0" />
+		</div>
+
 		<div id="players"></div>
 
 		<div class="buttons">


### PR DESCRIPTION
Opening PR to review later

* Auto join setting is controlled from the admin page
* Producers are automatically assigned to players, in 

Disconnections are not handled (for now?). When a user disconnect, it could be a network blip, and to make sure the game data flows correctly immediately on reconnection, the player is not cleared.

With some reconnection timeout management, we could imagine that if a player disconnects, his slots is taken by one of the other producer that was waiting pending assignment. User who was waiting the longest gets the spot.

TODOs:
- [ ] Handle disconnections
- [ ] Testing (verify no regression)
- [ ] Specify max players in all layouts



