### PR TITLE
Responsive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docker/postgresql/pgdata
 node_modules
 .env
 .DS_Store
+
+.codegpt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"cSpell.words": ["hearpos"]
+}

--- a/public/views/bg.js
+++ b/public/views/bg.js
@@ -11,6 +11,7 @@ if (QueryString.get('bg') === '0') {
 	bg.classList.add('bg');
 
 	const bounds = parent.getBoundingClientRect();
+	console.log(bounds);
 
 	const spacer_w = 160;
 	const spacer_h = 40;
@@ -114,22 +115,11 @@ if (QueryString.get('bg') === '0') {
 	parent.prepend(bg);
 } else {
 	// bg=1 (default pieces)
-	const bounds = parent.getBoundingClientRect();
-
-	const width = bounds.width;
-	const height = bounds.height;
-
-	const border = 100;
-
+	const pieces = [];
 	const grid_x = 8;
 	const grid_y = 5;
-
-	const span_x = (width - border * 2) / (grid_x - 1);
-	const span_y = (height - border * 2) / (grid_y - 1);
-
+	const border = 100;
 	const spread = 1 / 3;
-
-	const pieces = [];
 
 	let num_bags = Math.ceil((grid_x * grid_y) / PIECES.length);
 
@@ -138,37 +128,55 @@ if (QueryString.get('bg') === '0') {
 	}
 
 	const bg = document.createElement('div');
-
 	bg.classList.add('bg');
 
-	for (let x = grid_x; x--; ) {
-		for (let y = grid_y; y--; ) {
-			const piece = pieces.pop();
-			const img = new Image();
+	const pieceImages = pieces.map(piece => {
+		const img = new Image();
+		img.src = `/views/bg_pieces/${piece}.png`;
 
-			img.src = `/views/bg_pieces/${piece}.png`;
+		Object.assign(img.style, {
+			position: 'absolute',
+			transform: `rotate(${90 * Math.floor(Math.random() * 4)}deg)`,
+		});
 
-			const pos_x = Math.round(
-				border / 2 + span_x * (x - spread + 2 * spread * Math.random())
-			);
-			const pos_y = Math.round(
-				border + span_y * (y - spread + 2 * spread * Math.random())
-			);
+		return img;
+	});
 
-			Object.assign(img.style, {
-				left: `${pos_x}px`,
-				top: `${pos_y}px`,
-				position: 'absolute',
-				transform: `rotate(${90 * Math.floor(Math.random() * 4)}deg)`,
-			});
+	const positionPieceImages = () => {
+		const bounds = parent.getBoundingClientRect();
+		const { width, height } = bounds;
+		const span_x = (width - border * 2) / (grid_x - 1);
+		const span_y = (height - border * 2) / (grid_y - 1);
 
-			bg.appendChild(img);
+		for (let x = grid_x; x--; ) {
+			for (let y = grid_y; y--; ) {
+				const imgIdx = y * grid_x + x;
+				const img = pieceImages[imgIdx];
+
+				const pos_x = Math.round(
+					border / 2 + span_x * (x - spread + 2 * spread * Math.random())
+				);
+				const pos_y = Math.round(
+					border + span_y * (y - spread + 2 * spread * Math.random())
+				);
+
+				Object.assign(img.style, {
+					left: `${pos_x}px`,
+					top: `${pos_y}px`,
+				});
+			}
 		}
-	}
+	};
+
+	positionPieceImages();
+
+	pieceImages.forEach(img => bg.appendChild(img));
 
 	parent.style.backgroundColor = 'black';
 
 	parent.prepend(bg);
+
+	window.addEventListener('resize', positionPieceImages);
 }
 
 export default {};

--- a/public/views/bg.js
+++ b/public/views/bg.js
@@ -98,8 +98,6 @@ if (QueryString.get('bg') === '0') {
 	Object.assign(bg.style, {
 		position: 'absolute',
 		width: '119%',
-		height: '133%',
-		top: '-15%',
 		left: '-14%',
 		background: `url(/views/${bg_file}) 0 0 repeat`,
 		transform: 'rotate(-11deg)',
@@ -111,6 +109,29 @@ if (QueryString.get('bg') === '0') {
 		pos = ++pos % img_width;
 		bg.style.backgroundPositionX = `${pos}px`;
 	}, 1000 / 30);
+
+	function interpolator(x0, v0, x1, v1) {
+		return function (x) {
+			return v0 + ((x - x0) * (v1 - v0)) / (x1 - x0);
+		};
+	}
+
+	const interpolateTop = interpolator(1920, -15, 4096, -32);
+	const interpolateHeight = interpolator(1920, 133, 4096, 171);
+
+	const adjustSize = () => {
+		const bounds = parent.getBoundingClientRect();
+		const { width } = bounds;
+
+		Object.assign(bg.style, {
+			top: `${interpolateTop(width)}%`,
+			height: `${interpolateHeight(width)}%`,
+		});
+	};
+
+	adjustSize();
+
+	window.addEventListener('resize', adjustSize);
 
 	parent.prepend(bg);
 } else {

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -460,6 +460,18 @@
 					width: 43px;
 					height: 27px;
 				}
+
+				.heartpos3 .match.small .hearts {
+					--offset: calc(
+						var(--score-offset) + 64px
+					); /* accounts for flag width */
+				}
+			}
+
+			@container stream_bg (max-width: 1580px) {
+				.match.small {
+					--score-width: 300px;
+				}
 			}
 		</style>
 	</head>

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -646,6 +646,23 @@
 				<!-- Player 2 -->
 			</div>
 			<!-- End Playing Fields -->
+			<div
+				id="log"
+				style="
+					position: absolute;
+					bottom: 150px;
+					left: 0px;
+					width: 1000px;
+					height: 200px;
+					overflow-y: auto;
+					overflow-x: hidden;
+					white-space: pre-wrap;
+					border: 1px solid #ccc;
+					padding: 8px;
+					background: white;
+					color: black;
+				"
+			></div>
 		</div>
 		<!-- End Stream BG -->
 
@@ -660,6 +677,28 @@
 			});
 		</script>
 		<script src="/vendor/peerjs.1.5.4.min.js"></script>
+		<script type="module">
+			function addLogLine(text) {
+				const logDiv = document.getElementById('log');
+				const line = document.createElement('div');
+				line.textContent = text;
+				logDiv.appendChild(line);
+
+				// Auto-scroll to the bottom
+				logDiv.scrollTop = logDiv.scrollHeight;
+			}
+
+			const width = window.innerWidth;
+			const height = window.innerHeight;
+			addLogLine(`Viewport size: ${width} x ${height}`);
+
+			window.addEventListener('resize', () => {
+				addLogLine(
+					`Resized viewport: ${window.innerWidth} x ${window.innerHeight}`
+				);
+				document.querySelector('.match');
+			});
+		</script>
 		<script type="module">
 			import '/views/bg.js';
 			import { peerServerOptions } from '/views/constants.js';

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -304,15 +304,16 @@
 			}
 
 			.player_vid {
+				--offset: 360px;
+
 				position: absolute;
 				top: 0;
-				width: 600px;
+				width: calc(var(--player-width) - var(--offset));
 				height: 1023px;
 				padding: 0;
 				object-fit: cover;
 				/* background: yellow; /**/
 
-				--offset: 360px;
 				right: var(--offset);
 			}
 
@@ -436,7 +437,6 @@
 			}
 			.match.small .player_vid {
 				top: 96px;
-				width: 965px;
 				height: 609px;
 			}
 

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -4,13 +4,16 @@
 		<link rel="stylesheet" type="text/css" href="/views/tetris.css" />
 		<style>
 			#stream_bg {
-				width: 1920px;
+				container-type: inline-size;
+				container-name: stream_bg;
+				width: 100vw;
 				height: 1080px;
 			}
 
 			.match {
+				--scale: 1;
 				position: absolute;
-				left: 960px;
+				left: 50%;
 				top: 0;
 			}
 
@@ -33,7 +36,7 @@
 			}
 
 			.score {
-				width: 333px;
+				width: 333px; /* can reduce to 300px for score <10M */
 				padding-right: 0;
 				height: 112px;
 				top: 0;
@@ -124,6 +127,7 @@
 				padding: 3px 0;
 				height: 64px;
 				text-transform: uppercase;
+				white-space: nowrap;
 			}
 
 			.name .header {
@@ -317,7 +321,8 @@
 			}
 
 			.match.small {
-				transform: scale(0.7245042492917847); /* (1080-57)/706/2 */
+				--scale: 0.7245042492917847; /* (1080-57)/706/2 */
+				transform: scale(var(--scale));
 			}
 			#match2.small {
 				top: 511px;
@@ -412,11 +417,11 @@
 				top: 0;
 			}
 			.match.small .name {
-				width: 462px;
 				--offset: 707px;
+				width: calc((100vw / var(--scale) / 2) - var(--offset) - 51px - 105px);
 			}
 			.match.small .flag {
-				--offset: 1190px;
+				--offset: calc((100vw / var(--scale) / 2) - 30px - 105px);
 			}
 			.match.small .player_vid {
 				top: 96px;
@@ -431,6 +436,19 @@
 
 			.match.small .p2 > * {
 				left: var(--offset);
+			}
+
+			@container stream_bg (max-width: 1800px) {
+				.match.small .name {
+					z-index: 7;
+					width: calc((100vw / var(--scale) / 2) - 707px - 30px);
+				}
+				.match.small .flag {
+					--offset: 707px;
+					top: 91px;
+					width: 43px;
+					height: 27px;
+				}
 			}
 		</style>
 	</head>

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -669,6 +669,7 @@
 				<!-- Player 2 -->
 			</div>
 			<!-- End Playing Fields -->
+			<!-- DOM Logger
 			<div
 				id="log"
 				style="
@@ -686,7 +687,7 @@
 					color: black;
 				"
 			></div>
-		</div>
+			 --></div>
 		<!-- End Stream BG -->
 
 		<!-- Audio -->
@@ -711,6 +712,7 @@
 				logDiv.scrollTop = logDiv.scrollHeight;
 			}
 
+			/*
 			const width = window.innerWidth;
 			const height = window.innerHeight;
 			addLogLine(`Viewport size: ${width} x ${height}`);
@@ -721,6 +723,7 @@
 				);
 				document.querySelector('.match');
 			});
+			/**/
 		</script>
 		<script type="module">
 			import '/views/bg.js';

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -4,14 +4,19 @@
 		<link rel="stylesheet" type="text/css" href="/views/tetris.css" />
 		<style>
 			#stream_bg {
+				--width: 100vw;
+
 				container-type: inline-size;
 				container-name: stream_bg;
-				width: 100vw;
+				width: var(--width);
 				height: 1080px;
 			}
 
 			.match {
 				--scale: 1;
+				--board-offset: 357px;
+				--player-width: calc(var(--width) / 2 / var(--scale));
+
 				position: absolute;
 				left: 50%;
 				top: 0;
@@ -163,7 +168,7 @@
 			.tetris_rate,
 			.drought,
 			.flag {
-				--offset: 357px;
+				--offset: var(--board-offset);
 			}
 
 			.hearts {
@@ -322,6 +327,11 @@
 
 			.match.small {
 				--scale: 0.7245042492917847; /* (1080-57)/706/2 */
+				--score-width: 326px;
+				--score-offset: calc(
+					var(--board-offset) + var(--score-width) + (var(--border-size) * 1px) +
+						9px
+				); /* why 9px??? */
 				transform: scale(var(--scale));
 			}
 			#match2.small {
@@ -335,7 +345,7 @@
 			.match.small .score,
 			.match.small .lines,
 			.match.small .next_piece {
-				--offset: 357px;
+				--offset: var(--board-offset);
 			}
 
 			.match.small .next_piece {
@@ -366,7 +376,7 @@
 				z-index: 8;
 			}
 			.match.small .score {
-				width: 326px;
+				width: var(--score-width);
 				z-index: 7;
 			}
 			.match.small .hearts {
@@ -387,9 +397,10 @@
 			.heartpos3 .match.small .hearts,
 			.heartpos4 .match.small .hearts {
 				--border-size: 14;
+				--offset: var(--score-offset);
+
 				width: unset;
 				top: 91px;
-				--offset: 707px;
 				height: 29px;
 				padding: 0 6px 0 9px;
 				gap: 2px;
@@ -401,14 +412,17 @@
 				right: unset;
 			}
 
+			.match.small .flag,
 			.heartpos4 .match.small .hearts {
-				left: calc(-1 * 100vw / 2 / var(--scale));
+				--offset: calc(-1 * var(--player-width));
+				left: var(--offset);
 				right: unset;
 			}
 
+			.match.small .p2 .flag,
 			.heartpos4 .match.small .p2 .hearts {
 				left: unset;
-				right: calc(-1 * 100vw / 2 / var(--scale));
+				right: var(--offset);
 			}
 
 			.match.small .flag,
@@ -417,11 +431,8 @@
 				top: 0;
 			}
 			.match.small .name {
-				--offset: 707px;
-				width: calc((100vw / var(--scale) / 2) - var(--offset) - 51px - 105px);
-			}
-			.match.small .flag {
-				--offset: calc((100vw / var(--scale) / 2) - 30px - 105px);
+				--offset: var(--score-offset);
+				width: calc(var(--player-width) - var(--offset) - 51px - 105px);
 			}
 			.match.small .player_vid {
 				top: 96px;
@@ -441,10 +452,10 @@
 			@container stream_bg (max-width: 1800px) {
 				.match.small .name {
 					z-index: 7;
-					width: calc((100vw / var(--scale) / 2) - 707px - 30px);
+					width: calc(var(--player-width) - var(--offset) - 30px);
 				}
 				.match.small .flag {
-					--offset: 707px;
+					--offset: var(--score-offset);
 					top: 91px;
 					width: 43px;
 					height: 27px;

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -402,13 +402,13 @@
 			}
 
 			.heartpos4 .match.small .hearts {
-				left: -1325px;
+				left: calc(-1 * 100vw / 2 / var(--scale));
 				right: unset;
 			}
 
 			.heartpos4 .match.small .p2 .hearts {
 				left: unset;
-				right: -1325px;
+				right: calc(-1 * 100vw / 2 / var(--scale));
 			}
 
 			.match.small .flag,

--- a/public/views/tetris.css
+++ b/public/views/tetris.css
@@ -21,6 +21,8 @@ td {
 }
 
 #stream_bg {
+	--border-size: 15; /* should rename to box-border-size */
+
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -44,7 +46,6 @@ td {
 	text-align: center;
 
 	/* css magic to handle borders 💪 */
-	--border-size: 15;
 	border: solid calc(var(--border-size) * 1px) transparent;
 	border-image-source: url('/views/border_3px.png');
 	border-image-slice: var(--border-size) var(--border-size) var(--border-size)


### PR DESCRIPTION
## Context
Quals in CTWC competitive broadcasts typically show the qualifier rank on the size, consuming a portion of the available real-estate. The NTC layouts are typically completely hardcoded for 1920x1080, and thus end up being cut off.

## Approach
Make CTWC layout responsive by adjusting itself to the available width. 
The current design is to use the entire available width (height is still hardcoded to 1080). In OBS, an operator can control the available width by adjusting the pixel source of the Browser Source.