### PR TITLE
Room view follows main view

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -194,8 +194,8 @@ class MatchRoom extends Room {
 				view_meta.concurrent_2_matches =
 					view_meta.concurrent_2_matches === 'true';
 			}
-			if ('players' in view_meta) {
-				view_meta.players = parseInt(view_meta.players, 10);
+			if ('_players' in view_meta) {
+				view_meta._players = parseInt(view_meta._players, 10);
 			}
 
 			if (this.state.concurrent_2_matches !== view_meta.concurrent_2_matches) {
@@ -294,7 +294,7 @@ class MatchRoom extends Room {
 	}
 
 	getMaxPossiblePlayers() {
-		return Math.min(this.getViewMeta().players || Infinity, MAX_PLAYERS);
+		return Math.min(this.getViewMeta()._players || Infinity, MAX_PLAYERS);
 	}
 
 	doAutoJoin() {

--- a/public/js/connection.js
+++ b/public/js/connection.js
@@ -18,7 +18,8 @@ export default class Connection {
 
 		if (extra_search_params) {
 			extra_search_params.forEach((value, key) => {
-				url.searchParams.set(key, value); // should this use .append() ?
+				if (key === 'players') key = '_players'; // do not reserve the key 'players'!
+				url.searchParams.set(key, value);
 			});
 		}
 

--- a/routes/websocket.js
+++ b/routes/websocket.js
@@ -71,6 +71,8 @@ export default function init(server, wss) {
 				user_secret: m[2],
 			};
 
+			request.nc_url.searchParams.set('_layout', request.tetris.view.layout_id);
+
 			// connection from the non-session-ed views (from OBS)
 			const user = await UserDAO.getUserBySecret(
 				request.tetris.view.user_secret


### PR DESCRIPTION
## Context

Players are not seeing the same view as the main stream.

## Approach

Since there is already a concept of primary view in NTC, leverage that to have the room view producer side be the same as the primary view.

Takes into account the layout name as well as ALL the query string params, so the room view gets updated as needed. 

Note: this only works for producers who have been marked as players. Non players are not notified of the primary room view.