### PR TITLE
feat: introduce ready state for the whole room

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -487,11 +487,6 @@ class MatchRoom extends Room {
 					break; // simple passthrough
 				}
 
-				case 'focusPlayer': {
-					update_admin = false;
-					break; // simple passthrough
-				}
-
 				case 'setDisplayName': {
 					const [p_num, name] = args;
 
@@ -554,7 +549,9 @@ class MatchRoom extends Room {
 				case 'showProfileCard':
 				case 'setWinner':
 				case 'setGameOver':
-				case 'cancelGameOver': {
+				case 'cancelGameOver':
+				case 'focusPlayer':
+				case 'setReady': {
 					update_admin = false;
 					break; // simple passthrough
 				}

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -229,6 +229,8 @@ export default class Player {
 			...options,
 		};
 
+		this.ready = false;
+
 		this.field_pixel_size =
 			this.options.field_pixel_size || this.options.pixel_size;
 		this.preview_pixel_size =
@@ -427,6 +429,10 @@ export default class Player {
 	onGameOver() {}
 	onCurtainDown() {}
 	onTetris() {}
+
+	setReady(isReady) {
+		this.ready = !!isReady;
+	}
 
 	showProfileCard(visible) {
 		this.profile_card.hidden = !visible;
@@ -778,6 +784,12 @@ export default class Player {
 		this._renderLevel(last_frame);
 		this._renderLines(last_frame);
 		this._renderPiece(last_frame);
+
+		if (this.ready) {
+			this.showProfileCard(false);
+		}
+
+		this.ready = false;
 	}
 
 	_renderValidFrame(frame) {

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -194,6 +194,10 @@ class TetrisCompetitionAPI {
 		players.forEach(player => player.setCurtainLogo(url));
 	}
 
+	setReady(isReady) {
+		players.forEach(player => player.setReady(isReady));
+	}
+
 	_repaintVictories(player_idx) {
 		const player = players[player_idx]; // direct access... not great
 		const victories = this.victories[player_idx];

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -4,6 +4,7 @@ const dom = {
 	roomid: document.querySelector('#roomid'),
 	producer_count: document.querySelector('#producer_count'),
 	bestof: document.querySelector('#bestof'),
+	set_ready: document.querySelector('#set_ready'),
 	clear_victories: document.querySelector('#clear_victories'),
 	show_runways: document.querySelector('#show_runways'),
 	hide_runways: document.querySelector('#hide_runways'),
@@ -20,7 +21,7 @@ const dom = {
 
 const MAX_BEST_OF = 13;
 
-// TODO: refactor into dynamic getter
+// TODO: refactor into dynamic forwarder -_-
 const remoteAPI = {
 	setBestOf: function (n) {
 		connection.send(['setBestOf', n]);
@@ -93,6 +94,9 @@ const remoteAPI = {
 	},
 	focusPlayer: function (player_idx) {
 		connection.send(['focusPlayer', player_idx]);
+	},
+	setReady: function (ready) {
+		connection.send(['setReady', ready]);
 	},
 };
 
@@ -388,6 +392,10 @@ function bootstrap() {
 
 	dom.curtain_logo_url.onchange = () =>
 		remoteAPI.setCurtainLogo(dom.curtain_logo_url.value);
+
+	dom.set_ready.addEventListener('click', () => {
+		remoteAPI.setReady(true);
+	});
 
 	dom.clear_victories.addEventListener('click', () => {
 		remoteAPI.resetVictories();

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -142,6 +142,7 @@
 				/>
 			</div>
 			<div id="buttons">
+				<button id="set_ready" title="Profile card will auto-hide when the next game starts">Set Ready</button>
 				<button id="clear_victories">Clear Victories</button>
 				<button id="show_runways">Show Runways</button>
 				<button id="hide_runways">Hide Runways</button>


### PR DESCRIPTION
## Context

Profile cards are shown per match. In a 2-concurrent match view, when a game host wants to do a simul-start (especially relevant for live events), it can be a little stressful to quickly hide the profile cards for the 2 matches.

With ready state, a game host can put the players in ready state, and the profile card will automatically hide when the next game starts

## Approach

Introduce a ready state to automatically hide the profile card on next start.