### PR TITLE
feat: ignore player practice till next admin-started game

### DIFF
--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -599,6 +599,16 @@ export default class Player {
 
 	startCountDown(seconds = 5) {
 		this.count_down_timer = clearTimeout(this.count_down_timer);
+
+		this._gameReset();
+		this.renderPreview(18, null);
+		this.createGame(this.last_frame.gameid ?? 0);
+
+		// break encapsulation to alter behaviour
+		// frames from the current game should NOT cause any UI update till the next game start
+		this.game.no_curtain_top_out = true;
+		this.game.over = true;
+
 		this.only_show_admin_started_game = true;
 		this.admin_only_pending_game = true;
 
@@ -763,10 +773,11 @@ export default class Player {
 		this._refreshProfileCard();
 	}
 
-	createGame() {
+	createGame(gameid) {
 		this._destroyGame();
 
 		this.game = new BaseGame();
+		if (gameid) this.game.gameid = gameid;
 
 		// Handlers with local rendering actions
 		this.game.onScore = this._renderScore;
@@ -851,6 +862,8 @@ export default class Player {
 	}
 
 	_setFrameOuter(data) {
+		this.last_frame = data;
+
 		if (!this.game) {
 			this._renderNewGame(data);
 		} else {
@@ -859,6 +872,11 @@ export default class Player {
 	}
 
 	_renderNewGame(frame) {
+		if (this.only_show_admin_started_game) {
+			if (!this.admin_only_pending_game) return;
+			this.admin_only_pending_game = false;
+		}
+
 		this._gameReset();
 		this._hideCurtain();
 		this.createGame();


### PR DESCRIPTION
## Context

NTC layouts always show the real time data of the players, and compute the real time score differential between 2 players.

If after dying a player plays practice games, his last death score is reset, to be set to the current game score. And that messes up the score differential.


## Goal

The Game 5s count down now represents admin sanctionned games. Once a player dies, none of the latest game frame should affect the layouts till the admin starts the next officially sanctionned game (by triggering the next count down)


## Approach

The approach currently is a disgusting hack!!!

The player class intercepts new-game events, and prevents them to update the ui if the game is not in `admin_only_pending_game` "mode"



