### PR TITLE
Commentator View

### DIFF
--- a/public/views/BaseGame.js
+++ b/public/views/BaseGame.js
@@ -364,20 +364,25 @@ export default class BaseGame {
 		this.data.score.runways = { ...this.data.score.runways };
 		this.data.score.projections = { ...this.data.score.projections };
 
-		// pin the runway to whatever the final score is
-		for (const threshold_level of [39, 29, 19]) {
-			if (this.data.level >= threshold_level) break;
-
-			this.data.score.projections[`LV${threshold_level}`] =
-				this.data.score.runways[`LV${threshold_level}`] = death_score;
-		}
-
 		const last_point_evt = peek(last_frame?.points || []);
 
 		if (last_point_evt) {
 			last_point_evt.score.runway = death_score;
 			last_point_evt.score.projection = death_score;
 			last_point_evt.score.tr_runway = this.data.score.tr_runway;
+		}
+
+		// pin the runway to whatever the final score is
+		for (const threshold_level of [39, 29, 19]) {
+			if (this.data.level >= threshold_level) break;
+
+			this.data.score.projections[`LV${threshold_level}`] =
+				this.data.score.runways[`LV${threshold_level}`] = death_score;
+
+			if (!last_point_evt) continue;
+
+			last_point_evt.score.projections[`LV${threshold_level}`] =
+				last_point_evt.score.runways[`LV${threshold_level}`] = death_score;
 		}
 
 		this.onGameOver(last_frame);

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -197,6 +197,7 @@ const DEFAULT_OPTIONS = {
 	stereo: 0, // [-1, 1] representing left:-1 to right:1
 	reliable_field: 1,
 	draw_field: 1,
+	avatar: QueryString.get('avatar') !== '0',
 	curtain: 1,
 	buffer_time,
 	format_score: (v, size) => {
@@ -286,7 +287,7 @@ export default class Player extends EventTarget {
 		this.dom.field.prepend(this.field_bg);
 
 		// Avatar Block
-		if (QueryString.get('avatar') !== '0') {
+		if (this.options.avatar) {
 			this.avatar = document.createElement('div');
 			this.avatar.classList.add('avatar');
 			Object.assign(this.avatar.style, {

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -260,7 +260,7 @@ class TetrisCompetitionAPI {
 }
 
 // TODO: modularize this file better
-export default class Competition {
+export class Competition {
 	constructor(_players, api_overrides = {}) {
 		this.players = players = _players;
 
@@ -420,3 +420,5 @@ export default class Competition {
 		return this.players.filter(player => player.peerid === peerid);
 	}
 }
+
+export default Competition;

--- a/public/views/competition.js
+++ b/public/views/competition.js
@@ -37,12 +37,12 @@ function getPlayer(idx) {
 	return players[idx];
 }
 
-function tetris_value(level) {
+export function getTetrisValue(level) {
 	return 1200 * (level + 1);
 }
 
 function getSortedPlayers(players, getter = 'getScore') {
-	return players.concat().sort((p1, p2) => {
+	return [...players].sort((p1, p2) => {
 		const p1_score = p1[getter]();
 		const p2_score = p2[getter]();
 
@@ -79,12 +79,12 @@ export function getTetrisDiff(leader, laggard, getter = 'getScore') {
 		lines += 4;
 		tetrises += 1;
 
-		diff -= tetris_value(level);
+		diff -= getTetrisValue(level);
 	}
 
 	//  correct the overshot
 	//  note: diff is negative, to this statement *reduces* the tetrises value
-	tetrises += diff / tetris_value(level);
+	tetrises += diff / getTetrisValue(level);
 
 	return tetrises;
 }

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -323,6 +323,22 @@
 				color: #fff;
 			}
 
+			.runways .active.leader {
+				color: #0eff0e;
+			}
+
+			.runways .active.laggard {
+				color: #fd0009;
+			}
+
+			.runways .leader {
+				color: #008d00;
+			}
+
+			.runways .laggard {
+				color: #880005;
+			}
+
 			.simul-tetris {
 				display: none;
 				position: absolute;
@@ -584,7 +600,7 @@
 		<script src="/vendor/peerjs.1.5.1.min.js"></script>
 		<script type="module">
 			import '/views/bg.js';
-			import { peerServerOptions } from '/views/constants.js';
+			import { peerServerOptions, TRANSITIONS } from '/views/constants.js';
 			import {
 				peek,
 				noop,
@@ -593,17 +609,113 @@
 			} from '/views/utils.js';
 			import QueryString from '/js/QueryString.js';
 			import CompetitionPlayer from '/views/CompetitionPlayer.js';
-			import { Competition, getTetrisDiff } from '/views/competition.js';
+			import {
+				Competition,
+				getTetrisValue,
+				getTetrisDiff,
+			} from '/views/competition.js';
 			import InvisibleMixin from '/views/InvisibleMixin.js';
 
 			const player_template = document.getElementById('player');
 			const players = [];
 
+			function getLevelLines(player, level) {
+				if (player.game.data.start_level >= level) return 0;
+				if (level === player.game.data.start_level + 1)
+					return TRANSITIONS[player.game.data.start_level];
+				return level * 10 - TRANSITIONS[player.game.data.start_level];
+			}
+
+			function computeRunwayDiff(players, level) {
+				function getter() {
+					return this.game?.data.score.runways[`LV${level}`] || 0;
+				}
+
+				function setter(value) {
+					const formatted_value = this.options.format_tetris_diff(value);
+					const elmt = this.dom[`runway_tdiff_lv${level}`];
+
+					if (value < 0) {
+						elmt.textContent = `${formatted_value}`;
+						elmt.parentNode.classList.add('laggard');
+						elmt.parentNode.classList.remove('leader');
+						return;
+					}
+
+					elmt.parentNode.classList.remove('laggard');
+					elmt.parentNode.classList.add('leader');
+
+					if (value === 0) {
+						elmt.textContent = formatted_value;
+					} else {
+						elmt.textContent = `+${formatted_value}`;
+					}
+				}
+
+				const [leader, laggard] = [...players].sort(
+					(p1, p2) => getter.apply(p2) - getter.apply(p1)
+				);
+
+				const leader_score = getter.apply(leader);
+				const laggard_score = getter.apply(laggard);
+
+				if (leader_score === laggard_score) return 0;
+				if (!laggard.game?.data) return 0; // stupid value 🤷
+
+				const start_level = laggard.game.data.start_level;
+				const transition = TRANSITIONS[start_level];
+
+				let { lines: lgLines, level: lgLevel } = laggard.game.data;
+				let tetrises = 0;
+				let diff = leader_score - laggard_score;
+
+				if (lgLevel >= level) {
+					// the runway is passed, so we're basically computing the transition lead
+					// make some assumption on line threshold, otherwise it's too complicated
+					lgLevel = level;
+					lgLines = getLevelLines(laggard, level);
+				}
+
+				// console.log(level, [lgLevel, lgLines], [leader_score, laggard_score], diff);
+
+				while (diff > 0) {
+					if (lgLines >= transition - 4) {
+						// below transition, level doesn't change every 10 lines
+						if (lgLines % 10 >= 6) {
+							// the tetris is counted at end level, not start level
+							lgLevel += 1;
+						}
+					}
+
+					lgLines += 4;
+					tetrises += 1;
+
+					diff -= getTetrisValue(lgLevel);
+				}
+
+				//  correct the overshot
+				//  note: diff is negative, to this statement *reduces* the tetrises value
+				tetrises += diff / getTetrisValue(lgLevel);
+
+				setter.call(leader, tetrises);
+				setter.call(laggard, -tetrises);
+			}
+
+			function computeRunwayDiffs(players) {
+				const min_level = players.reduce(
+					(acc, p) => Math.min(acc, p.game?.data.level || 0),
+					Infinity
+				);
+				const levels = [19, 29, 39].filter(l => l > min_level);
+
+				for (const level of levels) {
+					computeRunwayDiff(players, level);
+				}
+			}
+
 			[1, 2].forEach(match_num => {
 				const match_node = document.getElementById(`match${match_num}`);
-
 				const match_players = [];
-				const sync_timers = [];
 
 				[1, 2].forEach((player_num, player_idx) => {
 					const player_fragment = document.importNode(
@@ -635,6 +747,16 @@
 							runway_lv19: player_node.querySelector(`.runways .value .lv19`),
 							runway_lv29: player_node.querySelector(`.runways .value .lv29`),
 							runway_lv39: player_node.querySelector(`.runways .value .lv39`),
+
+							runway_tdiff_lv19: player_node.querySelector(
+								`.runways .tdiff .lv19 span`
+							),
+							runway_tdiff_lv29: player_node.querySelector(
+								`.runways .tdiff .lv29 span`
+							),
+							runway_tdiff_lv39: player_node.querySelector(
+								`.runways .tdiff .lv39 span`
+							),
 
 							diff: player_node.querySelector(`.score .diff`),
 							t_diff: player_node.querySelector(`.score .tetris_diff .value`),
@@ -689,7 +811,7 @@
 
 					player.onLevel = frame => {
 						player.dom.tetris_value.textContent = readableScoreFomatter(
-							frame.raw.level * 1200
+							getTetrisValue(frame.raw.level)
 						);
 
 						[...player.dom.runways_box.querySelectorAll('.active')].forEach(
@@ -790,6 +912,8 @@
 						player.dom.runways_box.classList[
 							start_level >= 19 ? 'add' : 'remove'
 						]('hide19');
+
+						computeRunwayDiffs(match_players);
 					};
 
 					player.onGameOver = () => {
@@ -804,6 +928,10 @@
 								other_player.dom.runways_box.classList.add('visible');
 							}
 						}
+
+						player.dom.runways_box.querySelectorAll('.active').forEach(elmt => {
+							elmt.classList.remove('active');
+						});
 					};
 
 					match_players.push(player);
@@ -861,6 +989,7 @@
 
 				const updateMatchStats = () => {
 					competition.computeScoreDifferentials(match_players);
+					computeRunwayDiffs(match_players);
 				};
 
 				match_players.forEach(player => {

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -33,9 +33,9 @@
 			}
 
 			.score {
-				width: 333px;
+				width: 313px;
 				padding-right: 0;
-				height: 112px;
+				height: 139px;
 				top: 0;
 			}
 
@@ -46,8 +46,8 @@
 
 			.score .aligner {
 				display: inline-block;
-				font-size: 36.01px;
-				line-height: 40px;
+				font-size: 32.01px;
+				line-height: 36px;
 			}
 
 			.score .aligner .diff {
@@ -56,20 +56,12 @@
 			}
 
 			.score .tetris_diff {
-				margin-top: -40px;
-				line-height: 40px;
-				animation: 0.5s ease-out fadeOut;
-				opacity: 0;
+				margin-top: 6px;
+				font-size: 16.01px;
 			}
 
-			.score.with_tdiff .tetris_diff {
-				animation: 0.5s ease-out fadeIn;
-				opacity: 1;
-			}
-
-			.score.with_tdiff .aligner .diff {
-				animation: 0.5s ease-out fadeOut;
-				opacity: 0;
+			.score .tetris_diff .value {
+				font-size: 24.01px;
 			}
 
 			.aligner div {
@@ -77,54 +69,70 @@
 			}
 
 			.lines,
+			.tr_value,
+			.burn,
+			.burn_max,
+			.next_piece,
+			.level {
+				top: 166px;
+			}
+
+			.lines,
 			.next_piece {
-				top: 139px;
-				width: 151px;
+				width: 141px;
 				height: 56px;
 			}
 
 			.lines {
 				padding-top: 6px;
-				width: 155px;
+				width: 145px;
 				padding-right: 0;
-				--offset: 178px;
+				--offset: 168px;
 			}
 
 			.next_piece {
 				height: 59px;
 			}
 
+			.board,
+			.drought {
+				top: 252px;
+			}
+
 			.board {
 				--border-size: 12;
 				padding: 3px;
-				width: 336px;
-				height: 676px;
-				top: 225px;
+				width: 316px;
+				height: 636px;
 			}
 
 			.name,
 			.tetris_rate,
+			.burn,
+			.burn_max,
+			.efficiency,
 			.drought,
-			.level {
+			.level,
+			.tr_value {
 				padding-right: 0;
 			}
 
 			.name,
 			.flag {
-				top: 923px;
+				top: 910px;
 			}
 
 			.name {
 				--offset: 0;
-				width: 336px;
+				width: 316px;
 				padding: 3px 0;
-				height: 64px;
+				height: 77px;
 				text-transform: uppercase;
 			}
 
 			.name .header {
 				font-size: 32.01px; /* sad -_- */
-				padding-top: 21px;
+				padding-top: 29px;
 				padding-bottom: 9px;
 			}
 
@@ -154,12 +162,14 @@
 			.tetris_rate,
 			.drought,
 			.flag,
-			.running_trt {
-				--offset: 357px;
+			.burn,
+			.efficiency,
+			.runways {
+				--offset: 337px;
 			}
 
 			.hearts {
-				bottom: -766px;
+				bottom: -919px;
 				width: 24px;
 				padding-right: 0;
 				height: unset;
@@ -182,35 +192,81 @@
 			}
 
 			.level,
+			.tr_value,
 			.tetris_rate,
+			.burn,
+			.burn_max,
+			.efficiency,
 			.drought {
 				padding-top: 5px;
 				width: 78px;
 				height: 54px;
 			}
 
-			.tetris_rate,
-			.drought {
-				top: 840px;
+			.level,
+			.tr_value,
+			.burn,
+			.burn_max {
+				height: 57px;
 			}
 
-			.level {
-				top: 757px;
-				width: 56px;
+			.tr_value {
+				width: 177px;
+				--offset: 439px;
+			}
+
+			.burn,
+			.drought,
+			.burn_max {
+				width: 132px;
+			}
+
+			.burn {
+				--offset: 640px;
+			}
+
+			.burn_max {
+				--offset: 796px;
+			}
+
+			.burn .header span,
+			.burn_max .header span,
+			.drought .header span {
+				font-size: 16.01px;
+			}
+
+			.tetris_rate {
+				top: 0;
+			}
+
+			.efficiency {
+				top: 83px;
 			}
 
 			.drought {
-				color: red;
-				display: none;
+				width: 120px;
+				height: 57px;
+				padding-left: 1px;
+			}
+
+			.drought.last {
+				width: 135px;
+				--offset: 479px;
+			}
+
+			.drought.max {
+				--offset: 636px;
+			}
+
+			.drought.count {
+				width: 152px;
+				--offset: 778px;
 			}
 
 			.drought.active {
+				color: red;
 				display: block;
 				animation: 0.5s ease-out fadeIn;
-			}
-
-			.drought .header {
-				padding-bottom: 4px; /* because the bar is thinner than text */
 			}
 
 			.drought .header img {
@@ -222,31 +278,28 @@
 
 			.flag {
 				padding: 0;
-				width: 105px;
-				height: 70px;
+				width: 125px;
+				height: 83px;
 			}
 
 			.running_trt {
-				top: 0;
 				padding: 0;
+				top: 0;
+				--offset: 439px;
 				right: var(--offset);
-				width: 573px;
-				height: 90px;
+				width: 491px;
+				height: 145px;
 			}
 
 			.runways {
 				display: none;
 				justify-content: space-between;
 				color: #888;
-				font-size: 24.01px;
-				line-height: 24px;
-				--offset: 483px;
 				right: var(--offset);
-				width: 444px;
+				width: 591px;
 				height: unset;
-				bottom: -1023px;
-				--border-size: 12;
-				padding: 3px 3px 1px 6px;
+				top: 338px;
+				line-height: 28px;
 			}
 
 			.runways.hide19 .lv19,
@@ -265,6 +318,11 @@
 
 			.runways .value {
 				text-align: right;
+			}
+
+			.runways .tdiff {
+				text-align: right;
+				font-size: 16.01px;
 			}
 
 			.runways .active {
@@ -293,14 +351,14 @@
 
 			.player_vid {
 				position: absolute;
-				top: 0;
-				width: 600px;
-				height: 1023px;
+				top: 455px;
+				width: 614px;
+				height: 565px;
 				padding: 0;
 				object-fit: cover;
 				/* background: yellow; /**/
 
-				--offset: 360px;
+				--offset: 346px;
 				right: var(--offset);
 			}
 
@@ -463,8 +521,23 @@
 				</div>
 
 				<div class="box level">
-					<div class="header">LV</div>
+					<div class="header">LVL</div>
 					<div class="content">00</div>
+				</div>
+
+				<div class="box tr_value">
+					<div class="header">TR VAL</div>
+					<div class="content">000&#x202F;000</div>
+				</div>
+
+				<div class="box burn">
+					<div class="header">BRN<span>CUR</span></div>
+					<div class="content">---</div>
+				</div>
+
+				<div class="box burn_max">
+					<div class="header">BRN<span>MAX</span></div>
+					<div class="content">---</div>
 				</div>
 
 				<div class="box tetris_rate">
@@ -472,8 +545,28 @@
 					<div class="content">---</div>
 				</div>
 
+				<div class="box efficiency">
+					<div class="header">EFF</div>
+					<div class="content">---</div>
+				</div>
+
 				<div class="box drought">
-					<div class="header"><img src="/views/red_bar.png" /></div>
+					<div class="header">DRT<span>CUR</span></div>
+					<div class="value">99</div>
+				</div>
+
+				<div class="box drought last">
+					<div class="header">DRT<span>LAST</span></div>
+					<div class="value">99</div>
+				</div>
+
+				<div class="box drought max">
+					<div class="header">DRT<span>MAX</span></div>
+					<div class="value">99</div>
+				</div>
+
+				<div class="box drought count">
+					<div class="header">DRT<span>COUNT</span></div>
 					<div class="value">99</div>
 				</div>
 
@@ -490,6 +583,11 @@
 						<div class="lv19">000&#x202F;000</div>
 						<div class="lv29">0&#x202F;000&#x202F;000</div>
 						<div class="lv39">0&#x202F;000&#x202F;000</div>
+					</div>
+					<div class="tdiff">
+						<div class="lv19">+0.00T</div>
+						<div class="lv29">+0.00T</div>
+						<div class="lv39">+0.00T</div>
 					</div>
 				</div>
 
@@ -567,10 +665,6 @@
 			const SIMUL_TETRIS_DELAY = SHOW_SIMUL_TETRIS
 				? parseInt(QueryString.get('simultris'), 10)
 				: 120;
-
-			const CYCLE_TDIFF = /^[1-9]\d*$/.test(QueryString.get('cycle_tdiff'))
-				? parseInt(QueryString.get('cycle_tdiff'), 10)
-				: 0;
 
 			const sponsor_img_index = /^\d+$/.test(QueryString.get('sponsorimg'))
 				? parseInt(QueryString.get('sponsorimg'), 10)
@@ -685,6 +779,8 @@
 							level: player_node.querySelector(`.level .content`),
 							lines: player_node.querySelector(`.lines .content`),
 							trt: player_node.querySelector(`.tetris_rate .content`),
+							eff: player_node.querySelector(`.efficiency .content`),
+							burn: player_node.querySelector(`.burn .content`),
 							preview: player_node.querySelector(`.next_piece`),
 							field: player_node.querySelector(`.board`),
 							drought: player_node.querySelector(`.drought .value`),
@@ -714,8 +810,8 @@
 						{
 							biglogo: true,
 							bigntc: true,
-							field_pixel_size: 4.25,
-							running_trt_dot_size: 5,
+							field_pixel_size: 4,
+							running_trt_dot_size: 4,
 							preview_pixel_size: 3.75,
 							format_score: v => readableScoreFomatter(v),
 							stereo: translate([1, 2], [-1, 1], player_num),
@@ -724,10 +820,6 @@
 
 					if (QueryString.get('invisible') === '1') {
 						InvisibleMixin(player);
-					}
-
-					if (!CYCLE_TDIFF) {
-						player.dom.score_box.querySelector('.tetris_diff').remove();
 					}
 
 					if (show_runways === true) {
@@ -1010,14 +1102,6 @@
 					commentatorBot = new MatchCommentatorBot(match_players);
 				}
 			});
-
-			if (CYCLE_TDIFF) {
-				setInterval(() => {
-					players.forEach(player => {
-						player.dom.score_box.classList.toggle('with_tdiff');
-					});
-				}, CYCLE_TDIFF * 1000);
-			}
 
 			const competition = new Competition(players);
 

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -290,7 +290,7 @@
 				justify-content: space-between;
 				color: #888;
 				right: var(--offset);
-				width: 591px;
+				width: 588px;
 				height: unset;
 				top: 338px;
 				line-height: 28px;

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -1,0 +1,1106 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<link rel="stylesheet" type="text/css" href="/views/tetris.css" />
+		<style>
+			#stream_bg {
+				width: 1920px;
+				height: 1080px;
+			}
+
+			.match {
+				position: absolute;
+				left: 960px;
+				top: 0;
+			}
+
+			.box {
+				padding: 3px;
+				font-size: 24.01px;
+				line-height: 24px;
+				height: 51px;
+				right: var(--offset);
+			}
+
+			.box .header {
+				padding-bottom: 6px;
+			}
+
+			.board,
+			.score,
+			.next_piece {
+				--offset: 0;
+			}
+
+			.score {
+				width: 333px;
+				padding-right: 0;
+				height: 112px;
+				top: 0;
+			}
+
+			.score .header {
+				padding-top: 2px;
+				padding-bottom: 8px;
+			}
+
+			.score .aligner {
+				display: inline-block;
+				font-size: 36.01px;
+				line-height: 40px;
+			}
+
+			.score .aligner .diff {
+				animation: 0.5s ease-out fadeIn;
+				opacity: 1;
+			}
+
+			.score .tetris_diff {
+				margin-top: -40px;
+				line-height: 40px;
+				animation: 0.5s ease-out fadeOut;
+				opacity: 0;
+			}
+
+			.score.with_tdiff .tetris_diff {
+				animation: 0.5s ease-out fadeIn;
+				opacity: 1;
+			}
+
+			.score.with_tdiff .aligner .diff {
+				animation: 0.5s ease-out fadeOut;
+				opacity: 0;
+			}
+
+			.aligner div {
+				text-align: right;
+			}
+
+			.lines,
+			.next_piece {
+				top: 139px;
+				width: 151px;
+				height: 56px;
+			}
+
+			.lines {
+				padding-top: 6px;
+				width: 155px;
+				padding-right: 0;
+				--offset: 178px;
+			}
+
+			.next_piece {
+				height: 59px;
+			}
+
+			.board {
+				--border-size: 12;
+				padding: 3px;
+				width: 336px;
+				height: 676px;
+				top: 225px;
+			}
+
+			.name,
+			.tetris_rate,
+			.drought,
+			.level {
+				padding-right: 0;
+			}
+
+			.name,
+			.flag {
+				top: 923px;
+			}
+
+			.name {
+				--offset: 0;
+				width: 336px;
+				padding: 3px 0;
+				height: 64px;
+				text-transform: uppercase;
+			}
+
+			.name .header {
+				font-size: 32.01px; /* sad -_- */
+				padding-top: 21px;
+				padding-bottom: 9px;
+			}
+
+			.name .content {
+				display: none;
+				color: #b0afb0;
+				letter-spacing: 5px;
+				text-indent: 5px;
+			}
+
+			.name .content .win {
+				color: #fb0204;
+			}
+
+			.name.seed .header {
+				padding-top: 14px;
+				padding-bottom: 0;
+			}
+
+			.name.seed .content {
+				display: unset;
+				font-size: 16.01px;
+			}
+
+			.hearts,
+			.level,
+			.tetris_rate,
+			.drought,
+			.flag,
+			.running_trt {
+				--offset: 357px;
+			}
+
+			.hearts {
+				bottom: -766px;
+				width: 24px;
+				padding-right: 0;
+				height: unset;
+				font-size: 0px;
+				line-height: 32px;
+			}
+
+			.hearts span {
+				width: 24px;
+				height: 30px;
+				overflow: hidden;
+				background: url(/views/heart_grey.png);
+				background-repeat: no-repeat;
+				background-position: center left;
+				display: block;
+			}
+
+			.hearts span.win {
+				background-image: url(/views/heart_red.png);
+			}
+
+			.level,
+			.tetris_rate,
+			.drought {
+				padding-top: 5px;
+				width: 78px;
+				height: 54px;
+			}
+
+			.tetris_rate,
+			.drought {
+				top: 840px;
+			}
+
+			.level {
+				top: 757px;
+				width: 56px;
+			}
+
+			.drought {
+				color: red;
+				display: none;
+			}
+
+			.drought.active {
+				display: block;
+				animation: 0.5s ease-out fadeIn;
+			}
+
+			.drought .header {
+				padding-bottom: 4px; /* because the bar is thinner than text */
+			}
+
+			.drought .header img {
+				padding-top: 3px;
+				margin-left: -2px;
+				vertical-align: top;
+				animation: 1s linear infinite fadeOut;
+			}
+
+			.flag {
+				padding: 0;
+				width: 105px;
+				height: 70px;
+			}
+
+			.running_trt {
+				top: 0;
+				padding: 0;
+				right: var(--offset);
+				width: 573px;
+				height: 90px;
+			}
+
+			.runways {
+				display: none;
+				justify-content: space-between;
+				color: #888;
+				font-size: 24.01px;
+				line-height: 24px;
+				--offset: 483px;
+				right: var(--offset);
+				width: 444px;
+				height: unset;
+				bottom: -1023px;
+				--border-size: 12;
+				padding: 3px 3px 1px 6px;
+			}
+
+			.runways.hide19 .lv19,
+			.runways.hide39 .lv39 {
+				display: none;
+			}
+
+			.runways.visible {
+				display: flex;
+				animation: 0.5s ease-out fadeIn;
+			}
+
+			.runways .label {
+				text-align: left;
+			}
+
+			.runways .value {
+				text-align: right;
+			}
+
+			.runways .active {
+				color: #fff;
+			}
+
+			.simul-tetris {
+				display: none;
+				position: absolute;
+				transform-origin: 50% 50%;
+				top: 150px;
+				--offset: 341px;
+				right: var(--offset);
+			}
+
+			.p2 > * {
+				left: var(--offset);
+			}
+
+			.p2 .lines {
+				left: 0;
+			}
+			.p2 .next_piece {
+				left: 179px;
+			}
+
+			.player_vid {
+				position: absolute;
+				top: 0;
+				width: 600px;
+				height: 1023px;
+				padding: 0;
+				object-fit: cover;
+				/* background: yellow; /**/
+
+				--offset: 360px;
+				right: var(--offset);
+			}
+
+			#ticker {
+				position: absolute;
+				width: 1920px;
+				height: 57px;
+				top: 1023px;
+				/* background: orange;
+				opacity: 0.5; /**/
+			}
+
+			.match.small {
+				transform: scale(0.7245042492917847); /* (1080-57)/706/2 */
+			}
+			#match2.small {
+				top: 511px;
+			}
+
+			.match.small .runways {
+				display: none;
+			}
+
+			.match.small .score,
+			.match.small .lines,
+			.match.small .next_piece {
+				--offset: 357px;
+			}
+
+			.match.small .next_piece {
+				z-index: 4;
+				top: 139px;
+			}
+
+			.match.small .lines {
+				z-index: 3;
+				width: 154px;
+				top: 225px;
+			}
+
+			.match.small .level {
+				z-index: 2;
+				top: 311px;
+				width: 78px;
+			}
+
+			.match.small .tetris_rate,
+			.match.small .drought {
+				top: 394px;
+				z-index: 1;
+			}
+
+			.match.small .score {
+				width: 302px;
+			}
+
+			.match.small .board {
+				top: 0;
+				z-index: 8;
+			}
+			.match.small .score {
+				z-index: 7;
+			}
+			.match.small .hearts {
+				bottom: unset;
+				top: 477px;
+			}
+			.match.small .flag,
+			.match.small .name {
+				z-index: 6;
+				top: 0;
+			}
+			.match.small .name {
+				width: 486px;
+				--offset: 683px;
+			}
+			.match.small .flag {
+				--offset: 1190px;
+			}
+			.match.small .player_vid {
+				top: 96px;
+				width: 965px;
+				height: 609px;
+			}
+
+			.match.small .simul-tetris {
+				top: 250px;
+				--offset: 574px;
+			}
+
+			.match.small .p2 > * {
+				left: var(--offset);
+			}
+		</style>
+	</head>
+	<body>
+		<template id="curtain_0">
+			<div class="custom_curtain">
+				<br />
+				<br />
+				<img src="/images/ctwc_das_400.png" style="max-width: 220px" />
+				<br />
+				<br />
+				<p style="font-size: 12px">Presented by</p>
+				<img src="/images/sponsors/logo-experion.svg" style="width: 280px" />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<img src="/brand/logo.v3.white.png" />
+			</div>
+		</template>
+		<template id="curtain_1">
+			<div class="custom_curtain">
+				<br />
+				<br />
+				<br />
+				<img src="/images/ctwc_logo.jpeg" style="max-width: 240px" />
+				<br />
+				<br />
+				<!-- p style="font-size: 12px">Presented by</p>
+				<img src="/images/sponsors/G_Fuel_logo.svg" style="width: 260px" / -->
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<img src="/brand/logo.v3.white.3x.png" style="max-width: 110px" />
+			</div>
+		</template>
+		<template id="player">
+			<div class="player">
+				<video class="player_vid"></video>
+
+				<div class="box hearts">&nbsp;</div>
+
+				<div class="box name">
+					<div class="header">PLAYER 1</div>
+					<div class="content"></div>
+				</div>
+
+				<div class="box lines">
+					<div class="header">LINES</div>
+					<div class="content">000</div>
+				</div>
+
+				<div class="box next_piece"></div>
+
+				<div class="box score">
+					<div class="header">SCORE</div>
+					<div class="aligner">
+						<div class="value">0&#x202F;000&#x202F;000</div>
+						<div class="diff winning">0&#x202F;000&#x202F;000</div>
+					</div>
+					<div class="tetris_diff">
+						<span class="value">0.00</span>&#x202F;TETRISES
+					</div>
+				</div>
+
+				<div class="box level">
+					<div class="header">LV</div>
+					<div class="content">00</div>
+				</div>
+
+				<div class="box tetris_rate">
+					<div class="header">TRT</div>
+					<div class="content">---</div>
+				</div>
+
+				<div class="box drought">
+					<div class="header"><img src="/views/red_bar.png" /></div>
+					<div class="value">99</div>
+				</div>
+
+				<div class="box running_trt"></div>
+				<div class="box board"></div>
+
+				<div class="box runways">
+					<div class="label">
+						<div class="lv19">L19&#x202F;RUNWAY</div>
+						<div class="lv29">L29&#x202F;RUNWAY</div>
+						<div class="lv39">L39&#x202F;RUNWAY</div>
+					</div>
+					<div class="value">
+						<div class="lv19">000&#x202F;000</div>
+						<div class="lv29">0&#x202F;000&#x202F;000</div>
+						<div class="lv39">0&#x202F;000&#x202F;000</div>
+					</div>
+				</div>
+
+				<div class="box flag"></div>
+
+				<img class="simul-tetris" src="/images/simul-tetris.png" />
+			</div>
+		</template>
+
+		<div id="stream_bg">
+			<div id="match1" class="match small"></div>
+			<div id="match2" class="match small"></div>
+
+			<div id="ticker"></div>
+
+			<div id="playing_fields">
+				<!-- divider -->
+
+				<!-- Player 1 -->
+				<!-- Player 2 -->
+			</div>
+			<!-- End Playing Fields -->
+		</div>
+		<!-- End Stream BG -->
+
+		<!-- Audio -->
+
+		<script>
+			// custom view parameters which will be passed in the websocket URI
+			const view_meta = new URLSearchParams({
+				video: '1920x1080', // urgh, so big for so much space wasted :(
+				concurrent_2_matches: true,
+				players: 4,
+			});
+		</script>
+		<script src="/vendor/peerjs.1.5.1.min.js"></script>
+		<script type="module">
+			import '/views/bg.js';
+			import { peerServerOptions } from '/views/constants.js';
+			import { noop, translate, readableScoreFomatter } from '/views/utils.js';
+			import QueryString from '/js/QueryString.js';
+			import CompetitionPlayer from '/views/CompetitionPlayer.js';
+			import Competition from '/views/competition.js';
+			import InvisibleMixin from '/views/InvisibleMixin.js';
+			import { MatchCommentatorBot } from '/views/commentator_bot.js';
+
+			let commentatorBot;
+
+			// Penner easing
+			// http://robertpenner.com/easing/
+			function easeOutElastic(t, b, c, d) {
+				var s = 1.70158;
+				var p = 0;
+				var a = c;
+				if (t == 0) return b;
+				if ((t /= d) >= 1) return b + c;
+				if (!p) p = d * 0.3;
+				if (a < Math.abs(c)) {
+					a = c;
+					var s = p / 4;
+				} else var s = (p / (2 * Math.PI)) * Math.asin(c / a);
+				return (
+					a *
+						Math.pow(2, -10 * t) *
+						Math.sin(((t * d - s) * (2 * Math.PI)) / p) +
+					c +
+					b
+				);
+			}
+
+			const isDAS = QueryString.get('style') === 'das';
+			const hasAds = QueryString.get('ads') === '1';
+
+			const SHOW_SIMUL_TETRIS = /^[1-9]\d*$/.test(QueryString.get('simultris'));
+			const SIMUL_TETRIS_DELAY = SHOW_SIMUL_TETRIS
+				? parseInt(QueryString.get('simultris'), 10)
+				: 120;
+
+			const CYCLE_TDIFF = /^[1-9]\d*$/.test(QueryString.get('cycle_tdiff'))
+				? parseInt(QueryString.get('cycle_tdiff'), 10)
+				: 0;
+
+			const sponsor_img_index = /^\d+$/.test(QueryString.get('sponsorimg'))
+				? parseInt(QueryString.get('sponsorimg'), 10)
+				: 0;
+
+			let curtain_template;
+			if (/^[01]$/.test(QueryString.get('curtain'))) {
+				curtain_template = document.getElementById(
+					`curtain_${QueryString.get('curtain')}`
+				);
+			}
+
+			// triple-typed variable... that is disgusting -_-
+			// false: never show runways (default)
+			// 1 -> true: always show runways
+			// 'transitions' -> 'transitions': show slightly before transitions
+			// x,y -> [x, y]: show runways for x seconds every y seconds
+			let show_runways = false;
+			if (QueryString.get('runways') === '1') {
+				show_runways = true;
+			} else if (QueryString.get('runways') === 'transitions') {
+				show_runways = 'transitions';
+			} else {
+				const m = (QueryString.get('runways') || '').match(
+					/^([1-9]\d*),([1-9]\d*)$/
+				);
+				if (m) {
+					const show_for = parseInt(m[1], 10);
+					const repeat_in = parseInt(m[2], 10);
+					if (show_for < repeat_in) show_runways = [show_for, repeat_in];
+				}
+			}
+
+			let images;
+
+			if (hasAds) {
+				images = [
+					'/images/sponsors/ctwcdas_inner_20.png',
+					'/images/sponsors/gfuel_30.png',
+				].map(url => {
+					const img = new Image();
+					img.src = url;
+					return img;
+				});
+			}
+
+			const player_template = document.getElementById('player');
+			const players = [];
+
+			[1, 2].forEach(match_num => {
+				const match_node = document.getElementById(`match${match_num}`);
+
+				const match_players = [];
+				const sync_timers = [];
+
+				let runways_interval = null;
+				let runways_timeout = null;
+
+				// function is only used when show_runways is an array
+				const showRunways = () => {
+					runways_timeout = clearTimeout(runways_timeout);
+
+					match_players.forEach(player => {
+						player.dom.runways_box.classList.add('visible');
+					});
+
+					runways_timeout = setTimeout(hideRunways, show_runways[0] * 1000);
+				};
+
+				const hideRunways = () => {
+					match_players.forEach(player => {
+						player.dom.runways_box.classList.remove('visible');
+					});
+				};
+
+				const resetRunways = Array.isArray(show_runways)
+					? (hide = true) => {
+							runways_interval = clearInterval(runways_interval);
+
+							if (hide) hideRunways();
+
+							runways_interval = setInterval(
+								showRunways,
+								show_runways[1] * 1000
+							);
+					  }
+					: noop;
+
+				[1, 2].forEach((player_num, player_idx) => {
+					const player_fragment = document.importNode(
+						player_template.content,
+						true
+					);
+					const player_node = player_fragment.querySelector('.player');
+
+					player_node.classList.add(`p${player_num}`);
+					match_node.appendChild(player_node);
+
+					let curtain;
+					if (curtain_template) {
+						const curtain_fragment = document.importNode(
+							curtain_template.content,
+							true
+						);
+						curtain = curtain_fragment.querySelector('.custom_curtain');
+					}
+
+					const player = new CompetitionPlayer(
+						{
+							name: player_node.querySelector(`.name .header`),
+							score: player_node.querySelector(`.score .value`),
+							level: player_node.querySelector(`.level .content`),
+							lines: player_node.querySelector(`.lines .content`),
+							trt: player_node.querySelector(`.tetris_rate .content`),
+							preview: player_node.querySelector(`.next_piece`),
+							field: player_node.querySelector(`.board`),
+							drought: player_node.querySelector(`.drought .value`),
+
+							runway_lv19: player_node.querySelector(`.runways .value .lv19`),
+							runway_lv29: player_node.querySelector(`.runways .value .lv29`),
+							runway_lv39: player_node.querySelector(`.runways .value .lv39`),
+
+							diff: player_node.querySelector(`.score .diff`),
+							t_diff: player_node.querySelector(`.score .tetris_diff .value`),
+
+							runways_box: player_node.querySelector(`.runways`),
+
+							hearts: player_node.querySelector(`.hearts.box`),
+							drought_box: player_node.querySelector(`.drought`),
+							video: player_node.querySelector(`.player_vid`),
+							flag: player_node.querySelector(`.flag`),
+							score_box: player_node.querySelector(`.score`),
+							name_box: player_node.querySelector(`.name`),
+							seed: player_node.querySelector(`.name .content`),
+
+							running_trt: player_node.querySelector(`.running_trt`),
+
+							curtain,
+							simul_tetris: player_node.querySelector(`.simul-tetris`),
+						},
+						{
+							biglogo: true,
+							bigntc: true,
+							field_pixel_size: 4.25,
+							running_trt_dot_size: 5,
+							preview_pixel_size: 3.75,
+							format_score: v => readableScoreFomatter(v),
+							stereo: translate([1, 2], [-1, 1], player_num),
+						}
+					);
+
+					if (QueryString.get('invisible') === '1') {
+						InvisibleMixin(player);
+					}
+
+					if (!CYCLE_TDIFF) {
+						player.dom.score_box.querySelector('.tetris_diff').remove();
+					}
+
+					if (show_runways === true) {
+						// permanently visible
+						player_node.querySelector(`.runways`).classList.add('visible');
+					} else if (Array.isArray(show_runways)) {
+						// visible on interval and on transition
+						player.onTransition = () => {
+							resetRunways(false);
+							showRunways();
+						};
+					}
+
+					if (isDAS) {
+						player_node.querySelector(`.runways`).classList.add('hide39');
+					}
+
+					player._setName = player.setName;
+					player.setName = function (name) {
+						this.dom.seed.textContent = '';
+						this.dom.name_box.classList.remove('seed');
+
+						const m = (name || '').match(/^(\d+)\. (.+)$/);
+
+						if (m) {
+							if (QueryString.get('seed') === '1') {
+								this.dom.name_box.classList.add('seed');
+							}
+							this._setName(m[2]);
+							this.dom.seed.textContent = `seed ${m[1]}`;
+						} else {
+							this._setName(name);
+						}
+					};
+
+					if (show_runways === 'transitions') {
+						player.onLines = frame => {
+							if (player.game.data.start_level !== 18) return; // we only cater for level 18 (for now)
+							if (player.is_chasing_down) return;
+							if (
+								(frame.raw.lines >= 120 && frame.raw.lines < 135) ||
+								(frame.raw.lines >= 220 && frame.raw.lines < 235) ||
+								(frame.raw.lines >= 320 && frame.raw.lines < 335)
+							) {
+								player.dom.runways_box.classList.add('visible');
+							} else {
+								player.dom.runways_box.classList.remove('visible');
+							}
+						};
+					}
+
+					if (show_runways) {
+						player.onLevel = frame => {
+							[...player.dom.runways_box.querySelectorAll('.active')].forEach(
+								elmt => {
+									elmt.classList.remove('active');
+								}
+							);
+
+							for (const threshold_level of [19, 29, 39]) {
+								if (frame.raw.level < threshold_level) {
+									[
+										...player.dom.runways_box.querySelectorAll(
+											`.lv${threshold_level}`
+										),
+									].forEach(elmt => {
+										elmt.classList.add('active');
+									});
+									break;
+								} else if (frame.raw.level === threshold_level) {
+									player.dom.runways_box.querySelector(
+										`.label .lv${threshold_level}`
+									).textContent = `L${frame.raw.level} SCORE`;
+								}
+							}
+						};
+					}
+
+					player.onDroughtStart = () => {
+						player.dom.drought_box.classList.add('active');
+					};
+
+					player.onDroughtEnd = () => {
+						player.dom.drought_box.classList.remove('active');
+					};
+
+					player.onGameStart = () => {
+						player.is_chasing_down = false;
+						player.dom.drought_box.classList.remove('active');
+
+						if (!show_runways) return;
+
+						[...player.dom.runways_box.querySelectorAll('.active')].forEach(
+							elmt => {
+								elmt.classList.remove('active');
+							}
+						);
+
+						[19, 29, 39].forEach(level => {
+							player.dom.runways_box.querySelector(
+								`.label .lv${level}`
+							).textContent = `L${level} RUNWAY`;
+
+							player.dom.runways_box.querySelector(
+								`.value .lv${level}`
+							).textContent = `0`;
+						});
+
+						const start_level = player.game?.data?.start_level || 18;
+
+						player.dom.runways_box.classList[
+							start_level >= 19 ? 'add' : 'remove'
+						]('hide19');
+
+						if (show_runways === 'transitions') {
+							player.dom.runways_box.classList.remove('visible');
+						} else {
+							resetRunways();
+						}
+
+						if (show_runways === true) {
+							player.dom.runways_box.classList.add('visible');
+						}
+					};
+
+					player.onGameOver = () => {
+						if (show_runways) {
+							const score = player.game.data.score.current;
+							const other_player = match_players.find(
+								_player => _player !== player
+							);
+							if (other_player.game && !other_player.game.over) {
+								const other_player_score = other_player.game.data.score.current;
+								if (other_player_score < score) {
+									other_player.is_chasing_down = true;
+									other_player.dom.runways_box.classList.add('visible');
+								}
+							}
+						}
+						if (show_runways !== true) {
+							player.dom.runways_box.classList.remove('visible');
+						}
+					};
+
+					if (hasAds) {
+						// custom branding
+						player._renderField = player.renderField;
+
+						const img = images[sponsor_img_index];
+
+						player.renderField = function (level, field) {
+							this._renderField(level, field);
+
+							if (this.show_sponsor_block) {
+								const pixels_per_block = this.field_pixel_size * (7 + 1);
+
+								const ctx = this.field_ctx;
+
+								ctx.fillStyle = 'rgba(0,0,0,0)';
+
+								if (sponsor_img_index === 1) {
+									// gfuel
+									for (let x = 0; x < 10; x++) {
+										for (let y = 0; y < 20; y++) {
+											if (field[y * 10 + x] === 1) {
+												const pos_x = x * pixels_per_block - 1;
+												const pos_y = y * pixels_per_block - 1;
+
+												ctx.clearRect(
+													pos_x,
+													pos_y,
+													this.field_pixel_size * 8,
+													this.field_pixel_size * 8
+												);
+												ctx.drawImage(img, pos_x, pos_y);
+											}
+										}
+									}
+								} else if (sponsor_img_index === 0) {
+									// xperion inner
+									for (let x = 0; x < 10; x++) {
+										for (let y = 0; y < 20; y++) {
+											if (field[y * 10 + x] === 2) {
+												// replace blue blocks
+												// we clear the inside of the block, but keep the border
+												const pos_x =
+													x * pixels_per_block + this.field_pixel_size;
+												const pos_y =
+													y * pixels_per_block + this.field_pixel_size;
+
+												ctx.clearRect(
+													pos_x,
+													pos_y,
+													this.field_pixel_size * 5,
+													this.field_pixel_size * 5
+												);
+												ctx.drawImage(img, pos_x, pos_y);
+											}
+										}
+									}
+								}
+							}
+						};
+					}
+
+					player.onTetris = function () {
+						const now = Date.now();
+
+						player.last_tetris_time = now;
+
+						if (
+							match_players.every(
+								player => player.last_tetris_time >= now - SIMUL_TETRIS_DELAY
+							)
+						) {
+							// clear all ongoing simul-tetris timers for this match
+							while (sync_timers.length) clearTimeout(sync_timers.pop());
+
+							match_players.forEach(player => {
+								// show sponsor block
+								player.show_sponsor_block =
+									sponsor_img_index === 1 || player.game.data.level === 18;
+
+								if (!SHOW_SIMUL_TETRIS) return;
+
+								window.cancelAnimationFrame(player.animationId);
+
+								// show the simul-tetris sign
+								const scale_start = 0;
+								const scale_end = 0.85 + Math.random() * 0.1;
+								const scale_change = scale_end - scale_start;
+								const angle = -10 + Math.random() * 20;
+								const duration = 750;
+
+								player.dom.simul_tetris.style.display = 'inline';
+								player.dom.simul_tetris.style.transform = `scale(${scale_start}) rotate(${angle}deg)`;
+
+								const start_time = Date.now();
+
+								function step() {
+									const elapsed = Date.now() - start_time;
+									const scale = easeOutElastic(
+										elapsed,
+										scale_start,
+										scale_change,
+										duration
+									);
+
+									player.dom.simul_tetris.style.transform = `scale(${scale}) rotate(${angle}deg)`;
+
+									if (elapsed < duration) {
+										player.animationId = window.requestAnimationFrame(step);
+									} else {
+										sync_timers.push(
+											setTimeout(() => {
+												player.dom.simul_tetris.style.display = 'none';
+											}, 500)
+										);
+									}
+								}
+
+								player.animationId = window.requestAnimationFrame(step);
+							});
+
+							sync_timers.push(
+								setTimeout(() => {
+									players.forEach(player => {
+										player.show_sponsor_block = false;
+									});
+								}, 6000)
+							);
+						}
+					};
+
+					match_players.push(player);
+					players.push(player);
+				});
+
+				if (match_num === 1 && QueryString.get('combot') === '1') {
+					commentatorBot = new MatchCommentatorBot(match_players);
+				}
+			});
+
+			if (CYCLE_TDIFF) {
+				setInterval(() => {
+					players.forEach(player => {
+						player.dom.score_box.classList.toggle('with_tdiff');
+					});
+				}, CYCLE_TDIFF * 1000);
+			}
+
+			const competition = new Competition(players);
+
+			competition.API.setMatch = function (match_idx) {
+				if (match_idx !== 0 && match_idx !== 1) {
+					document.querySelectorAll('.match').forEach(match_node => {
+						match_node.classList.add('small');
+						match_node.style.display = null;
+					});
+
+					return;
+				}
+
+				let show_match, hide_match;
+
+				if (match_idx === 0) {
+					show_match = document.querySelector('#match1');
+					hide_match = document.querySelector('#match2');
+				} else {
+					show_match = document.querySelector('#match2');
+					hide_match = document.querySelector('#match1');
+				}
+
+				show_match.classList.remove('small');
+
+				hide_match.style.display = 'none';
+				show_match.style.display = null;
+			};
+
+			competition.API.showProfileCard = function (visible, match_idx) {
+				const match_players = players.slice(2 * match_idx, 2 * match_idx + 2);
+
+				match_players.forEach(player => player.showProfileCard(visible));
+			};
+
+			competition.API.setWinner = function (player_idx) {
+				const match_idx = player_idx < 2 ? 0 : 1;
+				const match_players = players.slice(2 * match_idx, 2 * match_idx + 2);
+
+				const winner = players[player_idx];
+				const loser = match_players.find(player => player !== winner);
+
+				loser.showLoserFrame();
+				winner.playWinnerAnimation();
+			};
+
+			for (let player_idx = 0; player_idx < players.length; player_idx += 2) {
+				const match_players = players.slice(player_idx, player_idx + 2);
+
+				const updateMatchStats = () => {
+					competition.computeScoreDifferentials(match_players);
+				};
+
+				match_players.forEach(player => {
+					player.onScore = updateMatchStats;
+				});
+			}
+
+			const match_value = QueryString.get('match');
+
+			if (/^([01]|both)$/.test(match_value)) {
+				competition.API.setMatch(
+					match_value == 'both' ? null : parseInt(match_value, 10)
+				);
+			} else {
+				// Layout starts 1 match view
+				competition.API.setMatch(0);
+			}
+
+			// expose API into window for debugging
+			window._players = players;
+			window._NTC_API = competition.API;
+
+			window._NTC_API.showRunways = () => {
+				players.forEach(player => {
+					player.dom.runways_box.classList.add('visible');
+				});
+			};
+			window._NTC_API.hideRunways = () => {
+				players.forEach(player => {
+					player.dom.runways_box.classList.remove('visible');
+				});
+			};
+		</script>
+	</body>
+</html>

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -488,6 +488,7 @@
 				display: flex;
 			}
 			.match.small .hearts span {
+				padding: 0 2px;
 				display: inline-block;
 			}
 			.match.small .flag,
@@ -515,6 +516,7 @@
 			}
 
 			.match.small .p2 > * {
+				right: unset;
 				left: var(--offset);
 			}
 		</style>

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -356,7 +356,7 @@
 				left: 0;
 			}
 			.p2 .next_piece {
-				left: 179px;
+				left: 169px;
 			}
 
 			.player_vid {

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -382,47 +382,94 @@
 			}
 
 			.match.small {
-				transform: scale(0.7245042492917847); /* (1080-57)/706/2 */
+				transform: scale(0.7680180180180181); /* (1080-57)/666/2 */
 			}
 			#match2.small {
 				top: 511px;
 			}
 
-			.match.small .runways {
-				display: none;
+			.match.small .score,
+			.match.small .running_trt,
+			.match.small .tetris_rate {
+				top: 104px;
 			}
 
+			.match.small .efficiency {
+				top: 187px;
+			}
+
+			.match.small .name,
 			.match.small .score,
 			.match.small .lines,
 			.match.small .next_piece {
-				--offset: 357px;
+				--offset: 337px;
 			}
 
-			.match.small .next_piece {
-				z-index: 4;
-				top: 139px;
+			.match.small .lines,
+			.match.small .level,
+			.match.small .tetris_value,
+			.match.small .burn,
+			.match.small .burn_max {
+				top: 270px;
+			}
+
+			.match.small .burn.max {
+				--offset: 984px;
+			}
+			.match.small .burn {
+				--offset: 828px;
+			}
+			.match.small .tetris_value {
+				--offset: 627px;
+			}
+			.match.small .level {
+				width: 88px;
+				--offset: 515px;
 			}
 
 			.match.small .lines {
-				z-index: 3;
 				width: 154px;
-				top: 225px;
 			}
 
-			.match.small .level {
-				z-index: 2;
-				top: 311px;
-				width: 78px;
+			.match.small .running_trt {
+				--offset: 729px;
+			}
+
+			.match.small .next_piece,
+			.match.small .drought {
+				top: 356px;
+			}
+
+			.match.small .next_piece {
+				width: 148px;
+				padding-left: 6px;
+			}
+
+			.match.small .drought.current {
+				--offset: 515px;
+			}
+			.match.small .drought.last {
+				--offset: 657px;
+			}
+			.match.small .drought.max {
+				--offset: 814px;
+			}
+			.match.small .drought.count {
+				--offset: 956px;
 			}
 
 			.match.small .tetris_rate,
-			.match.small .drought {
-				top: 394px;
+			.match.small .efficiency {
+				--offset: 627px;
 				z-index: 1;
 			}
 
+			.match.small .tetris_rate {
+				top: 104px;
+			}
+
 			.match.small .score {
-				width: 302px;
+				width: 266px;
 			}
 
 			.match.small .board {
@@ -434,7 +481,12 @@
 			}
 			.match.small .hearts {
 				bottom: unset;
-				top: 477px;
+				top: 553px;
+				width: unset;
+				display: flex;
+			}
+			.match.small .hearts span {
+				display: inline-block;
 			}
 			.match.small .flag,
 			.match.small .name {
@@ -442,21 +494,22 @@
 				top: 0;
 			}
 			.match.small .name {
-				width: 486px;
-				--offset: 683px;
+				width: 737px;
 			}
 			.match.small .flag {
-				--offset: 1190px;
-			}
-			.match.small .player_vid {
-				top: 96px;
-				width: 965px;
-				height: 609px;
+				--offset: 1095px;
 			}
 
-			.match.small .simul-tetris {
-				top: 250px;
-				--offset: 574px;
+			.match.small .player_vid,
+			.match.small .runways {
+				top: 442px;
+			}
+
+			.match.small .player_vid {
+				top: 448px;
+				--offset: 960px;
+				width: 290px;
+				height: 215px;
 			}
 
 			.match.small .p2 > * {

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -69,7 +69,7 @@
 			}
 
 			.lines,
-			.tr_value,
+			.tetris_value,
 			.burn,
 			.burn_max,
 			.next_piece,
@@ -113,7 +113,7 @@
 			.efficiency,
 			.drought,
 			.level,
-			.tr_value {
+			.tetris_value {
 				padding-right: 0;
 			}
 
@@ -192,10 +192,9 @@
 			}
 
 			.level,
-			.tr_value,
+			.tetris_value,
 			.tetris_rate,
 			.burn,
-			.burn_max,
 			.efficiency,
 			.drought {
 				padding-top: 5px;
@@ -204,20 +203,18 @@
 			}
 
 			.level,
-			.tr_value,
-			.burn,
-			.burn_max {
+			.tetris_value,
+			.burn {
 				height: 57px;
 			}
 
-			.tr_value {
+			.tetris_value {
 				width: 177px;
 				--offset: 439px;
 			}
 
 			.burn,
-			.drought,
-			.burn_max {
+			.drought {
 				width: 132px;
 			}
 
@@ -225,12 +222,11 @@
 				--offset: 640px;
 			}
 
-			.burn_max {
+			.burn.max {
 				--offset: 796px;
 			}
 
 			.burn .header span,
-			.burn_max .header span,
 			.drought .header span {
 				font-size: 16.01px;
 			}
@@ -265,8 +261,6 @@
 
 			.drought.active {
 				color: red;
-				display: block;
-				animation: 0.5s ease-out fadeIn;
 			}
 
 			.drought .header img {
@@ -292,7 +286,7 @@
 			}
 
 			.runways {
-				display: none;
+				display: flex;
 				justify-content: space-between;
 				color: #888;
 				right: var(--offset);
@@ -455,42 +449,6 @@
 		</style>
 	</head>
 	<body>
-		<template id="curtain_0">
-			<div class="custom_curtain">
-				<br />
-				<br />
-				<img src="/images/ctwc_das_400.png" style="max-width: 220px" />
-				<br />
-				<br />
-				<p style="font-size: 12px">Presented by</p>
-				<img src="/images/sponsors/logo-experion.svg" style="width: 280px" />
-				<br />
-				<br />
-				<br />
-				<br />
-				<br />
-				<br />
-				<img src="/brand/logo.v3.white.png" />
-			</div>
-		</template>
-		<template id="curtain_1">
-			<div class="custom_curtain">
-				<br />
-				<br />
-				<br />
-				<img src="/images/ctwc_logo.jpeg" style="max-width: 240px" />
-				<br />
-				<br />
-				<!-- p style="font-size: 12px">Presented by</p>
-				<img src="/images/sponsors/G_Fuel_logo.svg" style="width: 260px" / -->
-				<br />
-				<br />
-				<br />
-				<br />
-				<br />
-				<img src="/brand/logo.v3.white.3x.png" style="max-width: 110px" />
-			</div>
-		</template>
 		<template id="player">
 			<div class="player">
 				<video class="player_vid"></video>
@@ -525,19 +483,19 @@
 					<div class="content">00</div>
 				</div>
 
-				<div class="box tr_value">
+				<div class="box tetris_value">
 					<div class="header">TR VAL</div>
 					<div class="content">000&#x202F;000</div>
 				</div>
 
-				<div class="box burn">
+				<div class="box burn current">
 					<div class="header">BRN<span>CUR</span></div>
 					<div class="content">---</div>
 				</div>
 
-				<div class="box burn_max">
+				<div class="box burn max">
 					<div class="header">BRN<span>MAX</span></div>
-					<div class="content">---</div>
+					<div class="content">0</div>
 				</div>
 
 				<div class="box tetris_rate">
@@ -550,24 +508,24 @@
 					<div class="content">---</div>
 				</div>
 
-				<div class="box drought">
+				<div class="box drought current">
 					<div class="header">DRT<span>CUR</span></div>
-					<div class="value">99</div>
+					<div class="value"></div>
 				</div>
 
 				<div class="box drought last">
 					<div class="header">DRT<span>LAST</span></div>
-					<div class="value">99</div>
+					<div class="value"></div>
 				</div>
 
 				<div class="box drought max">
 					<div class="header">DRT<span>MAX</span></div>
-					<div class="value">99</div>
+					<div class="value"></div>
 				</div>
 
 				<div class="box drought count">
 					<div class="header">DRT<span>COUNT</span></div>
-					<div class="value">99</div>
+					<div class="value"></div>
 				</div>
 
 				<div class="box running_trt"></div>
@@ -585,9 +543,9 @@
 						<div class="lv39">0&#x202F;000&#x202F;000</div>
 					</div>
 					<div class="tdiff">
-						<div class="lv19">+0.00T</div>
-						<div class="lv29">+0.00T</div>
-						<div class="lv39">+0.00T</div>
+						<div class="lv19"><span>+0.00</span>T</div>
+						<div class="lv29"><span>+0.00</span>T</div>
+						<div class="lv39"><span>+0.00</span>T</div>
 					</div>
 				</div>
 
@@ -627,89 +585,16 @@
 		<script type="module">
 			import '/views/bg.js';
 			import { peerServerOptions } from '/views/constants.js';
-			import { noop, translate, readableScoreFomatter } from '/views/utils.js';
+			import {
+				peek,
+				noop,
+				translate,
+				readableScoreFomatter,
+			} from '/views/utils.js';
 			import QueryString from '/js/QueryString.js';
 			import CompetitionPlayer from '/views/CompetitionPlayer.js';
-			import Competition from '/views/competition.js';
+			import { Competition, getTetrisDiff } from '/views/competition.js';
 			import InvisibleMixin from '/views/InvisibleMixin.js';
-			import { MatchCommentatorBot } from '/views/commentator_bot.js';
-
-			let commentatorBot;
-
-			// Penner easing
-			// http://robertpenner.com/easing/
-			function easeOutElastic(t, b, c, d) {
-				var s = 1.70158;
-				var p = 0;
-				var a = c;
-				if (t == 0) return b;
-				if ((t /= d) >= 1) return b + c;
-				if (!p) p = d * 0.3;
-				if (a < Math.abs(c)) {
-					a = c;
-					var s = p / 4;
-				} else var s = (p / (2 * Math.PI)) * Math.asin(c / a);
-				return (
-					a *
-						Math.pow(2, -10 * t) *
-						Math.sin(((t * d - s) * (2 * Math.PI)) / p) +
-					c +
-					b
-				);
-			}
-
-			const isDAS = QueryString.get('style') === 'das';
-			const hasAds = QueryString.get('ads') === '1';
-
-			const SHOW_SIMUL_TETRIS = /^[1-9]\d*$/.test(QueryString.get('simultris'));
-			const SIMUL_TETRIS_DELAY = SHOW_SIMUL_TETRIS
-				? parseInt(QueryString.get('simultris'), 10)
-				: 120;
-
-			const sponsor_img_index = /^\d+$/.test(QueryString.get('sponsorimg'))
-				? parseInt(QueryString.get('sponsorimg'), 10)
-				: 0;
-
-			let curtain_template;
-			if (/^[01]$/.test(QueryString.get('curtain'))) {
-				curtain_template = document.getElementById(
-					`curtain_${QueryString.get('curtain')}`
-				);
-			}
-
-			// triple-typed variable... that is disgusting -_-
-			// false: never show runways (default)
-			// 1 -> true: always show runways
-			// 'transitions' -> 'transitions': show slightly before transitions
-			// x,y -> [x, y]: show runways for x seconds every y seconds
-			let show_runways = false;
-			if (QueryString.get('runways') === '1') {
-				show_runways = true;
-			} else if (QueryString.get('runways') === 'transitions') {
-				show_runways = 'transitions';
-			} else {
-				const m = (QueryString.get('runways') || '').match(
-					/^([1-9]\d*),([1-9]\d*)$/
-				);
-				if (m) {
-					const show_for = parseInt(m[1], 10);
-					const repeat_in = parseInt(m[2], 10);
-					if (show_for < repeat_in) show_runways = [show_for, repeat_in];
-				}
-			}
-
-			let images;
-
-			if (hasAds) {
-				images = [
-					'/images/sponsors/ctwcdas_inner_20.png',
-					'/images/sponsors/gfuel_30.png',
-				].map(url => {
-					const img = new Image();
-					img.src = url;
-					return img;
-				});
-			}
 
 			const player_template = document.getElementById('player');
 			const players = [];
@@ -719,39 +604,6 @@
 
 				const match_players = [];
 				const sync_timers = [];
-
-				let runways_interval = null;
-				let runways_timeout = null;
-
-				// function is only used when show_runways is an array
-				const showRunways = () => {
-					runways_timeout = clearTimeout(runways_timeout);
-
-					match_players.forEach(player => {
-						player.dom.runways_box.classList.add('visible');
-					});
-
-					runways_timeout = setTimeout(hideRunways, show_runways[0] * 1000);
-				};
-
-				const hideRunways = () => {
-					match_players.forEach(player => {
-						player.dom.runways_box.classList.remove('visible');
-					});
-				};
-
-				const resetRunways = Array.isArray(show_runways)
-					? (hide = true) => {
-							runways_interval = clearInterval(runways_interval);
-
-							if (hide) hideRunways();
-
-							runways_interval = setInterval(
-								showRunways,
-								show_runways[1] * 1000
-							);
-					  }
-					: noop;
 
 				[1, 2].forEach((player_num, player_idx) => {
 					const player_fragment = document.importNode(
@@ -763,15 +615,6 @@
 					player_node.classList.add(`p${player_num}`);
 					match_node.appendChild(player_node);
 
-					let curtain;
-					if (curtain_template) {
-						const curtain_fragment = document.importNode(
-							curtain_template.content,
-							true
-						);
-						curtain = curtain_fragment.querySelector('.custom_curtain');
-					}
-
 					const player = new CompetitionPlayer(
 						{
 							name: player_node.querySelector(`.name .header`),
@@ -780,10 +623,14 @@
 							lines: player_node.querySelector(`.lines .content`),
 							trt: player_node.querySelector(`.tetris_rate .content`),
 							eff: player_node.querySelector(`.efficiency .content`),
-							burn: player_node.querySelector(`.burn .content`),
+							burn: player_node.querySelector(`.burn.current .content`),
+							burn_max: player_node.querySelector(`.burn.max .content`),
 							preview: player_node.querySelector(`.next_piece`),
 							field: player_node.querySelector(`.board`),
-							drought: player_node.querySelector(`.drought .value`),
+							drought: player_node.querySelector(`.drought.current .value`),
+							drought_last: player_node.querySelector(`.drought.last .value`),
+							drought_max: player_node.querySelector(`.drought.max .value`),
+							drought_count: player_node.querySelector(`.drought.count .value`),
 
 							runway_lv19: player_node.querySelector(`.runways .value .lv19`),
 							runway_lv29: player_node.querySelector(`.runways .value .lv29`),
@@ -802,9 +649,9 @@
 							name_box: player_node.querySelector(`.name`),
 							seed: player_node.querySelector(`.name .content`),
 
+							tetris_value: player_node.querySelector(`.tetris_value .content`),
 							running_trt: player_node.querySelector(`.running_trt`),
 
-							curtain,
 							simul_tetris: player_node.querySelector(`.simul-tetris`),
 						},
 						{
@@ -820,21 +667,6 @@
 
 					if (QueryString.get('invisible') === '1') {
 						InvisibleMixin(player);
-					}
-
-					if (show_runways === true) {
-						// permanently visible
-						player_node.querySelector(`.runways`).classList.add('visible');
-					} else if (Array.isArray(show_runways)) {
-						// visible on interval and on transition
-						player.onTransition = () => {
-							resetRunways(false);
-							showRunways();
-						};
-					}
-
-					if (isDAS) {
-						player_node.querySelector(`.runways`).classList.add('hide39');
 					}
 
 					player._setName = player.setName;
@@ -855,48 +687,34 @@
 						}
 					};
 
-					if (show_runways === 'transitions') {
-						player.onLines = frame => {
-							if (player.game.data.start_level !== 18) return; // we only cater for level 18 (for now)
-							if (player.is_chasing_down) return;
-							if (
-								(frame.raw.lines >= 120 && frame.raw.lines < 135) ||
-								(frame.raw.lines >= 220 && frame.raw.lines < 235) ||
-								(frame.raw.lines >= 320 && frame.raw.lines < 335)
-							) {
-								player.dom.runways_box.classList.add('visible');
-							} else {
-								player.dom.runways_box.classList.remove('visible');
-							}
-						};
-					}
+					player.onLevel = frame => {
+						player.dom.tetris_value.textContent = readableScoreFomatter(
+							frame.raw.level * 1200
+						);
 
-					if (show_runways) {
-						player.onLevel = frame => {
-							[...player.dom.runways_box.querySelectorAll('.active')].forEach(
-								elmt => {
-									elmt.classList.remove('active');
-								}
-							);
-
-							for (const threshold_level of [19, 29, 39]) {
-								if (frame.raw.level < threshold_level) {
-									[
-										...player.dom.runways_box.querySelectorAll(
-											`.lv${threshold_level}`
-										),
-									].forEach(elmt => {
-										elmt.classList.add('active');
-									});
-									break;
-								} else if (frame.raw.level === threshold_level) {
-									player.dom.runways_box.querySelector(
-										`.label .lv${threshold_level}`
-									).textContent = `L${frame.raw.level} SCORE`;
-								}
+						[...player.dom.runways_box.querySelectorAll('.active')].forEach(
+							elmt => {
+								elmt.classList.remove('active');
 							}
-						};
-					}
+						);
+
+						for (const threshold_level of [19, 29, 39]) {
+							if (frame.raw.level < threshold_level) {
+								[
+									...player.dom.runways_box.querySelectorAll(
+										`.lv${threshold_level}`
+									),
+								].forEach(elmt => {
+									elmt.classList.add('active');
+								});
+								break;
+							} else if (frame.raw.level === threshold_level) {
+								player.dom.runways_box.querySelector(
+									`.label .lv${threshold_level}`
+								).textContent = `L${frame.raw.level} SCORE`;
+							}
+						}
+					};
 
 					player.onDroughtStart = () => {
 						player.dom.drought_box.classList.add('active');
@@ -906,11 +724,50 @@
 						player.dom.drought_box.classList.remove('active');
 					};
 
+					player.onPiece = frame => {
+						if (!frame?.pieces) return;
+
+						let piece_evt = peek(frame.pieces);
+
+						if (!piece_evt?.i_droughts) return;
+
+						player.dom.drought_last.textContent = piece_evt.i_droughts.last;
+						player.dom.drought_max.textContent = piece_evt.i_droughts.max;
+						player.dom.drought_count.textContent = piece_evt.i_droughts.count;
+
+						if (
+							piece_evt.i_droughts.cur > 13 &&
+							piece_evt.i_droughts.cur >= piece_evt.i_droughts.max
+						) {
+							player.dom.drought_max.closest('.box').classList.add('active');
+						} else {
+							player.dom.drought_max.closest('.box').classList.remove('active');
+						}
+					};
+
+					let max_burn = 0;
+
+					player.onLines = frame => {
+						if (player.game?.data.running_stats.burn >= max_burn) {
+							player.dom.burn_max.textContent = max_burn =
+								player.game.data.running_stats.burn;
+						}
+					};
+
 					player.onGameStart = () => {
 						player.is_chasing_down = false;
-						player.dom.drought_box.classList.remove('active');
 
-						if (!show_runways) return;
+						player.dom.burn.textContent =
+							player.dom.burn_max.textContent =
+							max_burn =
+								0;
+
+						player.dom.drought.textContent = 0;
+						player.dom.drought_last.textContent = 0;
+						player.dom.drought_max.textContent = 0;
+						player.dom.drought_count.textContent = 0;
+						player.dom.drought_box.classList.remove('active');
+						player.dom.drought_max.closest('.box').classList.remove('active');
 
 						[...player.dom.runways_box.querySelectorAll('.active')].forEach(
 							elmt => {
@@ -933,174 +790,25 @@
 						player.dom.runways_box.classList[
 							start_level >= 19 ? 'add' : 'remove'
 						]('hide19');
-
-						if (show_runways === 'transitions') {
-							player.dom.runways_box.classList.remove('visible');
-						} else {
-							resetRunways();
-						}
-
-						if (show_runways === true) {
-							player.dom.runways_box.classList.add('visible');
-						}
 					};
 
 					player.onGameOver = () => {
-						if (show_runways) {
-							const score = player.game.data.score.current;
-							const other_player = match_players.find(
-								_player => _player !== player
-							);
-							if (other_player.game && !other_player.game.over) {
-								const other_player_score = other_player.game.data.score.current;
-								if (other_player_score < score) {
-									other_player.is_chasing_down = true;
-									other_player.dom.runways_box.classList.add('visible');
-								}
+						const score = player.game.data.score.current;
+						const other_player = match_players.find(
+							_player => _player !== player
+						);
+						if (other_player.game && !other_player.game.over) {
+							const other_player_score = other_player.game.data.score.current;
+							if (other_player_score < score) {
+								other_player.is_chasing_down = true;
+								other_player.dom.runways_box.classList.add('visible');
 							}
-						}
-						if (show_runways !== true) {
-							player.dom.runways_box.classList.remove('visible');
-						}
-					};
-
-					if (hasAds) {
-						// custom branding
-						player._renderField = player.renderField;
-
-						const img = images[sponsor_img_index];
-
-						player.renderField = function (level, field) {
-							this._renderField(level, field);
-
-							if (this.show_sponsor_block) {
-								const pixels_per_block = this.field_pixel_size * (7 + 1);
-
-								const ctx = this.field_ctx;
-
-								ctx.fillStyle = 'rgba(0,0,0,0)';
-
-								if (sponsor_img_index === 1) {
-									// gfuel
-									for (let x = 0; x < 10; x++) {
-										for (let y = 0; y < 20; y++) {
-											if (field[y * 10 + x] === 1) {
-												const pos_x = x * pixels_per_block - 1;
-												const pos_y = y * pixels_per_block - 1;
-
-												ctx.clearRect(
-													pos_x,
-													pos_y,
-													this.field_pixel_size * 8,
-													this.field_pixel_size * 8
-												);
-												ctx.drawImage(img, pos_x, pos_y);
-											}
-										}
-									}
-								} else if (sponsor_img_index === 0) {
-									// xperion inner
-									for (let x = 0; x < 10; x++) {
-										for (let y = 0; y < 20; y++) {
-											if (field[y * 10 + x] === 2) {
-												// replace blue blocks
-												// we clear the inside of the block, but keep the border
-												const pos_x =
-													x * pixels_per_block + this.field_pixel_size;
-												const pos_y =
-													y * pixels_per_block + this.field_pixel_size;
-
-												ctx.clearRect(
-													pos_x,
-													pos_y,
-													this.field_pixel_size * 5,
-													this.field_pixel_size * 5
-												);
-												ctx.drawImage(img, pos_x, pos_y);
-											}
-										}
-									}
-								}
-							}
-						};
-					}
-
-					player.onTetris = function () {
-						const now = Date.now();
-
-						player.last_tetris_time = now;
-
-						if (
-							match_players.every(
-								player => player.last_tetris_time >= now - SIMUL_TETRIS_DELAY
-							)
-						) {
-							// clear all ongoing simul-tetris timers for this match
-							while (sync_timers.length) clearTimeout(sync_timers.pop());
-
-							match_players.forEach(player => {
-								// show sponsor block
-								player.show_sponsor_block =
-									sponsor_img_index === 1 || player.game.data.level === 18;
-
-								if (!SHOW_SIMUL_TETRIS) return;
-
-								window.cancelAnimationFrame(player.animationId);
-
-								// show the simul-tetris sign
-								const scale_start = 0;
-								const scale_end = 0.85 + Math.random() * 0.1;
-								const scale_change = scale_end - scale_start;
-								const angle = -10 + Math.random() * 20;
-								const duration = 750;
-
-								player.dom.simul_tetris.style.display = 'inline';
-								player.dom.simul_tetris.style.transform = `scale(${scale_start}) rotate(${angle}deg)`;
-
-								const start_time = Date.now();
-
-								function step() {
-									const elapsed = Date.now() - start_time;
-									const scale = easeOutElastic(
-										elapsed,
-										scale_start,
-										scale_change,
-										duration
-									);
-
-									player.dom.simul_tetris.style.transform = `scale(${scale}) rotate(${angle}deg)`;
-
-									if (elapsed < duration) {
-										player.animationId = window.requestAnimationFrame(step);
-									} else {
-										sync_timers.push(
-											setTimeout(() => {
-												player.dom.simul_tetris.style.display = 'none';
-											}, 500)
-										);
-									}
-								}
-
-								player.animationId = window.requestAnimationFrame(step);
-							});
-
-							sync_timers.push(
-								setTimeout(() => {
-									players.forEach(player => {
-										player.show_sponsor_block = false;
-									});
-								}, 6000)
-							);
 						}
 					};
 
 					match_players.push(player);
 					players.push(player);
 				});
-
-				if (match_num === 1 && QueryString.get('combot') === '1') {
-					commentatorBot = new MatchCommentatorBot(match_players);
-				}
 			});
 
 			const competition = new Competition(players);

--- a/public/views/mp/commentator.html
+++ b/public/views/mp/commentator.html
@@ -23,6 +23,7 @@
 			}
 
 			.box .header {
+				color: #888;
 				padding-bottom: 6px;
 			}
 
@@ -40,6 +41,7 @@
 			}
 
 			.score .header {
+				color: #fff;
 				padding-top: 2px;
 				padding-bottom: 8px;
 			}


### PR DESCRIPTION
## Context

Competition layouts intentionally display few metrics to not overwhelm audiences, especially for newcomers to Tetris.

Commentators on the other hand  could benefit from seeing many stats that they can leverage during their commentaries. 

Since NesTrisChamps support multiple view into the same room, it makes sense to have a commentator-specific view. The main stream main show a simplified view, but commentators could load the view on the side and have many more stats they can chose (or not) to discuss).

## Approach

Taking the CTWC23 layout as base, create a commentator view with following features:
* Show Running Tetris Rate (useful to understands recent performance when a commentator focuses on player and then shifts his/her focus to the other player)
* Show Efficiency metrics
* Show Burn value
* Show Value of a Tetris for the current level
* Show real time drought stats (current drought, last drought length, max drought length, total number of drought)
* Show runways for level 19, 29, 39, and the tetris diffs for the runways

Note that runways locks on death score on death, so the stats will show if the laggard's runways is larger than the leader score, during chase down. This can help commentator make assessments on whether they think the laggard can make it.

![image](https://github.com/timotheeg/nestrischamps/assets/935223/17e7ef29-40dc-4b9e-879a-7e1757cc09ce)
