### PR TITLE
feat: allow host to restart player OCR

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -479,7 +479,8 @@ class MatchRoom extends Room {
 					break;
 				}
 
-				case 'restartCamera': {
+				case 'restartCamera':
+				case 'restartOcr': {
 					update_admin = false;
 					forward_to_views = false;
 
@@ -493,9 +494,14 @@ class MatchRoom extends Room {
 					if (user && this.last_view) {
 						const producer = user.getProducer();
 
-						producer.send(['dropPlayer']);
-						producer.send(['setViewPeerId', this.last_view.id]);
-						producer.send(['makePlayer', p_num, this.getViewMeta()]); // should reset camera!
+						if (command === 'restartCamera') {
+							producer.send(['dropPlayer']);
+							producer.send(['setViewPeerId', this.last_view.id]);
+							producer.send(['makePlayer', p_num, this.getViewMeta()]); // should reset camera!
+						} else {
+							// restartOcr
+							producer.send(['restartOcr']);
+						}
 					}
 
 					break;

--- a/public/producer/GameTracker.js
+++ b/public/producer/GameTracker.js
@@ -51,6 +51,11 @@ export default class GameTracker extends EventTarget {
 		this.palette = Array(10).fill();
 	}
 
+	dumpGame() {
+		this.in_game = false;
+		this.cur_lines = undefined;
+	}
+
 	_getLevelFromLines(lines, ocr_level_digits) {
 		if (lines === null || ocr_level_digits === null) return null;
 		if (!this.transition) return GameTracker.digitsToValue(ocr_level_digits);

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -56,6 +56,10 @@ export class Player extends EventTarget {
 				this.dispatchEvent(new CustomEvent('drop_player'));
 			},
 
+			restartOcr() {
+				this.dispatchEvent(new CustomEvent('restart_ocr'));
+			},
+
 			setVdoNinjaURL: () => {},
 		};
 	}

--- a/public/producer/components/capture.js
+++ b/public/producer/components/capture.js
@@ -132,6 +132,12 @@ export class NTC_Producer_Capture extends NtcComponent {
 			this.#domrefs.room.loadRoomView(detail.view_meta);
 		});
 
+		player.addEventListener('restart_ocr', () => {
+			if (this.#player.gameTracker) {
+				this.#player.gameTracker.dumpGame();
+			}
+		});
+
 		if (QueryString.get('tts') === '1') {
 			player.addEventListener('chat_message', ({ detail: msg }) => {
 				msg && speak(msg);

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -178,6 +178,10 @@ class Player {
 			remoteAPI.restartCamera(this.idx);
 		};
 
+		this.dom.restart_ocr_btn.onclick = () => {
+			remoteAPI.restartOcr(this.idx);
+		};
+
 		this.dom.camera_mirror_btn.onclick = () => {
 			remoteAPI.mirrorCamera(this.idx);
 		};
@@ -617,6 +621,7 @@ function addPlayer() {
 		remove_btn: player_node.querySelector('.remove_player'),
 		camera_restart_btn: player_node.querySelector('.camera_restart'),
 		camera_mirror_btn: player_node.querySelector('.camera_mirror'),
+		restart_ocr_btn: player_node.querySelector('.restart_ocr'),
 		focus_player_btn: player_node.querySelector('.focus_player'),
 		remote_calibration_btn: player_node.querySelector('.remote_calibration'),
 		vdo_ninja_url: player_node.querySelector('.vdo_ninja_url'),

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -336,6 +336,7 @@
 					<p>
 						<button class="camera_restart">Restart Camera</button>
 						<button class="camera_mirror">Mirror Camera</button>
+						<button class="restart_ocr">Restart OCR</button>
 					</p>
 					<p>
 						<button class="focus_player">Focus Player</button>


### PR DESCRIPTION
## Context

[Feature request on discord](https://discord.com/channels/817528744565932043/817528745018654787/1477761040430403787), pasted below for convenience:

> so when a player starts with a bad OCR read (ie: starts on 18 but it reads 29), the restreamer can do remote calibration mid game...  however, because NTC only reads the level at the beginning, maybe the restreamer could have a "re-read" button that basically dumps the current game, re-reads the board, and continues from there?  Sure, you'd lose continuity of the game as far as saving it, but it would be better for restreams for sure.


## Approach

Introduce a new per-player button in the admin page, that allows the game host to force-restart OCR for the the player.