### PR TITLE
Use web worker for interval

### DIFF
--- a/public/ocr/ocr.html
+++ b/public/ocr/ocr.html
@@ -364,6 +364,15 @@
 						</select>
 					</div>
 
+					<div
+						title="Use Web Worker to provide stable interval even when the tab is unfocused"
+					>
+						<label for="use_worker_for_interval"
+							>Use Web worker for interval</label
+						>
+						<input type="checkbox" id="use_worker_for_interval" />
+					</div>
+
 					<div id="image_corrections">
 						<div class="brightness">
 							Brightness:


### PR DESCRIPTION
Add `Use Web worker for interval` into OCR configuration. It provides stable framerate even when the tab is unfocused by calling setInterval from Web Worker.

Reference:
- https://medium.com/@adithyaviswam/overcoming-browser-throttling-of-setinterval-executions-45387853a826
- https://jsfiddle.net/kc3pd5w1/ microbenchmark by smd3256
