### PR TITLE
Unpack gameStart & gameModeState

### DIFF
--- a/public/ocr/EDGameTracker.js
+++ b/public/ocr/EDGameTracker.js
@@ -176,8 +176,8 @@ export default class EDGameTracker {
 		const ctime = Date.now() - this.startTime; // record ctime as early as possible
 
 		const [
-			gameMode, // 0
-			playState,
+			gameStartGameMode, // 0
+			gameModeStatePlayState,
 			completedRowXClear,
 			completedRow0,
 			completedRow1,
@@ -215,6 +215,11 @@ export default class EDGameTracker {
 		] = frameBuffer;
 
 		field.length = 200; // drops the tail
+
+		const gameModeState = gameModeStatePlayState >> 4;
+		const playState = gameModeStatePlayState & 0xF;
+		const gameStart = gameStartGameMode >> 4;
+		const gameMode = gameStartGameMode & 0xF;
 
 		const frameCounter = (frameCounter1 << 8) | frameCounter0;
 		const lines = this._bcdToDecimal(lines0, lines1);


### PR DESCRIPTION
Currently this data does not exist, but getting this change in so that when the data is introduced it doesn't break anything.

gameModeState is a value 0-8.  During game play this will be 8 and at game over will be 3.  The values control which branch is taken [here](https://github.com/kirjavascript/TetrisGYM/blob/master/src/gamemodestate/branch.asm)

gameStart will be a 4 bit counter that will increment in the same function where the stats and playfield are [initialized](https://github.com/zohassadar/TetrisGYM/blob/master/src/gamemodestate/initstate.asm).  
