### PR TITLE
Track competition scores

### DIFF
--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -262,7 +262,7 @@ class ScoreDAO {
 		let filter_by_competition_mode = '';
 
 		if ([true, false].includes(options.competition)) {
-			args.push(!!options.competition);
+			args.push(options.competition);
 			filter_by_competition_mode = ` AND competition=$${args.length} `;
 		}
 

--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -227,14 +227,22 @@ class ScoreDAO {
 		return result.rows[0].id;
 	}
 
-	async getNumberOfScores(user) {
+	async getNumberOfScores(user, options = {}) {
+		const args = [user.id];
+		let additional_conditions = '';
+
+		if ([true, false].includes(options.competition)) {
+			args.push(options.competition);
+			additional_conditions += ` AND competition=$${args.length} `;
+		}
+
 		const result = await dbPool.query(
 			`
 				SELECT count(*)
 				FROM scores
-				WHERE player_id=$1
+				WHERE player_id=$1 ${additional_conditions}
 			`,
-			[user.id]
+			args
 		);
 
 		return parseInt(result.rows[0].count, 10);

--- a/daos/ScoreDAO.js
+++ b/daos/ScoreDAO.js
@@ -250,6 +250,8 @@ class ScoreDAO {
 			...options,
 		};
 
+		const args = [user.id];
+
 		let null_handling = '';
 
 		if (options.sort_field === 'tetris_rate') {
@@ -260,7 +262,8 @@ class ScoreDAO {
 		let filter_by_competition_mode = '';
 
 		if ([true, false].includes(options.competition)) {
-			filter_by_competition_mode = ` AND competition=${options.competition}`;
+			args.push(!!options.competition);
+			filter_by_competition_mode = ` AND competition=$${args.length} `;
 		}
 
 		// WARNING: this query uses plain JS variable interpolation, parameters MUST be sane
@@ -272,7 +275,7 @@ class ScoreDAO {
 				ORDER BY ${options.sort_field} ${options.sort_order} ${null_handling}
 				LIMIT ${options.page_size} OFFSET ${options.page_size * options.page_idx}
 			`,
-			[user.id]
+			args
 		);
 
 		return result.rows;

--- a/domains/Producer.js
+++ b/domains/Producer.js
@@ -14,10 +14,11 @@ class Producer extends EventEmitter {
 		this._handleMessage = this._handleMessage.bind(this);
 	}
 
-	setConnection(connection, { match = false }) {
+	setConnection(connection, { match = false, competition = false }) {
 		this.kick('concurrency_limit');
 
 		this.is_match_connection = !!match;
+		this.is_competition = !!competition;
 
 		connection.on('message', this._handleMessage);
 
@@ -52,7 +53,9 @@ class Producer extends EventEmitter {
 			delete this.game.onNewGame;
 		}
 
-		this.game = new Game(this.user);
+		this.game = new Game(this.user, {
+			competition: this.is_match_connection || this.is_competition,
+		});
 
 		this.game.onNewGame = frame => {
 			console.log(

--- a/domains/User.js
+++ b/domains/User.js
@@ -61,9 +61,12 @@ class User extends EventEmitter {
 		this.checkScheduleDestroy();
 	}
 
-	setProducerConnection(conn, { match = false, target_user = null }) {
+	setProducerConnection(
+		conn,
+		{ match = false, competition = false, target_user = null }
+	) {
 		this.addConnection(conn);
-		this.producer.setConnection(conn, { match });
+		this.producer.setConnection(conn, { match, competition });
 
 		if (match) {
 			this.joinMatchRoom(target_user);

--- a/modules/Game.js
+++ b/modules/Game.js
@@ -17,9 +17,10 @@ const SCORE_BASES = [0, 40, 100, 300, 1200];
 const LINE_CLEAR_IGNORE_FRAMES = 7;
 
 class Game {
-	constructor(user) {
+	constructor(user, { competition = false }) {
 		this.frame_file = '';
 		this.user = user;
+		this.competition = !!competition;
 		this.frame_count = 0;
 		this.data = null;
 		this.over = false;
@@ -440,6 +441,8 @@ class Game {
 
 			num_frames: this.num_frames,
 			frame_file: this.frame_file,
+
+			competition: this.competition,
 		};
 	}
 

--- a/routes/score.js
+++ b/routes/score.js
@@ -320,9 +320,7 @@ router.put(
 	async (req, res) => {
 		console.log(`Updating score ${req.params.id}`);
 
-		// only the competition mode is allowed to be udpated
-
-		if (!['true', 'false'].includes(req.params.mode)) {
+		if (!['0', '1'].includes(req.params.mode)) {
 			res.status(400).send('Invalid value for competition mode');
 			return;
 		}

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -147,7 +147,12 @@ router.post('/set_pb', express.json(), async (req, res) => {
 		return;
 	}
 
-	const update = _.pick(req.body, ['score', 'start_level', 'end_level']);
+	const update = _.pick(req.body, [
+		'score',
+		'start_level',
+		'end_level',
+		'competition',
+	]);
 
 	do {
 		if (
@@ -170,6 +175,8 @@ router.post('/set_pb', express.json(), async (req, res) => {
 			update.end_level > 30
 		)
 			break;
+
+		if (typeof update.competition != 'boolean') break;
 
 		const user = await UserDAO.getUserById(req.session.user.id);
 

--- a/setup/20230304.sql
+++ b/setup/20230304.sql
@@ -1,0 +1,3 @@
+ALTER TABLE scores ADD COLUMN competition BOOLEAN default false;
+DROP INDEX IDX_scores_manual_scores;
+CREATE UNIQUE INDEX IDX_scores_manual_scores on scores (player_id, start_level, competition) where manual;

--- a/setup/20230304.sql
+++ b/setup/20230304.sql
@@ -1,3 +1,8 @@
 ALTER TABLE scores ADD COLUMN competition BOOLEAN default false;
+
 DROP INDEX IDX_scores_manual_scores;
+
 CREATE UNIQUE INDEX IDX_scores_manual_scores on scores (player_id, start_level, competition) where manual;
+CREATE INDEX IDX_scores_player_level_competition ON scores (player_id, start_level, competition);
+CREATE INDEX IDX_scores_player_session ON scores (player_id, session);
+CREATE INDEX IDX_scores_player_level ON scores (player_id, start_level);

--- a/setup/db.sql
+++ b/setup/db.sql
@@ -44,6 +44,7 @@ CREATE TABLE scores (
 	transition INTEGER DEFAULT NULL,
 	num_frames INTEGER DEFAULT 0,
 	frame_file VARCHAR(256) DEFAULT '',
+	competition BOOLEAN default false,
 	manual BOOLEAN default false,
 
 	CONSTRAINT fk_player
@@ -51,7 +52,7 @@ CREATE TABLE scores (
 			REFERENCES twitch_users(id)
 );
 
-CREATE UNIQUE INDEX IDX_scores_manual_scores on scores (player_id, start_level) where manual;
+CREATE UNIQUE INDEX IDX_scores_manual_scores on scores (player_id, start_level, competition) where manual;
 CREATE INDEX IDX_scores_player_datetime ON scores (player_id, datetime);
 CREATE INDEX IDX_scores_player_score ON scores (player_id, score);
 CREATE INDEX IDX_scores_datetime ON scores (datetime);

--- a/setup/db.sql
+++ b/setup/db.sql
@@ -53,8 +53,11 @@ CREATE TABLE scores (
 );
 
 CREATE UNIQUE INDEX IDX_scores_manual_scores on scores (player_id, start_level, competition) where manual;
-CREATE INDEX IDX_scores_player_datetime ON scores (player_id, datetime);
+CREATE INDEX IDX_scores_player_level_competition ON scores (player_id, start_level, competition);
 CREATE INDEX IDX_scores_player_score ON scores (player_id, score);
+CREATE INDEX IDX_scores_player_session ON scores (player_id, session);
+CREATE INDEX IDX_scores_player_level ON scores (player_id, start_level);
+CREATE INDEX IDX_scores_player_datetime ON scores (player_id, datetime);
 CREATE INDEX IDX_scores_datetime ON scores (datetime);
 
 CREATE TABLE sessions (

--- a/views/progress.ejs
+++ b/views/progress.ejs
@@ -77,9 +77,9 @@
 
 <script>
 (async function showChart() {
-	const response = await fetch('/stats/progress/data')
+	const response = await fetch(`/stats/progress/data${document.location.search}`)
 	const progress = await response.json()
-	const response1819 = await fetch('/stats/progress/data-1819')
+	const response1819 = await fetch(`/stats/progress/data-1819${document.location.search}`)
 	const progress1819 = await response1819.json()
 
 	Highcharts.chart('container_overall', {

--- a/views/progress.ejs
+++ b/views/progress.ejs
@@ -65,7 +65,13 @@
 
 <section class="section">
 	<div class="container content">
-		<h1 class="title is-1">Progress</h1>
+		<h1 class="title is-1">Progress <span class="title is-5"><%= filter.current %></span></h1>
+		<p class="is-size-7">
+			<% filter.links.forEach((a, idx) => { %>
+				<% if (idx > 0) { %> - <% } %>
+				<a href="<%= a.href %>" class="filter"><%= a.text %></a>
+			<% }) %>
+		</p>
 		<figure class="highcharts-figure">
 			<div id="container_overall"></div>
 			<div id="container_18"></div>
@@ -76,6 +82,12 @@
 </section>
 
 <script>
+document.querySelectorAll('a.filter').forEach(a => {
+	const m = (a.href || '').match(/#competition=(0|1)/);
+	const qs = m ? `?competition=${m[1]}` : '';
+	a.href = `${document.location.pathname}${qs}`;
+});
+
 (async function showChart() {
 	const response = await fetch(`/stats/progress/data${document.location.search}`)
 	const progress = await response.json()

--- a/views/scores.ejs
+++ b/views/scores.ejs
@@ -29,7 +29,14 @@
 
 <section class="section">
 	<div class="container content">
-		<h1 class="title is-1">Score Summary</h1>
+		<h1 class="title is-1">Score Summary <span class="title is-5"><%= filter.current %></span></h1>
+
+		<p class="is-size-7">
+		<% filter.links.forEach((a, idx) => { %>
+			<% if (idx > 0) { %> - <% } %>
+			<a href="<%= a.href %>" class="filter"><%= a.text %></a>
+		<% }) %>
+		</p>
 
 		<%- include('partials/pagination') %>
 
@@ -55,7 +62,7 @@
 			<% const datetime = score.datetime.toISOString(); %>
 			<tr class="<%= idx % 2 ? 'odd': 'even' %>">
 
-				<td title="<%=datetime%>"><%= score.datetime.toISOString().substr(0, 16).replace('T', ' ') %></td>
+				<td title="<%=datetime%>"><%= datetime.substr(0, 16).replace('T', ' ') %></td>
 				<td class="data-number" align="right"><%= score.start_level %></td>
 				<td class="data-number" align="right"><%= score.end_level %></td>
 				<td class="score data-number" align="right"><%= (score.score || 0).toString().padStart(6, '0') %></td>
@@ -116,6 +123,12 @@
 
 		return `${score}`;
 	}
+
+	document.querySelectorAll('a.filter').forEach(a => {
+		const m = (a.href || '').match(/#competition=(0|1)/);
+		const qs = m ? `?competition=${m[1]}` : '';
+		a.href = `${document.location.pathname}${qs}`;
+	});
 
 	document.querySelectorAll('a.delete_score').forEach(a => {
 		a.addEventListener('click', async (evt) => {
@@ -216,12 +229,12 @@
 						if (data.competition) {
 							span.textContent = 'YES - ';
 							a.href = `/stats/scores/${id}/competition/0`;
-							a.textContent = 'set as regular game';
+							a.textContent = 'set as regular score';
 						}
 						else {
 							span.textContent = 'NO - ';
 							a.href = `/stats/scores/${id}/competition/1`;
-							a.textContent = 'set as competition game';
+							a.textContent = 'set as competition score';
 						}
 					}
 

--- a/views/scores.ejs
+++ b/views/scores.ejs
@@ -201,14 +201,62 @@
 				// TODO: derive stats again and show them
 				// TODO show pretty graphs
 
+				const dl = document.createElement('dl');
+
+				{
+					// Handle competition mode and score update
+					const dt = document.createElement('dt');
+					const dd = document.createElement('dd');
+					const span = document.createElement('span');
+					const a = document.createElement('a');
+
+					dt.textContent = 'Competition Score';
+
+					function updateCompetitionMode() {
+						if (data.competition) {
+							span.textContent = 'YES - ';
+							a.href = `/stats/scores/${id}/competition/false`;
+							a.textContent = 'set as regular game';
+						}
+						else {
+							span.textContent = 'NO - ';
+							a.href = `/stats/scores/${id}/competition/true`;
+							a.textContent = 'set as competition game';
+						}
+					}
+
+					updateCompetitionMode();
+
+					a.addEventListener('click', async (evt) => {
+						evt.preventDefault();
+
+						try {
+							const response = await fetch(a.href, {
+								method: 'PUT',
+								mode: 'cors',
+								credentials: 'same-origin'
+							});
+
+							data.competition = !data.competition;
+							updateCompetitionMode();
+						}
+						catch(err) {
+							alert('Unable to update score. You may already have a manual score for this start level.');
+						}
+					});
+
+					dd.appendChild(span);
+					dd.appendChild(a);
+					dl.appendChild(dt);
+					dl.appendChild(dd);
+				}
+
 				const details = {
 					Transition: data.transition ? data.transition.toString().padStart(6, '0') : '-',
 					Clears: data.clears || '-',
 					"Pseudo 29 Start Score": getLevel29StartScore(data.clears || '-'),
 					Pieces: data.pieces || '-',
 				};
-
-				const dl = document.createElement('dl');
 
 				for (const [key, value] of Object.entries(details)) {
 					const dt = document.createElement('dt');
@@ -237,12 +285,12 @@
 					dl.appendChild(dd);
 				}
 
-
 				td.innerHTML = ''; // clear the loading message
 				td.appendChild(dl);
 			}
 			catch(err) {
 				console.log('Unable to show details');
+				console.error(err);
 			}
 		});
 	});

--- a/views/scores.ejs
+++ b/views/scores.ejs
@@ -215,12 +215,12 @@
 					function updateCompetitionMode() {
 						if (data.competition) {
 							span.textContent = 'YES - ';
-							a.href = `/stats/scores/${id}/competition/false`;
+							a.href = `/stats/scores/${id}/competition/0`;
 							a.textContent = 'set as regular game';
 						}
 						else {
 							span.textContent = 'NO - ';
-							a.href = `/stats/scores/${id}/competition/true`;
+							a.href = `/stats/scores/${id}/competition/1`;
 							a.textContent = 'set as competition game';
 						}
 					}

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -183,26 +183,36 @@
 
 				<fieldset class="fieldset content">
 					<legend>Personal Best</legend>
-					<p>Depending on when you started to use NestrisChamps, and how often you use it, your PB may not be in NestrisChamps' database. Here you have the ability to manually set <strong>one PB per start level</strong> in NestrisChamps database.</p>
+					<p>Depending on when you started to use NestrisChamps, and how often you use it, your PB may not be in NestrisChamps' database. Here you have the ability to manually set <strong>one PB per start level</strong> in NestrisChamps' database.</p>
 
 					<div class="field">
 						<label class="label">PB</label>
 						<div class="control">
-							<input id="pb_score" class="input" type="number" placeholder="Score" min="0" max="1600000">
+							<input id="pb_score" class="input" type="number" placeholder="Score" min="0" max="10000000" />
 						</div>
 					</div>
 
 					<div class="field">
 						<label class="label">Start Level</label>
 						<div class="control">
-							<input id="pb_start_level" class="input" type="number" placeholder="Start Level" min="0" max="99">
+							<input id="pb_start_level" class="input" type="number" placeholder="Start Level" min="0" max="99" />
 						</div>
 					</div>
 
 					<div class="field">
 						<label class="label">End Level</label>
 						<div class="control">
-							<input id="pb_end_level" class="input" type="number" placeholder="End Level" min="0" max="99">
+							<input id="pb_end_level" class="input" type="number" placeholder="End Level" min="0" max="99" />
+						</div>
+					</div>
+
+					<div class="field">
+						<label class="label">While competing</label>
+						<div class="select">
+							<select id="pb_competition">
+								<option value="1">Yes</option>
+								<option value="0" selected>No</option>
+							</select>
 						</div>
 					</div>
 
@@ -302,6 +312,8 @@ document.getElementById('set_pb_btn').addEventListener('click', async () => {
 	for (const [key, node] of Object.entries(pb_nodes)) {
 		data[key] = parseInt(node.value, 10);
 	}
+
+	data.competition = document.getElementById('pb_competition').value === '1';
 
 	// fire and forget ... urgh -_-
 	try {


### PR DESCRIPTION
Based on request from player `CaptainRR`:

Add capabilities to distinguish between competition scores and regular score:
* Scores page can be filtered with a query string `?competition=0|1`
* Progress page can be filtered with a query string `?competition=0|1`
* Scores page allow user to switch the mode of a given score
* Producer page automatically sets the game as `competition=1` when in match room
* Games can be recorded as `competition=1` from the private room view by adding a query string argument `?competition=1`
* Manual scores can be added for regular and competitive games


Non-related bonus: Remove websocket connections that should not be allowed:
* Connect producer by user secret (user secret authentication should only be for views
* Remove ability of to load an admin page by user id
