### PR TITLE
Introduce softer tetris flashes

### DIFF
--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -163,7 +163,6 @@ function easeInQuad(t, b, c, d) {
 	return c * (t /= d) * t + b;
 }
 
-
 // One time check of Query String args
 // Bit dirty to have Player.js access query String
 // But that's the most covenient way to share the functionality
@@ -683,7 +682,7 @@ export default class Player extends EventTarget {
 	_doTetris() {
 		const start = Date.now();
 		const final_black = 'rgba(0,0,0,0)';
-		let duration = (25 / 60) * 1000;
+		const duration = (25 / 60) * 1000;
 
 		if (this.options.tetris_flash) {
 			this.field_bg.style.display = 'block';
@@ -726,8 +725,9 @@ export default class Player extends EventTarget {
 
 			steps();
 		} else if (this.options.tetris_flash === 3) {
+			this.field_bg_inner.style.background = 'white';
+
 			// Fade in-out swipe
-			duration = 500;
 			const steps = () => {
 				const elapsed = Date.now() - start;
 				let ratio = Math.min(elapsed / duration, 1);
@@ -736,17 +736,11 @@ export default class Player extends EventTarget {
 
 				if (elapsed < duration / 2) {
 					const real_ratio = ratio * 2;
-					props.height = `${easeOutQuad(real_ratio, 0, 100, 1)}%`;
-					props.background = whiteToTransparentGradient
-						.getColorAt(1 - real_ratio)
-						.toRGBAString();
+					props.height = `${real_ratio * 100}%`;
 				} else {
 					const real_ratio = (ratio - 0.5) * 2;
-					props.top = `${easeInQuad(real_ratio, 0, 100, 1)}%`;
-					props.height = `${easeInQuad(real_ratio, 100, -100, 1)}%`;
-					props.background = whiteToTransparentGradient
-						.getColorAt(real_ratio)
-						.toRGBAString();
+					props.top = `${real_ratio * 100}%`;
+					props.height = `${(1 - real_ratio) * 100}%`;
 				}
 
 				Object.assign(this.field_bg_inner.style, props);

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -571,7 +571,7 @@ export default class Player extends EventTarget {
 
 			this.curtain_container.style.top = `${top}px`;
 
-			if (elapsed < duration) {
+			if (elapsed <= duration) {
 				this.curtain_animation_ID = window.requestAnimationFrame(steps);
 			} else {
 				this.curtain_animation_ID = null;
@@ -617,7 +617,7 @@ export default class Player extends EventTarget {
 					.toHexString();
 
 				this.comp_message_animation_ID =
-					elapsed < fadeDuration ? window.requestAnimationFrame(steps) : null;
+					elapsed <= fadeDuration ? window.requestAnimationFrame(steps) : null;
 			};
 
 			steps();
@@ -696,7 +696,7 @@ export default class Player extends EventTarget {
 				const flashing = (elapsed / 1000) % (5 / 60) < 2 / 60; // flash for 2 "frames" every 5 "frames"
 				this.field_bg.style.background = flashing ? 'white' : final_black;
 
-				if (elapsed < duration) {
+				if (elapsed <= duration) {
 					this.tetris_animation_ID = window.requestAnimationFrame(steps);
 				} else {
 					// make sure we don't end on white
@@ -715,7 +715,7 @@ export default class Player extends EventTarget {
 					.getColorAt(elapsed / duration) // getColorAt() clamps ratio to [0,1]
 					.toRGBAString();
 
-				if (elapsed < duration) {
+				if (elapsed <= duration) {
 					this.tetris_animation_ID = window.requestAnimationFrame(steps);
 				} else {
 					this.field_bg.style.removeProperty('background');
@@ -745,7 +745,7 @@ export default class Player extends EventTarget {
 
 				Object.assign(this.field_bg_inner.style, props);
 
-				if (elapsed < duration) {
+				if (elapsed <= duration) {
 					this.tetris_animation_ID = window.requestAnimationFrame(steps);
 				} else {
 					this.field_bg.style.removeProperty('background');

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -326,6 +326,10 @@ export default class Player extends EventTarget {
 			this[`${name}_ctx`] = canvas.getContext('2d');
 		});
 
+		this.field_ctx.canvas.style.top = `${bg_offset + field_canva_offset_t}px`;
+		this.field_ctx.canvas.style.left = `${bg_offset + field_canva_offset_l}px`;
+		this.field.appendChild(this.field_ctx.canvas);	
+
 		this.has_curtain = this.options.curtain || this.dom.curtain;
 
 		if (this.has_curtain) {
@@ -394,10 +398,6 @@ export default class Player extends EventTarget {
 		});
 		this.profile_card.hidden = true;
 		this.dom.field.appendChild(this.profile_card);
-
-		this.field_ctx.canvas.style.top = `${field_canva_offset_t}px`;
-		this.field_ctx.canvas.style.left = `${field_canva_offset_l}px`;
-		this.field_bg.appendChild(this.field_ctx.canvas);
 
 		if (this.render_running_trt_rtl && this.running_trt_ctx) {
 			this.running_trt_ctx.canvas.style.transform = 'scale(-1, 1)';


### PR DESCRIPTION
## Context

The tetris flash is hard on the eyes for people with photo-sensitivity. There is a mechanism to turn off the flash entirely (with `tetris_flash=0`, but is possible to have tetris markers that are easier on the eye instead?

[Reference request](https://discord.com/channels/817528744565932043/817528917590016020/1239023445069533214)

## Approach

Augment the query string arg `tetris_flash` to specify different type of flashes, as follow:
* `0` no flash
* `1` classic flash
* `2` Elongated flash that fades out
* `3` top-to-bottom swipe flash

Bonus fixes:
* Slight refactor on the flash div, set it to `display:none` when not flashing


