### PR TITLE
feat: support gym pause

### DIFF
--- a/public/ocr/GameTracker.js
+++ b/public/ocr/GameTracker.js
@@ -290,6 +290,7 @@ export default class GameTracker {
 			lines,
 			level,
 			preview: dispatch_frame.preview,
+			gym_pause: dispatch_frame.gym_pause,
 			field,
 			color1,
 			color2,
@@ -342,13 +343,6 @@ export default class GameTracker {
 
 				pojo[p] = value;
 			});
-		}
-
-		if ('gym_pause' in dispatch_frame) {
-			// it's not necessary to push gym_pause in the frame pojo data
-			// but we do it anyway because the caller will display the data
-			// breaks encapsulation a litte
-			pojo.gym_pause = dispatch_frame.gym_pause;
 		}
 
 		this.onMessage(pojo);

--- a/public/ocr/GameTracker.js
+++ b/public/ocr/GameTracker.js
@@ -77,8 +77,8 @@ export default class GameTracker {
 
 		// TODO(?): Do we need to consider the frame buffer to detect the pause text "properly"
 		// TODO(?): check luma on level for better reliability (wity grey Gym rom)
-		last_frame.gym_pause = !!(
-			last_frame.pause_text?.[1] &&
+		last_frame.gym_pause_active = !!(
+			last_frame.gym_pause?.[1] &&
 			last_frame.score &&
 			last_frame.lines &&
 			last_frame.level
@@ -93,7 +93,7 @@ export default class GameTracker {
 				frame.level = last_frame.level;
 			});
 		} else if (
-			!last_frame.gym_pause &&
+			!last_frame.gym_pause_active &&
 			!GameTracker.arrEqual(last_frame.score, peek(this.frame_buffer).score)
 		) {
 			this.score_frame_delay = this.frame_buffer.length;
@@ -121,7 +121,7 @@ export default class GameTracker {
 					frame.I = last_frame.I;
 				});
 			} else if (
-				!last_frame.gym_pause &&
+				!last_frame.gym_pause_active &&
 				!GameTracker.pieceCountersEqual(last_frame, peek(this.frame_buffer))
 			) {
 				this.piece_frame_delay = this.frame_buffer.length;
@@ -137,7 +137,7 @@ export default class GameTracker {
 					frame.cur_piece_das = last_frame.cur_piece_das;
 				});
 			} else {
-				// note: no need to test for gym_pause in das trainer rom
+				// note: no need to test for gym_pause_active in das trainer rom
 				if (
 					last_frame.preview != peek(this.frame_buffer).preview ||
 					last_frame.cur_piece != peek(this.frame_buffer).cur_piece ||
@@ -159,7 +159,7 @@ export default class GameTracker {
 				});
 			} else {
 				if (
-					!last_frame.gym_pause &&
+					!last_frame.gym_pause_active &&
 					last_frame.preview != peek(this.frame_buffer).preview
 				) {
 					this.piece_frame_delay = this.frame_buffer.length;
@@ -175,7 +175,7 @@ export default class GameTracker {
 		const raw_ocr_frame = this.frame_buffer.shift();
 		const dispatch_frame = { ...raw_ocr_frame };
 
-		if (dispatch_frame.gym_pause) {
+		if (dispatch_frame.gym_pause_active) {
 			// On gym pause, we generate a fake vanilla-pause frame were everything is black
 			dispatch_frame.score = null;
 			dispatch_frame.lines = null;
@@ -190,7 +190,7 @@ export default class GameTracker {
 		// replicate NESTrisOCR's gameid logic
 		// also check if the fixers must be reset
 		if (
-			dispatch_frame.gym_pause ||
+			dispatch_frame.gym_pause_active ||
 			dispatch_frame.lines === null ||
 			dispatch_frame.score === null ||
 			dispatch_frame.level === null
@@ -290,7 +290,7 @@ export default class GameTracker {
 			lines,
 			level,
 			preview: dispatch_frame.preview,
-			gym_pause: dispatch_frame.gym_pause,
+			gym_pause_active: dispatch_frame.gym_pause_active,
 			field,
 			color1,
 			color2,

--- a/public/ocr/GameTracker.js
+++ b/public/ocr/GameTracker.js
@@ -297,6 +297,10 @@ export default class GameTracker {
 			pojo.cur_piece = dispatch_frame.cur_piece;
 		}
 
+		if (this.config.tasks.gym_pause) {
+			pojo.gym_pause = dispatch_frame.gym_pause;
+		}
+
 		this.onMessage(pojo);
 	}
 }

--- a/public/ocr/GameTracker.js
+++ b/public/ocr/GameTracker.js
@@ -259,6 +259,14 @@ export default class GameTracker {
 			score: GameTracker.digitsToValue(
 				this.score_fixer.fix(dispatch_frame.score)
 			), // note: nulls are passthrough
+
+			raw: {
+				...dispatch_frame,
+				field,
+				color1,
+				color2,
+				color3,
+			},
 		};
 
 		if (this.config.tasks.T) {

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -26,7 +26,7 @@ const PERF_METHODS = [
 	'scanInstantDas',
 	'scanCurPieceDas',
 	'scanCurPiece',
-	'scanPauseText',
+	'scanGymPause',
 ];
 
 const DEFAULT_COLOR_0 = [0x00, 0x00, 0x00];
@@ -55,14 +55,14 @@ const TASK_RESIZE = {
 	color3: [5, 5],
 	stats: [getDigitsWidth(3), 14 * 7 + 14 * 7], // height captures all the individual stats...
 	piece_count: [getDigitsWidth(3), 14],
-	pause_text: [22, 1],
+	gym_pause: [22, 1],
 };
 
 // Not supplied as user control, because Gym Pause is 100% connected to the calibration of the field
 // then again... We coud argue everything *should* be 100% connected to the calibration of the field,
 // so... is it really wise to not allow user-controlled fine-tuning? That plus being an internal process, we
 // are not able to show what we are capturing for the gym pause
-const PAUSE_TEXT_CROP_RELATIVE_TO_FIELD = [37, 47, 22, 1];
+const GYM_PAUSE_CROP_RELATIVE_TO_FIELD = [37, 47, 22, 1];
 
 const SHINE_LUMA_THRESHOLD = 75; // Since shine is white, should this threshold be higher?
 const GYM_PAUSE_LUMA_THRESHOLD = 75;
@@ -114,21 +114,21 @@ export default class TetrisOCR extends EventTarget {
 			const scaleX = field_crop[2] / TASK_RESIZE.field[0];
 			const scaleY = field_crop[3] / TASK_RESIZE.field[1];
 
-			// we compute the pause_text crop in relation to the field
-			const pause_text_crop_coordinates = [
+			// we compute the gym_pause crop in relation to the field
+			const gym_pause_crop_coordinates = [
 				Math.round(
-					field_crop[0] + PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[0] * scaleX
+					field_crop[0] + GYM_PAUSE_CROP_RELATIVE_TO_FIELD[0] * scaleX
 				),
 				Math.round(
-					field_crop[1] + PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[1] * scaleY
+					field_crop[1] + GYM_PAUSE_CROP_RELATIVE_TO_FIELD[1] * scaleY
 				),
-				Math.round(PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[2] * scaleX),
-				Math.round(PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[3] * scaleY),
+				Math.round(GYM_PAUSE_CROP_RELATIVE_TO_FIELD[2] * scaleX),
+				Math.round(GYM_PAUSE_CROP_RELATIVE_TO_FIELD[3] * scaleY),
 			];
 
-			this.pause_text_task = { crop: pause_text_crop_coordinates };
+			this.gym_pause_task = { crop: gym_pause_crop_coordinates };
 
-			all_tasks.pause_text = this.pause_text_task;
+			all_tasks.gym_pause = this.gym_pause_task;
 		}
 
 		// Note: This create a lot of imageData objects of similar sizes
@@ -309,8 +309,8 @@ export default class TetrisOCR extends EventTarget {
 			Object.assign(res, this.scanPieceStats(source_img));
 		}
 
-		if (this.pause_text_task) {
-			res.pause_text = this.scanPauseText(source_img);
+		if (this.gym_pause_task) {
+			res.gym_pause = this.scanGymPause(source_img);
 		}
 
 		return res;
@@ -707,13 +707,13 @@ export default class TetrisOCR extends EventTarget {
 			.map(v => Math.sqrt(v / pix_refs.length));
 	}
 
-	scanPauseText(source_img) {
+	scanGymPause(source_img) {
 		// Scanning the pause text scans the bottom of the letter 'U', "S", and "E" of the text "PAUSE"
 		// that's because the bottom of the letters overlaps with block margins, which are black
 		// When the pause text is not visible, luma on these overlap is expected to be very low
 		// When pause text is visible, luma is expected to be high.
 
-		const task = this.pause_text_task;
+		const task = this.gym_pause_task;
 		const xywh_coordinates = this.getCropCoordinates(task);
 
 		crop(source_img, ...xywh_coordinates, task.crop_img);

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -26,7 +26,7 @@ const PERF_METHODS = [
 	'scanInstantDas',
 	'scanCurPieceDas',
 	'scanCurPiece',
-	'scanGymPause',
+	'scanPauseText',
 ];
 
 const DEFAULT_COLOR_0 = [0x00, 0x00, 0x00];
@@ -55,8 +55,14 @@ const TASK_RESIZE = {
 	color3: [5, 5],
 	stats: [getDigitsWidth(3), 14 * 7 + 14 * 7], // height captures all the individual stats...
 	piece_count: [getDigitsWidth(3), 14],
-	gym_pause: [22, 1],
+	pause_text: [22, 1],
 };
+
+// Not supplied as user control, because Gym Pause is 100% connected to the calibration of the field
+// then again... We coud argue everything *should* be 100% connected to the calibration of the field,
+// so... is it really wise to not allow user-controlled fine-tuning? That plus being an internal process, we
+// are not able to show what we are capturing for the gym pause
+const PAUSE_TEXT_CROP_RELATIVE_TO_FIELD = [37, 47, 22, 1];
 
 const SHINE_LUMA_THRESHOLD = 75; // Since shine is white, should this threshold be higher?
 const GYM_PAUSE_LUMA_THRESHOLD = 75;
@@ -100,10 +106,35 @@ export default class TetrisOCR extends EventTarget {
 			right: -1,
 		};
 
-		// This create a lot of imageData objects of similar sizes
-		// Somecould be shared because they are the same dimensions (e.g. 3 digits for lines, and piece stats)
-		// but if we share them, we wouldnotbe able to display them individually in the debug UI
-		for (const [name, task] of Object.entries(this.config.tasks)) {
+		const all_tasks = { ...this.config.tasks };
+
+		if (!this.config.tasks.instant_das) {
+			const field_crop = this.config.tasks.field.crop;
+
+			const scaleX = field_crop[2] / TASK_RESIZE.field[0];
+			const scaleY = field_crop[3] / TASK_RESIZE.field[1];
+
+			// we compute the pause_text crop in relation to the field
+			const pause_text_crop_coordinates = [
+				Math.round(
+					field_crop[0] + PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[0] * scaleX
+				),
+				Math.round(
+					field_crop[1] + PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[1] * scaleY
+				),
+				Math.round(PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[2] * scaleX),
+				Math.round(PAUSE_TEXT_CROP_RELATIVE_TO_FIELD[3] * scaleY),
+			];
+
+			this.pause_text_task = { crop: pause_text_crop_coordinates };
+
+			all_tasks.pause_text = this.pause_text_task;
+		}
+
+		// Note: This create a lot of imageData objects of similar sizes
+		// Some could be shared because they are the same dimensions (e.g. 3 digits for lines, and piece stats)
+		// but if we share them, we would not be able to display them individually in the debug UI
+		for (const [name, task] of Object.entries(all_tasks)) {
 			if (this.palette && name.startsWith('color')) continue;
 
 			const {
@@ -268,7 +299,7 @@ export default class TetrisOCR extends EventTarget {
 		};
 
 		if (this.config.tasks.instant_das) {
-			// assumes all 3 das tasks are a unit
+			// assumes all 3 das tasks are a unit for the das trainer rom
 			res.instant_das = this.scanInstantDas(source_img);
 			res.cur_piece_das = this.scanCurPieceDas(source_img);
 			res.cur_piece = this.scanCurPiece(source_img);
@@ -278,8 +309,8 @@ export default class TetrisOCR extends EventTarget {
 			Object.assign(res, this.scanPieceStats(source_img));
 		}
 
-		if (this.config.tasks.gym_pause) {
-			res.gym_pause = this.scanGymPause(source_img);
+		if (this.pause_text_task) {
+			res.pause_text = this.scanPauseText(source_img);
 		}
 
 		return res;
@@ -676,8 +707,8 @@ export default class TetrisOCR extends EventTarget {
 			.map(v => Math.sqrt(v / pix_refs.length));
 	}
 
-	scanGymPause(source_img) {
-		const task = this.config.tasks.gym_pause;
+	scanPauseText(source_img) {
+		const task = this.pause_text_task;
 		const xywh_coordinates = this.getCropCoordinates(task);
 
 		crop(source_img, ...xywh_coordinates, task.crop_img);

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -708,6 +708,11 @@ export default class TetrisOCR extends EventTarget {
 	}
 
 	scanPauseText(source_img) {
+		// Scanning the pause text scans the bottom of the letter 'U', "S", and "E" of the text "PAUSE"
+		// that's because the bottom of the letters overlaps with block margins, which are black
+		// When the pause text is not visible, luma on these overlap is expected to be very low
+		// When pause text is visible, luma is expected to be high.
+
 		const task = this.pause_text_task;
 		const xywh_coordinates = this.getCropCoordinates(task);
 

--- a/public/ocr/TetrisOCR.js
+++ b/public/ocr/TetrisOCR.js
@@ -720,21 +720,15 @@ export default class TetrisOCR extends EventTarget {
 		bicubic(task.crop_img, task.scale_img);
 
 		const pix_refs = [
-			// 3 pixels for U
-			[1, 0],
+			// 1 pixel for U
 			[2, 0],
-			[3, 0],
 
-			// 3 pixels for S
-			[9, 0],
+			// 1 pixel for S
 			[10, 0],
-			[11, 0],
 
-			// 4 pixels for E
-			[16, 0],
+			// 2 pixels for E
 			[17, 0],
 			[18, 0],
-			[19, 0],
 		];
 
 		const total_luma = pix_refs

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1625,7 +1625,7 @@ function trackAndSendFrames() {
 			for (let key in data) {
 				if (key == 'ctime') continue;
 				if (key == 'raw') continue;
-				if (key == 'gym_pause') continue;
+				if (key == 'gym_pause_active') continue;
 				if (key == 'field') {
 					if (!data.field.every((v, i) => last_frame.field[i] === v)) {
 						break check_equal;

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -48,6 +48,7 @@ const reference_locations = {
 	S: { crop: [96, 304, 46, 14], pattern: 'BDD', red: true },
 	L: { crop: [96, 336, 46, 14], pattern: 'BDD', red: true },
 	I: { crop: [96, 368, 46, 14], pattern: 'BDD', red: true },
+	gym_pause: { crop: [266, 174, 44, 2] },
 };
 
 const configs = {
@@ -70,6 +71,7 @@ const configs = {
 			'S',
 			'L',
 			'I',
+			'gym_pause',
 		],
 	},
 	das_trainer: {
@@ -91,7 +93,7 @@ const configs = {
 		game_type: BinaryFrame.GAME_TYPE.MINIMAL,
 		reference: '/ocr/reference_ui_classic.png',
 		palette: 'easiercap',
-		fields: ['score', 'level', 'lines', 'field', 'preview'],
+		fields: ['score', 'level', 'lines', 'field', 'preview', 'gym_pause'],
 	},
 };
 

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1637,7 +1637,7 @@ function trackAndSendFrames() {
 			}
 
 			// all fields equal, do a sanity check on time
-			if (data.ctime - last_frame.ctime >= 200) break; // max 1 in 12 frames
+			if (data.ctime - last_frame.ctime >= 250) break; // max 1 in 15 frames (4fps)
 
 			// no need to send frame
 			return;

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1616,16 +1616,17 @@ function trackAndSendFrames() {
 		performance.clearMarks();
 		performance.clearMeasures();
 
+		// delete data fields which are never meant to be sent over the wire
 		delete data.color1;
 		delete data.color2;
 		delete data.color3;
+		delete data.gym_pause_active;
+		delete data.raw;
 
 		// only send frame if changed
 		check_equal: do {
 			for (let key in data) {
 				if (key == 'ctime') continue;
-				if (key == 'raw') continue;
-				if (key == 'gym_pause_active') continue;
 				if (key == 'field') {
 					if (!data.field.every((v, i) => last_frame.field[i] === v)) {
 						break check_equal;

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -1521,6 +1521,8 @@ function showFrameData(data) {
 	frame_data.innerHTML = '';
 
 	for (const [name, value] of Object.entries(data)) {
+		if (name === 'raw') continue;
+
 		const dt = document.createElement('dt');
 		const dd = document.createElement('dd');
 
@@ -1579,7 +1581,7 @@ function trackAndSendFrames() {
 
 		if (show_parts.checked) {
 			performance.mark('show_parts_start');
-			await showParts(data);
+			await showParts(data.raw); // show OCR values with no processing
 			performance.mark('show_parts_end');
 			try {
 				performance.measure('show_parts', 'show_parts_start', 'show_parts_end');

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -48,7 +48,6 @@ const reference_locations = {
 	S: { crop: [96, 304, 46, 14], pattern: 'BDD', red: true },
 	L: { crop: [96, 336, 46, 14], pattern: 'BDD', red: true },
 	I: { crop: [96, 368, 46, 14], pattern: 'BDD', red: true },
-	gym_pause: { crop: [266, 174, 44, 2] },
 };
 
 const configs = {
@@ -71,7 +70,6 @@ const configs = {
 			'S',
 			'L',
 			'I',
-			'gym_pause',
 		],
 	},
 	das_trainer: {
@@ -93,7 +91,7 @@ const configs = {
 		game_type: BinaryFrame.GAME_TYPE.MINIMAL,
 		reference: '/ocr/reference_ui_classic.png',
 		palette: 'easiercap',
-		fields: ['score', 'level', 'lines', 'field', 'preview', 'gym_pause'],
+		fields: ['score', 'level', 'lines', 'field', 'preview'],
 	},
 };
 
@@ -505,13 +503,14 @@ video.addEventListener('click', async evt => {
 		video.videoHeight
 	);
 
-	const field_xywh = getFieldCoordinates(img_data, floodStartPoint);
-	console.log('field coordinates', field_xywh);
+	// get field coordinates via flood-fill (includes borders on all sides)
+	const field_w_borders_xywh = getFieldCoordinates(img_data, floodStartPoint);
+	console.log('field coordinates', field_w_borders_xywh);
 
 	let [ox, oy, ow, oh] = getCaptureCoordinates(
 		reference_size,
 		reference_locations.field_w_borders.crop,
-		field_xywh
+		field_w_borders_xywh
 	);
 
 	if (ow <= 0 || oh <= 0) {
@@ -1625,6 +1624,8 @@ function trackAndSendFrames() {
 		check_equal: do {
 			for (let key in data) {
 				if (key == 'ctime') continue;
+				if (key == 'raw') continue;
+				if (key == 'gym_pause') continue;
 				if (key == 'field') {
 					if (!data.field.every((v, i) => last_frame.field[i] === v)) {
 						break check_equal;


### PR DESCRIPTION
## Context

Gym Pause overlaps the field and interferes with field scanning and block accounting. We we can actually detect the pause text when it overlaps on the block margin.

## Approach

Introduce scanning for `pause_text`, and use that to compute a `gym_pause` boolean.

When `gym_pause:true` is detected, generate a fake vanilla pause frame to the server. 

Bonus:
1.  Always show the raw OCR value in the calibration widgets. Do not show the corrected values.
2. Fix broken deferred check for das trainer changes