### PR TITLE
feat: support expressturn

### DIFF
--- a/modules/expressturn.js
+++ b/modules/expressturn.js
@@ -1,0 +1,93 @@
+// modules/expressturn.js
+// Paid for Turn server
+//
+// Credentials are dynamically generated with 2-days expiry
+// this should work well for heroku which restarts the app daily
+
+import fs from 'fs';
+import crypto from 'crypto';
+import { shuffle } from '../public/views/utils.js';
+import _ from 'lodash';
+
+const TTL = 86400 * 2; // 2 days
+
+// Generate TURN credentials
+// see https://www.expressturn.com/webrtc-secret-key-examples
+function generateTurnCredentials(username) {
+	// expiry timestamp
+	const timestamp = Math.floor(Date.now() / 1000) + TTL;
+
+	// Combine timestamp with username
+	const turnUsername = `${timestamp}:${username}`;
+
+	// Generate password using HMAC-SHA1 and encode in Base64
+	const password = crypto
+		.createHmac('sha1', process.env.EXPRESSTURN_SECRET_KEY)
+		.update(turnUsername)
+		.digest('base64');
+
+	return [turnUsername, password];
+}
+
+if (process.env.EXPRESSTURN_SECRET_KEY && process.env.EXPRESSTURN_USERNAME) {
+	// Generate and display credentials
+	const [username, credential] = generateTurnCredentials(
+		process.env.EXPRESSTURN_USERNAME
+	);
+
+	// expressturn has 17 relay servers, we will randomly pick 3 to use
+	const serverNums = shuffle(
+		Array(17)
+			.fill(0)
+			.map((_, idx) => idx + 1)
+	).slice(0, 3);
+
+	// one stun entry first
+	const iceServers = [
+		{
+			urls: serverNums.map(
+				serverNum => `stun:relay${serverNum}.expressturn.com:3478`
+			),
+		},
+	];
+
+	serverNums.forEach(serverNum => {
+		iceServers.push({
+			urls: [
+				`turns:relay${serverNum}.expressturn.com:443`,
+				`turn:relay${serverNum}.expressturn.com:3478?transport=udp`,
+				`turn:relay${serverNum}.expressturn.com:3478?transport=tcp`,
+			],
+			username,
+			credential,
+		});
+	});
+
+	const peerjsServerOptions = {
+		host: '0.peerjs.com',
+		path: '/',
+		port: 443,
+		secure: true,
+		config: {
+			iceServers,
+			// iceTransportPolicy: 'relay', // force turn for testing purposes
+		},
+	};
+
+	fs.writeFileSync(
+		'public/js/peerjsOptions.js',
+		`export const peerServerOptions = ${JSON.stringify(
+			peerjsServerOptions,
+			null,
+			2
+		)};\n`
+	);
+
+	// Formatted output using template literal
+	console.log(`TURN Credentials Generated
+----------------------------------------
+Username: ${username}
+Password: ${credential}
+TTL     : ${TTL} seconds
+----------------------------------------`);
+}

--- a/public/js/peerjsOptions.js
+++ b/public/js/peerjsOptions.js
@@ -1,0 +1,6 @@
+export const peerServerOptions = {
+	host: '0.peerjs.com',
+	path: '/',
+	port: 443,
+	secure: true,
+};

--- a/public/producer/CaptureDriver.js
+++ b/public/producer/CaptureDriver.js
@@ -112,6 +112,10 @@ export class CaptureDriver extends EventTarget {
 			driverMode: DRIVER_MODE,
 			ocrClass: (await getOcrClass()).name,
 		};
+
+		if (!this.#captureDetails.device) {
+			delete this.#captureDetails.device;
+		}
 	}
 
 	#stopFrameCapture() {

--- a/public/producer/MediaUtils.js
+++ b/public/producer/MediaUtils.js
@@ -31,7 +31,7 @@ export async function getConnectedDevices(type) {
 }
 
 export async function getDeviceLabel(device_id) {
-	if (!device_id) throw new Error('device_id not provided');
+	if (!device_id) return '';
 	const devices = await getConnectedDevices('videoinput');
 	const device = devices.find(d => d.deviceId === device_id);
 	return device ? device.label : 'Unknown Device';

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -2,7 +2,7 @@ import QueryString from '/js/QueryString.js';
 import BinaryFrame from '/js/BinaryFrame.js';
 import Connection from '/js/connection.js';
 
-import { peerServerOptions } from '/views/constants.js';
+import { peerServerOptions } from '/js/peerjsOptions.js';
 
 const SEND_BINARY = QueryString.get('binary') !== '0';
 const HEART_BEAT_TIMEOUT = 1000;

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -367,7 +367,7 @@ class Player {
 
 					driver = new CaptureDriver(config, stream);
 					driver.addPlayer({
-						processVideoFrame(frame) {
+						processFrame(frame) {
 							ocr.processVideoFrame(frame);
 						},
 					});

--- a/public/views/constants.js
+++ b/public/views/constants.js
@@ -1,38 +1,4 @@
-const isLocalRpi = false;
-
-const defaultPeerjsOptions = {
-	host: '0.peerjs.com',
-	path: '/',
-	port: 443,
-	secure: true,
-	config: {
-		iceServers: [
-			{ url: 'stun:freeturn.net:3478' },
-			{ url: 'turn:freeturn.net:3478', username: 'free', credential: 'free' },
-		],
-	},
-};
-
-const rpiPeerjsOptions = {
-	host: 'nestrischamps.local',
-	path: '/',
-	port: 9000,
-	secure: true,
-	config: {
-		iceServers: [
-			{ url: 'stun:nestrischamps.local:3478' },
-			{
-				url: 'turn:nestrischamps.local:3478',
-				username: 'ntc',
-				credential: 'ntc',
-			},
-		],
-	},
-};
-
-export const peerServerOptions = isLocalRpi
-	? rpiPeerjsOptions
-	: defaultPeerjsOptions;
+export { peerServerOptions } from '/js/peerjsOptions.js';
 
 export const DOM_DEV_NULL =
 	(typeof document !== 'undefined' && document.createElement('div')) || {};

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ import { Server } from 'http';
 import { createServer } from 'https';
 import { readFileSync } from 'fs';
 
+import './modules/expressturn.js'; // conditionnaly sets up peerjs server options
+
 import app from './modules/app.js';
 
 let server;

--- a/setup/local_rpi/setup.sh
+++ b/setup/local_rpi/setup.sh
@@ -33,22 +33,42 @@ sudo apt install -y nodejs
 npm install
 sudo npm install peer -g
 
+HOSTNAME=nestrischamps.local
+
 # generate the server keys
 openssl req -x509 \
   -sha256 \
   -nodes \
   -newkey rsa:2048 \
   -days 3650 \
-  -subj "/C=SG/O=Yobi/OU=Nestrischamps/CN=nestrischamps.local/" \
-  -keyout nestrischamps.local.key \
-  -out nestrischamps.local.crt
+  -subj "/C=SG/O=Yobi/OU=Nestrischamps/CN=${HOSTNAME}/" \
+  -keyout ${HOSTNAME}.key \
+  -out ${HOSTNAME}.crt
 
-sed -r -i 's/isLocalRpi = false/isLocalRpi = true/g' public/views/constants.js
+tee public/views/constants.js > /dev/null << EOF
+export const peerServerOptions = {
+	host: '${HOSTNAME}',
+	path: '/',
+	port: 9000,
+	secure: true,
+	config: {
+		iceServers: [
+			{ urls: ['stun:${HOSTNAME}:3478'] },
+			{
+				urls: ['turn:${HOSTNAME}:3478'],
+				username: 'ntc',
+				credential: 'ntc',
+			},
+		],
+	},
+};
+EOF
+
 
 SESSION_SECRET=$(echo "console.log(require('ulid').ulid())" | node)
 PORT=5443
-TLS_KEY_PATH=/home/yobi/src/nestrischamps/nestrischamps.local.key
-TLS_CERT_PATH=/home/yobi/src/nestrischamps/nestrischamps.local.crt
+TLS_KEY_PATH=/home/yobi/src/nestrischamps/${HOSTNAME}.key
+TLS_CERT_PATH=/home/yobi/src/nestrischamps/${HOSTNAME}.crt
 
 tee .env > /dev/null << EOF
 TLS_KEY=${TLS_KEY_PATH}


### PR DESCRIPTION
## Context
player cams over peerjs and remote calibration use webRTC, and used freeturn for a turnserver fallback.

freeturn is dead however, so if TURN was needed, it would just fail.

I have picked [expressturn ](https://www.expressturn.com/) as a paid for alternative solution

## Approach
* Don't provide any turn server by default
* If server conf offers expressturn env vars (`username` and `secret`), use them to derive new conf with stun and turn servers
* credentials are refreshed on every app restart and stay static thereafter

## Bonus
The latest changes to support the device label broke remote calibration with a runtime exception, this PR fixes that too.