### PR TITLE
HTTPS Server if TLS_CERT & TLS_KEY are specified

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -96,7 +96,7 @@ router.get('/games/:id', async (req, res) => {
 
 		game.frame_url = `${base_url}${game.frame_file}`;
 	} else {
-		game.frame_url = `http${process.env.TLS_CERT ? "s" : ""}://${req.headers.host}/api/files/${game.frame_file}`;
+		game.frame_url = `${req.protocol}://${req.headers.host}/api/files/${game.frame_file}`;
 	}
 
 	res.json(game);

--- a/routes/api.js
+++ b/routes/api.js
@@ -96,7 +96,7 @@ router.get('/games/:id', async (req, res) => {
 
 		game.frame_url = `${base_url}${game.frame_file}`;
 	} else {
-		game.frame_url = `http://${req.headers.host}/api/files/${game.frame_file}`;
+		game.frame_url = `http${process.env.TLS_CERT ? "s" : ""}://${req.headers.host}/api/files/${game.frame_file}`;
 	}
 
 	res.json(game);

--- a/server.js
+++ b/server.js
@@ -5,19 +5,17 @@ import { readFileSync } from 'fs';
 
 import app from './modules/app.js';
 
-var server;
+let server;
 
 if (process.env.TLS_KEY && process.env.TLS_CERT) {
 	const options = {
 		key: readFileSync(process.env.TLS_KEY),
-		cert: readFileSync(process.env.TLS_CERT)
+		cert: readFileSync(process.env.TLS_CERT),
 	};
 	server = createServer(options, app);
-}
-else if (process.env.TLS_KEY || process.env.TLS_CERT) {
+} else if (process.env.TLS_KEY || process.env.TLS_CERT) {
 	throw new Error('HTTPS requires both TLS_KEY and TLS_CERT');
-}
-else {
+} else {
 	server = Server(app);
 }
 

--- a/server.js
+++ b/server.js
@@ -5,14 +5,17 @@ import { readFileSync } from 'fs';
 
 import app from './modules/app.js';
 
-var server
+var server;
+
 if (process.env.TLS_KEY && process.env.TLS_CERT) {
 	const options = {
 		key: readFileSync(process.env.TLS_KEY),
 		cert: readFileSync(process.env.TLS_CERT)
 	};
-
 	server = createServer(options, app);
+}
+else if (process.env.TLS_KEY || process.env.TLS_CERT) {
+	throw new Error('HTTPS requires both TLS_KEY and TLS_CERT');
 }
 else {
 	server = Server(app);

--- a/server.js
+++ b/server.js
@@ -1,9 +1,23 @@
 import { WebSocketServer } from 'ws';
 import { Server } from 'http';
+import { createServer } from 'https';
+import { readFileSync } from 'fs';
 
 import app from './modules/app.js';
 
-const server = Server(app);
+var server
+if (process.env.TLS_KEY && process.env.TLS_CERT) {
+	const options = {
+		key: readFileSync(process.env.TLS_KEY),
+		cert: readFileSync(process.env.TLS_CERT)
+	};
+
+	server = createServer(options, app);
+}
+else {
+	server = Server(app);
+}
+
 const wss = new WebSocketServer({
 	clientTracking: false,
 	noServer: true,


### PR DESCRIPTION
I run my local instance of nestrischamps on a computer that isn't my normal desktop, so in order to prevent the browser complaining about permission issues with either the webcam or serial port over HTTP, I bring the server up with a self signed certificate in HTTPS mode.    This change modifies server.js to bring up an HTTPS server if a cert file and key file are specified with environment variables.    This also modifies the playback link to be HTTPS.
