### PR TITLE
feat: HTTPS option in docker build

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-if [[ -n $HTTPS ]]; then
+if [[ -n "$HTTPS" ]]; then
     echo "Generating self signed cert"
     openssl req \
         -x509 \
@@ -11,14 +11,11 @@ if [[ -n $HTTPS ]]; then
         -days 3650 \
         -nodes \
         -subj "/C=XX/ST=State/L=City/O=NTC/OU=NTC/CN=localhost"
-    mv *.pem nestrischamps/
+    mv ./*.pem nestrischamps/
 fi
 
-docker-compose build nc --build-arg HTTPS=$HTTPS
-
-if [[ -n $HTTPS ]]; then
-    rm nestrischamps/*.pem
-fi
+docker-compose build nc --build-arg HTTPS="$HTTPS"
+rm -f nestrischamps/*.pem
 
 docker create -ti --name cpsql nestrischamps bash
 docker cp cpsql:/nestrischamps/setup/db.sql postgresql/

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,25 @@
 #!/bin/sh
-docker-compose build nc
+
+if [[ -n $HTTPS ]]; then
+    echo "Generating self signed cert"
+    openssl req \
+        -x509 \
+        -newkey rsa:4096 \
+        -keyout key.pem \
+        -out cert.pem \
+        -sha256 \
+        -days 3650 \
+        -nodes \
+        -subj "/C=XX/ST=State/L=City/O=NTC/OU=NTC/CN=localhost"
+    mv *.pem nestrischamps/
+fi
+
+docker-compose build nc --build-arg HTTPS=$HTTPS
+
+if [[ -n $HTTPS ]]; then
+    rm nestrischamps/*.pem
+fi
+
 docker create -ti --name cpsql nestrischamps bash
 docker cp cpsql:/nestrischamps/setup/db.sql postgresql/
 docker rm -f cpsql

--- a/docker/nestrischamps/Dockerfile
+++ b/docker/nestrischamps/Dockerfile
@@ -3,5 +3,9 @@ FROM node:18-alpine
 RUN apk add git
 RUN git clone https://github.com/timotheeg/nestrischamps.git
 WORKDIR ./nestrischamps
+COPY *.pem ./
+ARG HTTPS
+ENV TLS_KEY=${HTTPS:+key.pem}
+ENV TLS_CERT=${HTTPS:+cert.pem}
 RUN npm ci
 CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
Will create self signed certificate if the HTTPS environment variable isn't null and add the TLS_KEY & TLS_CERT variables to the container.   

If HTTPS is not set,  the build script & Dockerfile maintain original behavior.