### PR TITLE
Support Ready and CountDown

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -554,7 +554,8 @@ class MatchRoom extends Room {
 				case 'setGameOver':
 				case 'cancelGameOver':
 				case 'focusPlayer':
-				case 'setReady': {
+				case 'setHideProfileCardOnNextGame':
+				case 'startCountDown': {
 					update_admin = false;
 					break; // simple passthrough
 				}

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -131,7 +131,11 @@
 			}
 
 			#room {
+				text-align: center;
 				overflow: hidden;
+			}
+			#room button {
+				margin-bottom: 1em;
 			}
 
 			#capture {
@@ -363,7 +367,12 @@
 				</div>
 			</div>
 
-			<div id="room"></div>
+			<div id="room">
+				<div class="controls">
+					<button id="set-ready">Set Ready</button>
+				</div>
+				<div class="view"></div>
+			</div>
 		</div>
 
 		<script src="/vendor/peerjs.1.5.1.min.js"></script>

--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -370,6 +370,7 @@
 			<div id="room">
 				<div class="controls">
 					<button id="set-ready">Set Ready</button>
+					<button id="not-ready">Not Ready</button>
 				</div>
 				<div class="view"></div>
 			</div>

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -101,7 +101,8 @@ const tabsContainer = document.querySelector('#tabs'),
 	tabContentsContainer = document.querySelector('#tab-content'),
 	tabContents = document.querySelectorAll('#tab-content > div'),
 	room = document.querySelector('#room'),
-	set_ready = room.querySelector('button'),
+	set_ready = room.querySelector('button#set-ready'),
+	not_ready = room.querySelector('button#not-ready'),
 	video_capture = document.querySelector('#video_capture'),
 	wizard = document.querySelector('#wizard'),
 	device_selector = document.querySelector('#device'),
@@ -648,6 +649,10 @@ focus_alarm.addEventListener('change', onFocusAlarmChanged);
 
 set_ready.addEventListener('click', () => {
 	connection?.send(['setReady']);
+});
+
+not_ready.addEventListener('click', () => {
+	connection?.send(['setReady', false]);
 });
 
 // ====================

--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -101,17 +101,16 @@ const tabsContainer = document.querySelector('#tabs'),
 	tabContentsContainer = document.querySelector('#tab-content'),
 	tabContents = document.querySelectorAll('#tab-content > div'),
 	room = document.querySelector('#room'),
+	set_ready = room.querySelector('button'),
 	video_capture = document.querySelector('#video_capture'),
 	wizard = document.querySelector('#wizard'),
 	device_selector = document.querySelector('#device'),
-	privacy = document.querySelector('#privacy'),
 	allow_video_feed = document.querySelector('#allow_video_feed'),
 	video_feed_selector = document.querySelector('#video_feed_device'),
 	video_feed = document.querySelector('#video_feed'),
 	color_matching = document.querySelector('#color_matching'),
 	palette_selector = document.querySelector('#palette'),
 	rom_selector = document.querySelector('#rom'),
-	controls = document.querySelector('#controls'),
 	instructions = document.querySelector('#instructions'),
 	capture_rate = document.querySelector('#capture_rate'),
 	show_parts = document.querySelector('#show_parts'),
@@ -583,8 +582,7 @@ function onShowPartsChanged() {
 	try {
 		adjustments.style.display = display;
 		config.source_canvas.style.display = display;
-	}
-	catch(err) {
+	} catch (err) {
 		// nothing to do here
 	}
 
@@ -647,6 +645,10 @@ function onFocusAlarmChanged() {
 }
 
 focus_alarm.addEventListener('change', onFocusAlarmChanged);
+
+set_ready.addEventListener('click', () => {
+	connection?.send(['setReady']);
+});
 
 // ====================
 // START: Image corrections
@@ -1807,7 +1809,7 @@ function loadRoomView() {
 	roomIFrame.setAttribute('height', 1080);
 	roomIFrame.setAttribute('src', url);
 
-	room.appendChild(roomIFrame);
+	room.querySelector('.view').appendChild(roomIFrame);
 
 	window.addEventListener('resize', resizeRoomIFrame);
 }

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -229,7 +229,7 @@ export default class Player {
 			...options,
 		};
 
-		this.ready = false;
+		this.hide_profile_card_on_next_game = false;
 
 		this.field_pixel_size =
 			this.options.field_pixel_size || this.options.pixel_size;
@@ -370,8 +370,8 @@ export default class Player {
 			display: 'none',
 			justifyContent: 'center',
 			alignItems: 'center',
-			fontSize: '1.5em',
-			lineHeight: '1.5em',
+			fontSize: '36px', // hardcoded is bad :'(
+			lineHeight: '36px',
 		});
 		this.comp_messages.hidden = true;
 		this.dom.field.appendChild(this.comp_messages);
@@ -453,8 +453,8 @@ export default class Player {
 	onCurtainDown() {}
 	onTetris() {}
 
-	setReady(isReady) {
-		this.ready = !!isReady;
+	setHideProfileCardOnNextGame(do_hide) {
+		this.hide_profile_card_on_next_game = !!do_hide;
 	}
 
 	showProfileCard(visible) {
@@ -553,20 +553,33 @@ export default class Player {
 		this.curtain_container.style.top = `-${this.bg_height}px`;
 	}
 
-	showCompMessage(message, double_size = false) {
+	showCompMessage(message, large = false) {
 		this.comp_messages.innerHTML = '';
 		const msg_container = document.createElement('div');
 		msg_container.innerText = message;
 		this.comp_messages.style.display = 'flex';
-		if (double_size) {
-			this.comp_messages.style.fontSize = '2em';
-		}
+		this.comp_messages.style.fontSize = large ? '48px' : '36px';
 		this.comp_messages.append(msg_container);
 	}
 
 	hideCompMessage() {
 		this.comp_messages.style.display = 'none';
-		this.comp_messages.style.fontSize = '1.5em';
+	}
+
+	startCountDown(seconds = 5) {
+		this.count_down_timer = clearTimeout(this.count_down_timer);
+
+		const showRemainingTime = () => {
+			this.showCompMessage(seconds--, true);
+
+			if (seconds >= 0) {
+				this.count_down_timer = setTimeout(showRemainingTime, 1000);
+			} else {
+				this.count_down_timer = null;
+			}
+		};
+
+		showRemainingTime();
 	}
 
 	_doTetris() {
@@ -825,11 +838,15 @@ export default class Player {
 		this._renderLines(last_frame);
 		this._renderPiece(last_frame);
 
-		if (this.ready) {
+		if (this.hide_profile_card_on_next_game) {
 			this.showProfileCard(false);
 		}
+		this.hide_profile_card_on_next_game = false;
 
-		this.ready = false;
+		if (this.count_down_timer) {
+			this.count_down_timer = clearTimeout(this.count_down_timer);
+		}
+		this.hideCompMessage();
 	}
 
 	_renderValidFrame(frame) {

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -194,8 +194,16 @@ class TetrisCompetitionAPI {
 		players.forEach(player => player.setCurtainLogo(url));
 	}
 
-	setReady(isReady) {
-		players.forEach(player => player.setReady(isReady));
+	setReady(isReady_or_player_Idx, ready = true) {
+		if (typeof isReady_or_player_Idx === 'number') {
+			if (ready) {
+				getPlayer(isReady_or_player_Idx).showCompMessage('READY');
+			} else {
+				getPlayer(isReady_or_player_Idx).hideCompMessage();
+			}
+		} else {
+			players.forEach(player => player.setReady(isReady));
+		}
 	}
 
 	_repaintVictories(player_idx) {

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -194,16 +194,20 @@ class TetrisCompetitionAPI {
 		players.forEach(player => player.setCurtainLogo(url));
 	}
 
-	setReady(isReady_or_player_Idx, ready = true) {
-		if (typeof isReady_or_player_Idx === 'number') {
-			if (ready) {
-				getPlayer(isReady_or_player_Idx).showCompMessage('READY');
-			} else {
-				getPlayer(isReady_or_player_Idx).hideCompMessage();
-			}
+	setReady(player_idx, ready = true) {
+		if (ready) {
+			getPlayer(player_idx).showCompMessage('READY');
 		} else {
-			players.forEach(player => player.setReady(isReady));
+			getPlayer(player_idx).hideCompMessage();
 		}
+	}
+
+	setHideProfileCardOnNextGame(do_hide) {
+		players.forEach(player => player.setHideProfileCardOnNextGame(do_hide));
+	}
+
+	startCountDown(seconds) {
+		players.forEach(player => player.startCountDown(seconds));
 	}
 
 	_repaintVictories(player_idx) {

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -4,7 +4,10 @@ const dom = {
 	roomid: document.querySelector('#roomid'),
 	producer_count: document.querySelector('#producer_count'),
 	bestof: document.querySelector('#bestof'),
-	set_ready: document.querySelector('#set_ready'),
+	setHideProfileCardOnNextGame: document.querySelector(
+		'#setHideProfileCardOnNextGame'
+	),
+	count_down: document.querySelector('#count_down'),
 	clear_victories: document.querySelector('#clear_victories'),
 	show_runways: document.querySelector('#show_runways'),
 	hide_runways: document.querySelector('#hide_runways'),
@@ -95,8 +98,11 @@ const remoteAPI = {
 	focusPlayer: function (player_idx) {
 		connection.send(['focusPlayer', player_idx]);
 	},
-	setReady: function (ready) {
-		connection.send(['setReady', ready]);
+	setHideProfileCardOnNextGame: function (do_hide) {
+		connection.send(['setHideProfileCardOnNextGame', do_hide]);
+	},
+	startCountDown: function (seconds) {
+		connection.send(['startCountDown', seconds]);
 	},
 };
 
@@ -393,8 +399,12 @@ function bootstrap() {
 	dom.curtain_logo_url.onchange = () =>
 		remoteAPI.setCurtainLogo(dom.curtain_logo_url.value);
 
-	dom.set_ready.addEventListener('click', () => {
-		remoteAPI.setReady(true);
+	dom.setHideProfileCardOnNextGame.addEventListener('click', () => {
+		remoteAPI.setHideProfileCardOnNextGame(true);
+	});
+
+	dom.count_down.addEventListener('click', () => {
+		remoteAPI.startCountDown(5);
 	});
 
 	dom.clear_victories.addEventListener('click', () => {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -141,8 +141,11 @@
 					placeholder="curtain logo url"
 				/>
 			</div>
-			<div id="buttons">
-				<button id="set_ready" title="Profile card will auto-hide when the next game starts">Set Ready</button>
+			<div class="buttons">
+				<button id="count_down" title="Show a 5s timer for ALL players">Count Down 5s</button>
+				<button id="setHideProfileCardOnNextGame" title="Profile card will auto-hide when the next game starts">Hide profile card when next game starts</button>
+			</div>
+			<div class="buttons">
 				<button id="clear_victories">Clear Victories</button>
 				<button id="show_runways">Show Runways</button>
 				<button id="hide_runways">Hide Runways</button>


### PR DESCRIPTION
In match rooms only:

* Players can set a ready signal that will show on his/her field in the renderers
* Admin can send a global count down signal to ALL PLAYERS of the room (beware of using this in multi-match rooms!)

There is no intelligence on state at the moment, if in the middle of a game, the admin accidentally clicks on the count down button, the game will be obstructed till the next game start,

TODOs:
- Add admin control to hide the field message (ready/countdown)
- The player ready button can be a toggle between ready/not-ready rather than being 2 buttons (terrible UX! 😅) 