### PR TITLE
Allow for self-restreams

### DIFF
--- a/public/ocr/ocr_main.js
+++ b/public/ocr/ocr_main.js
@@ -2000,6 +2000,9 @@ function getViewURL() {
 	searchParams.set('simultris', 0);
 	searchParams.set('srabbit', 0);
 	searchParams.set('in_producer', 1);
+	if (QueryString.get('combot', null) !== null) {
+		searchParams.set('combot', QueryString.get('combot'));
+	}
 
 	return `${producer_url.origin}${newPathname}?${searchParams}`;
 }


### PR DESCRIPTION
Self-restreams by allowing the player to not have the combot even if the producer has combot on.

A good example of the bug this fixes is where the player has three browser windows open:
 * http://localhost:5000/view/ctm/PLAYER1?combot=1
 * http://localhost:5000/room/u/player1/producer
 * http://localhost:5000/room/admin

The self-restreamer will hear the combot give score updates twice. It would be easy to mute if Firefox didn't use TTS server to do TTS instead of something that was mutable.

This patch allows the user to use this url to override the iframe's combot value:
 http://localhost:5000/room/u/player1/producer?combot=0

It also allows the player to choose combot when the producer has the combot off which is an added bonus.

I would like to make this easier to use (self-restream button) but this is the first step in making the rest of those changes.