### PR TITLE
Play frames without timer on backgrounded (throttled) views

### DIFF
--- a/public/views/FrameBuffer.js
+++ b/public/views/FrameBuffer.js
@@ -1,3 +1,5 @@
+import { peek } from '/views/utils.js';
+
 function noop() {}
 
 export default class FrameBuffer {
@@ -5,7 +7,6 @@ export default class FrameBuffer {
 		this.duration_ms = duration_ms;
 		this.frame_callback = frame_callback;
 		this.buffer = [];
-
 		this.frame_to = null;
 
 		this._sendFrame = this._sendFrame.bind(this);
@@ -21,31 +22,29 @@ export default class FrameBuffer {
 
 		if (this.buffer.length == 1) {
 			this._reset();
+		} else {
+			// we have at least 2 frames, check if we need do some rapid replays
+			this._maintainRealtime();
 		}
 	}
 
 	_reset() {
 		if (this.buffer.length <= 0) return;
 
-		this.client_time_base = 0;
-		this.local_time_base = 0;
+		// record client-local time equivalence
+		this.client_time_base = this.buffer[0].ctime;
+		this.local_time_base = Date.now() + this.duration_ms;
+
 		this.frame_to = setTimeout(this._sendFrame, this.duration_ms);
 	}
 
 	_sendFrame() {
 		if (this.buffer.length <= 0) return;
 
-		const data = this.buffer.shift();
-		const now = Date.now();
-
-		// record client-local time equivalence
-		if (!this.client_time_base) {
-			this.client_time_base = data.ctime;
-			this.local_time_base = now;
-		}
+		const frame = this.buffer.shift();
 
 		// send current frame
-		this.frame_callback(data);
+		this.frame_callback(frame);
 
 		// schedule next frame if needed
 		if (this.buffer.length) {
@@ -54,13 +53,34 @@ export default class FrameBuffer {
 
 			this.frame_to = setTimeout(
 				this._sendFrame,
-				this.local_time_base + elapsed - now
+				this.local_time_base + elapsed - Date.now()
 			);
 		}
 	}
 
-	_destroy() {
+	_maintainRealtime() {
+		/*
+		 * If a tab is backgrounded, timers are throttled, when a frame is received, we check if
+		 * there's a been a pile up of frames. If there is, we want to replay all frames till we catch up with the buffer size
+		 */
+		if (this.buffer.length < 2) return;
+
+		const latestClientTime = peek(this.buffer).ctime;
+
+		// batch-send all the "expired" frames that should have already been processed in a non-throttled environment
+		while (latestClientTime - this.buffer[0].ctime > this.duration_ms) {
+			this._clearFrameTimeout();
+			this._sendFrame(); // calling this naively means we set and clear the timeout many times, but it should be negligeable cost
+		}
+	}
+
+	_clearFrameTimeout() {
+		if (!this.frame_to) return;
 		this.frame_to = clearTimeout(this.frame_to);
+	}
+
+	_destroy() {
+		this._clearFrameTimeout();
 		this.local_time_base = 0;
 		this.client_time_base = 0;
 		this.buffer.length = 0;


### PR DESCRIPTION
## Context

Because the frame buffer is implemented with timers, when a tab is backgrounded (e.g. in a hidden scene in OBS) and timers are throttled, the frame buffer accumulates the frames without being able to replay them at real-time speed.

Because of that, when tab gets un-backgrounded (OBS scene becomes visible), then all pending frames get replayed at high speed. 

At the moment, when the websocket frames are received, they wakes the backgrounded tab, which then just stores the frame in the buffer and does nothing. The rendering is then scheduled with a `seTimeout()`, which gets delayed.

## Approach

Everytime a frame is received, the frame buffer will check if it contains expired frames (i.e. frames which would have been processed if the timers ran at the correct speed). If yes, the frame buffer will process expired frame synchronously on the spot.

This means that a backgrounded OBS tab will consume more resources than before, but switching between scenes should no longer show that annoying sped up effect.
