### PR TITLE
Rendering optimizations

### DIFF
--- a/public/views/BaseGame.js
+++ b/public/views/BaseGame.js
@@ -923,6 +923,8 @@ export default class BaseGame {
 		// we will update piece event with the deviation reactively
 		this._recordPieceEvent(cur_piece, data);
 
+		const len = this.pieces.length;
+
 		// Handle deviation
 		let distance_square = 0;
 
@@ -931,7 +933,7 @@ export default class BaseGame {
 		PIECES.forEach(name => {
 			const stats = this.data.pieces[name];
 
-			distance_square += Math.pow(stats.count / this.pieces.length - 1 / 7, 2);
+			distance_square += Math.pow(stats.count / len - 1 / 7, 2);
 		});
 
 		last_piece_event.deviation =
@@ -940,7 +942,7 @@ export default class BaseGame {
 				Math.sqrt(distance_square / PIECES.length);
 
 		// handle deviation
-		if (this.pieces.length >= 28) {
+		if (len >= 28) {
 			// compute the 28 and 56 deviation
 			// TODO: compute over "true" bags, that would always yield 0 deviation in modern tetrises
 			const counts = {};
@@ -948,7 +950,7 @@ export default class BaseGame {
 			PIECES.forEach(name => (counts[name] = 0));
 
 			for (let offset = 28; offset > 0; offset--) {
-				counts[this.pieces[this.pieces.length - offset].piece]++;
+				counts[this.pieces[len - offset].piece]++;
 			}
 
 			last_piece_event.deviation_28 = Math.sqrt(
@@ -958,9 +960,9 @@ export default class BaseGame {
 				) / PIECES.length
 			);
 
-			if (this.pieces.length >= 56) {
+			if (len >= 56) {
 				for (let offset = 28; offset > 0; offset--) {
-					counts[this.pieces[this.pieces.length - 28 - offset].piece]++;
+					counts[this.pieces[len - 28 - offset].piece]++;
 				}
 
 				last_piece_event.deviation_56 = Math.sqrt(

--- a/public/views/BaseGame.js
+++ b/public/views/BaseGame.js
@@ -70,7 +70,7 @@ function fuzzyBinarySearchWithLowerBias(array, path, target_value) {
 
 const DEFAULT_OPTIONS = {
 	usePieceStats: false,
-	seekableFrames: true,
+	seekableFrames: false,
 };
 
 export default class BaseGame {
@@ -141,8 +141,8 @@ export default class BaseGame {
 			}
 		}
 
-		if (this.frames.length > 0) {
-			this.duration = frame.ctime - this.frames[0].raw.ctime;
+		if (this.num_frames > 0 && this.start_ctime !== undefined) {
+			this.duration = frame.ctime - this.start_ctime;
 		}
 
 		// Warning: order of the 3 operations below matters!
@@ -210,6 +210,8 @@ export default class BaseGame {
 			points: [],
 			clears: [],
 		};
+
+		this.num_frames = 0;
 
 		// this.data is used to track game stats and data as they progress
 		// snapshots of them will be stored in frames as needed
@@ -457,7 +459,7 @@ export default class BaseGame {
 
 	_addFrame(data) {
 		const frame = {
-			idx: this.frames.length,
+			idx: this.num_frames,
 			raw: data,
 
 			pieces: this.array_views.pieces,
@@ -467,7 +469,14 @@ export default class BaseGame {
 			in_clear_animation: this.clear_animation_remaining_frames >= 0,
 		};
 
-		this.frames.push(frame);
+		if (this.options.seekableFrames) {
+			this.frames.push(frame);
+		} else {
+			this.frames.push(frame);
+			if (this.frames.length > 2) this.frames.shift();
+		}
+
+		this.num_frames++;
 
 		return frame;
 	}
@@ -671,7 +680,9 @@ export default class BaseGame {
 				return acc;
 			}, {}),
 		};
+
 		this.points.push(evt);
+
 		this.array_views.points = new ArrayView(this.points);
 	}
 
@@ -684,7 +695,9 @@ export default class BaseGame {
 				return acc;
 			}, {}),
 		};
+
 		this.clears.push(evt);
+
 		this.array_views.clears = new ArrayView(this.clears);
 
 		// record the fact that the last piece caused a clear event
@@ -895,7 +908,9 @@ export default class BaseGame {
 
 				// mark past pieces as being in drought
 				for (let offset = DROUGHT_PANIC_THRESHOLD - 1; offset > 0; offset--) {
-					this.pieces[this.pieces.length - offset].in_drought = true;
+					if (this.pieces.length - offset >= 0) {
+						this.pieces[this.pieces.length - offset].in_drought = true;
+					}
 				}
 			}
 
@@ -925,9 +940,7 @@ export default class BaseGame {
 				Math.sqrt(distance_square / PIECES.length);
 
 		// handle deviation
-		const len = this.pieces.length;
-
-		if (len > 28) {
+		if (this.pieces.length >= 28) {
 			// compute the 28 and 56 deviation
 			// TODO: compute over "true" bags, that would always yield 0 deviation in modern tetrises
 			const counts = {};
@@ -935,7 +948,7 @@ export default class BaseGame {
 			PIECES.forEach(name => (counts[name] = 0));
 
 			for (let offset = 28; offset > 0; offset--) {
-				counts[this.pieces[len - offset].piece]++;
+				counts[this.pieces[this.pieces.length - offset].piece]++;
 			}
 
 			last_piece_event.deviation_28 = Math.sqrt(
@@ -945,9 +958,9 @@ export default class BaseGame {
 				) / PIECES.length
 			);
 
-			if (len >= 56) {
+			if (this.pieces.length >= 56) {
 				for (let offset = 28; offset > 0; offset--) {
-					counts[this.pieces[len - 28 - offset].piece]++;
+					counts[this.pieces[this.pieces.length - 28 - offset].piece]++;
 				}
 
 				last_piece_event.deviation_56 = Math.sqrt(

--- a/public/views/BaseGame.js
+++ b/public/views/BaseGame.js
@@ -469,14 +469,12 @@ export default class BaseGame {
 			in_clear_animation: this.clear_animation_remaining_frames >= 0,
 		};
 
-		if (this.options.seekableFrames) {
-			this.frames.push(frame);
-		} else {
-			this.frames.push(frame);
-			if (this.frames.length > 2) this.frames.shift();
-		}
-
+		this.frames.push(frame);
 		this.num_frames++;
+
+		if (!this.options.seekableFrames && this.frames.length > 2) {
+			this.frames.shift();
+		}
 
 		return frame;
 	}
@@ -680,9 +678,7 @@ export default class BaseGame {
 				return acc;
 			}, {}),
 		};
-
 		this.points.push(evt);
-
 		this.array_views.points = new ArrayView(this.points);
 	}
 
@@ -695,9 +691,7 @@ export default class BaseGame {
 				return acc;
 			}, {}),
 		};
-
 		this.clears.push(evt);
-
 		this.array_views.clears = new ArrayView(this.clears);
 
 		// record the fact that the last piece caused a clear event
@@ -908,9 +902,7 @@ export default class BaseGame {
 
 				// mark past pieces as being in drought
 				for (let offset = DROUGHT_PANIC_THRESHOLD - 1; offset > 0; offset--) {
-					if (this.pieces.length - offset >= 0) {
-						this.pieces[this.pieces.length - offset].in_drought = true;
-					}
+					this.pieces[this.pieces.length - offset].in_drought = true;
 				}
 			}
 

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -234,6 +234,7 @@ const DEFAULT_OPTIONS = {
 		const value = QueryString.get('flags');
 		return /^(c?fi|fpw?)$/.test(value) ? value : 'cfi'; // cfi: country-flag-icons - fi: flag-icons
 	})(),
+	seekableFrames: false,
 };
 
 const flagUrisFn = {
@@ -1028,7 +1029,9 @@ export default class Player extends EventTarget {
 	createGame() {
 		this._destroyGame();
 
-		this.game = new BaseGame();
+		this.game = new BaseGame({
+			seekableFrames: this.options.seekableFrames,
+		});
 
 		// Handlers with local rendering actions or custom behaviours
 		this.game.onScore = this._renderScore;

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -1185,34 +1185,50 @@ export default class Player extends EventTarget {
 			point_evt.score.current
 		);
 
-		if (point_evt.score.transition === null) {
+		if (
+			point_evt.score.transition === null &&
+			this.dom.runway_tr !== DOM_DEV_NULL
+		) {
 			this.dom.runway_tr.textContent = this.options.format_score(
 				point_evt.score.tr_runway,
 				6
 			);
 		}
 
-		this.dom.runway_game.textContent = this.options.format_score(
-			point_evt.score.runway,
-			7
-		);
+		if (this.dom.runway_game !== DOM_DEV_NULL) {
+			this.dom.runway_game.textContent = this.options.format_score(
+				point_evt.score.runway,
+				7
+			);
+		}
 
-		this.dom.runway_lv19.textContent = this.options.format_score(
-			point_evt.score.runways.LV19,
-			6
-		);
-		this.dom.runway_lv29.textContent = this.options.format_score(
-			point_evt.score.runways.LV29,
-			7
-		);
-		this.dom.runway_lv39.textContent = this.options.format_score(
-			point_evt.score.runways.LV39,
-			7
-		);
-		this.dom.projection.textContent = this.options.format_score(
-			point_evt.score.projection,
-			7
-		);
+		if (this.dom.runway_lv19 !== DOM_DEV_NULL) {
+			this.dom.runway_lv19.textContent = this.options.format_score(
+				point_evt.score.runways.LV19,
+				6
+			);
+		}
+
+		if (this.dom.runway_lv29 !== DOM_DEV_NULL) {
+			this.dom.runway_lv29.textContent = this.options.format_score(
+				point_evt.score.runways.LV29,
+				7
+			);
+		}
+
+		if (this.dom.runway_lv39 !== DOM_DEV_NULL) {
+			this.dom.runway_lv39.textContent = this.options.format_score(
+				point_evt.score.runways.LV39,
+				7
+			);
+		}
+
+		if (this.dom.projection !== DOM_DEV_NULL) {
+			this.dom.projection.textContent = this.options.format_score(
+				point_evt.score.projection,
+				7
+			);
+		}
 
 		this.onScore(frame);
 	}
@@ -1220,10 +1236,12 @@ export default class Player extends EventTarget {
 	_renderTransition(frame) {
 		const point_evt = peek(frame.points);
 
-		this.dom.runway_tr.textContent = this.options.format_score(
-			point_evt.score.transition,
-			6
-		);
+		if (this.dom.runway_tr !== DOM_DEV_NULL) {
+			this.dom.runway_tr.textContent = this.options.format_score(
+				point_evt.score.transition,
+				6
+			);
+		}
 
 		this.onTransition(frame);
 	}
@@ -1234,13 +1252,21 @@ export default class Player extends EventTarget {
 		if (!clear_evt) clear_evt = fake_clear_evt;
 
 		this.dom.lines.textContent = `${frame.raw.lines}`.padStart(3, '0');
-		this.dom.burn.textContent = clear_evt.burn;
+
+		if (this.dom.burn !== DOM_DEV_NULL) {
+			this.dom.burn.textContent = clear_evt.burn;
+		}
 
 		if (frame.clears.length) {
-			this.dom.trt.textContent = getPercent(clear_evt.tetris_rate);
-			this.dom.eff.textContent = (Math.round(clear_evt.efficiency) || 0)
-				.toString()
-				.padStart(3, '0');
+			if (this.dom.trt !== DOM_DEV_NULL) {
+				this.dom.trt.textContent = getPercent(clear_evt.tetris_rate);
+			}
+
+			if (this.dom.eff !== DOM_DEV_NULL) {
+				this.dom.eff.textContent = (Math.round(clear_evt.efficiency) || 0)
+					.toString()
+					.padStart(3, '0');
+			}
 
 			this.renderRunningTRT(frame.clears);
 		}
@@ -1256,7 +1282,9 @@ export default class Player extends EventTarget {
 	}
 
 	_renderLevel(frame) {
-		this.dom.level.textContent = `${frame.raw.level}`.padStart(2, '0');
+		if (this.dom.level !== DOM_DEV_NULL) {
+			this.dom.level.textContent = `${frame.raw.level}`.padStart(2, '0');
+		}
 
 		this.onLevel(frame);
 	}

--- a/public/views/Player.js
+++ b/public/views/Player.js
@@ -274,13 +274,15 @@ export default class Player extends EventTarget {
 
 		this.hide_profile_card_on_next_game = false;
 
-		this.field_pixel_size =
-			this.options.field_pixel_size || this.options.pixel_size;
+		const styles = getComputedStyle(this.dom.field);
+
+		this.field_pixel_size = Math.max(
+			1,
+			Math.floor(css_size(styles.width) / 79)
+		);
 		this.preview_pixel_size =
 			this.options.preview_pixel_size || this.options.pixel_size;
 		this.render_running_trt_rtl = !!this.options.running_trt_rtl;
-
-		const styles = getComputedStyle(this.dom.field);
 
 		// getComputedStyle returns padding in Chrome,
 		// but Firefox returns 4 individual properties paddingTop, paddingLeft, etc...
@@ -303,11 +305,12 @@ export default class Player extends EventTarget {
 		} else {
 			// when padding is zero, we assume the padding is embedded in the border itself and equal on all sides
 			// and the padding has the size of this.field_pixel_size
-			bg_width = css_size(styles.width) + this.field_pixel_size * 2;
-			bg_height = css_size(styles.height) + this.field_pixel_size * 2;
-			bg_offset = this.field_pixel_size * -1;
-			field_canva_offset_t = this.field_pixel_size;
-			field_canva_offset_l = this.field_pixel_size;
+			const effective_pixel_size = css_size(styles.width) / 79;
+			bg_width = css_size(styles.width) + effective_pixel_size * 2;
+			bg_height = css_size(styles.height) + effective_pixel_size * 2;
+			bg_offset = effective_pixel_size * -1;
+			field_canva_offset_t = effective_pixel_size;
+			field_canva_offset_l = effective_pixel_size;
 		}
 
 		this.bg_height = bg_height; // store value for curtain animation
@@ -338,11 +341,12 @@ export default class Player extends EventTarget {
 
 		// Avatar Block
 		if (this.options.avatar) {
+			const effective_pixel_size = css_size(styles.width) / 79;
 			this.avatar = document.createElement('div');
 			this.avatar.classList.add('avatar');
 			Object.assign(this.avatar.style, {
 				position: 'absolute',
-				top: `${field_padding_tb + this.field_pixel_size * 8}px`,
+				top: `${field_padding_tb + Math.floor(effective_pixel_size * 8)}px`,
 				left: `${bg_offset}px`,
 				width: `${bg_width}px`,
 				height: `${bg_width}px`,
@@ -367,8 +371,16 @@ export default class Player extends EventTarget {
 				canvas.style.left = styles.paddingLeft;
 			}
 
-			canvas.setAttribute('width', css_size(styles.width));
-			canvas.setAttribute('height', css_size(styles.height));
+			if (name === 'field') {
+				canvas.setAttribute('width', 79 * this.field_pixel_size);
+				canvas.setAttribute('height', 159 * this.field_pixel_size);
+				canvas.style.width = styles.width;
+				canvas.style.height = styles.height;
+				canvas.style.imageRendering = 'auto'; // ensure bicubic stretch natively
+			} else {
+				canvas.setAttribute('width', css_size(styles.width));
+				canvas.setAttribute('height', css_size(styles.height));
+			}
 
 			this.dom[name].appendChild(canvas);
 

--- a/public/views/mp/3v3v3.html
+++ b/public/views/mp/3v3v3.html
@@ -411,7 +411,6 @@
 								video: player_node.querySelector(`video`),
 							},
 							{
-								field_pixel_size: 2.5,
 								preview_pixel_size: 2,
 								preview_align: 'tr',
 								stereo: translate([0, num_teams - 1], [-1, 1], team_idx),

--- a/public/views/mp/4v4v4.html
+++ b/public/views/mp/4v4v4.html
@@ -402,7 +402,6 @@
 								video: player_node.querySelector(`video`),
 							},
 							{
-								field_pixel_size: 2.5,
 								preview_pixel_size: 2,
 								preview_align: 'tr',
 								stereo: translate([0, num_teams - 1], [-1, 1], team_idx),

--- a/public/views/mp/adder.html
+++ b/public/views/mp/adder.html
@@ -34,6 +34,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<div id="team" class="team">
@@ -133,6 +134,10 @@
 						player_node.classList.add(`p${player_idx + 1}`);
 						players_node.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const player = new Player(
 							{
 								name: player_node.querySelector(`.score .header`),
@@ -167,10 +172,6 @@
 						Object.assign(player_node.style, {
 							left: `${player_idx * player_width}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 
 						players.push(player);
 					});

--- a/public/views/mp/battleroyale.html
+++ b/public/views/mp/battleroyale.html
@@ -17,6 +17,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<div class="box leaderboard">
@@ -138,6 +139,10 @@
 						player_node.classList.add(`p${player_idx + 1}`);
 						stream_bg.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const rank_fragment = document.importNode(
 							rank_template.content,
 							true
@@ -192,10 +197,6 @@
 								spacer + player_idx * (player_width + spacer)
 							)}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 					});
 
 				const competition = new Competition(players);

--- a/public/views/mp/battleroyale_avg.html
+++ b/public/views/mp/battleroyale_avg.html
@@ -35,6 +35,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<div class="box leaderboard">
@@ -156,6 +157,10 @@
 						player_node.classList.add(`p${player_idx + 1}`);
 						stream_bg.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const rank_fragment = document.importNode(
 							rank_template.content,
 							true
@@ -231,10 +236,6 @@
 								spacer + player_idx * (player_width + spacer)
 							)}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 					});
 
 				const competition = new Competition(players);

--- a/public/views/mp/concurrent.html
+++ b/public/views/mp/concurrent.html
@@ -88,18 +88,21 @@
 				width: 266px;
 				z-index: 3;
 			}
+
 			.player.focus .board {
 				transform: scale(var(--focus-scale));
 				left: calc(var(--focus-left) + 32px);
 				top: calc(var(--focus-top) + 221px);
 				z-index: 2;
 			}
+
 			.player.focus .score {
 				transform: scale(var(--focus-scale));
 				left: var(--focus-left);
 				top: calc(var(--focus-top) + 77px);
 				z-index: 3;
 			}
+
 			.player.focus .running_trt {
 				transform: scale(var(--focus-scale));
 				left: var(--focus-left);
@@ -117,6 +120,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<template id="player">
@@ -194,6 +198,10 @@
 						player_node.classList.add(`p${player_idx + 1}`);
 						stream_bg.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const player = new Player(
 							{
 								name: player_node.querySelector(`.name`),
@@ -238,10 +246,6 @@
 								hspacer + col_idx * (player_width + hspacer)
 							)}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 
 						player._layout_data = {
 							left: player_node.style.left,

--- a/public/views/mp/ctwc23.html
+++ b/public/views/mp/ctwc23.html
@@ -1074,8 +1074,6 @@
 						{
 							biglogo: true,
 							bigntc: true,
-							field_pixel_size: 4.25,
-							running_trt_dot_size: 5,
 							preview_pixel_size: 3.75,
 							format_score: v => readableScoreFomatter(v),
 							stereo: translate([1, 2], [-1, 1], player_num),

--- a/public/views/mp/pairs.html
+++ b/public/views/mp/pairs.html
@@ -38,6 +38,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<div class="box leaderboard">
@@ -236,6 +237,10 @@
 						player_node.classList.add(`p${player_num}`);
 						team.node.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const player = new Player(
 							{
 								name: player_node.querySelector(`.score .header`),
@@ -276,10 +281,6 @@
 						Object.assign(player_node.style, {
 							left: `${(col_num - 1) * player_width}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 					});
 				});
 

--- a/public/views/mp/teams.html
+++ b/public/views/mp/teams.html
@@ -40,6 +40,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<div id="team1" class="team">
@@ -197,6 +198,10 @@
 						player_node.classList.add(`p${player_num}`);
 						team_node.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const player = new Player(
 							{
 								name: player_node.querySelector(`.score .header`),
@@ -233,10 +238,6 @@
 						Object.assign(player_node.style, {
 							left: `${base_offset_x + (col_num - 1) * player_width}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 					});
 				});
 

--- a/public/views/mp/tggc.html
+++ b/public/views/mp/tggc.html
@@ -29,6 +29,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<div id="stream_bg">
 			<div class="box leaderboard">
@@ -150,6 +151,10 @@
 						player_node.classList.add(`p${player_idx + 1}`);
 						stream_bg.appendChild(player_node);
 
+						if (QueryString.get('rtrt') === '0') {
+							player_node.querySelector(`.running_trt`).remove();
+						}
+
 						const rank_fragment = document.importNode(
 							rank_template.content,
 							true
@@ -204,10 +209,6 @@
 								spacer + player_idx * (player_width + spacer)
 							)}px`,
 						});
-
-						if (QueryString.get('rtrt') === '0') {
-							player.dom.running_trt.remove();
-						}
 					});
 
 				const competition = new Competition(players);

--- a/public/views/replay.js
+++ b/public/views/replay.js
@@ -87,6 +87,7 @@ export async function getReplayGame(gameid) {
 
 	const game = new BaseGame({
 		usePieceStats: use_piece_stats,
+		seekableFrames: true,
 	});
 	game._gameid = gameid; // game has a client id, this records the server id too, can be used later on
 


### PR DESCRIPTION
## Context

The Player class writes into all the info nodes (e.g. TRT, BURN. etc.), to keep the code simple, the writes were done regardless of whether the layout was actually rendering those information. 

Additionally, the BaseGame class tracks every single frame for a game because there is live and seekable replay support in some layouts. Most layout do NOT offer seekable controls for reply however, so tracking all frames is unecessary cost for most layouts.

With the new multiplayer layouts up to 12 pax (and 32 in total supported), we should save whatever cost we can.

## Approach
* For layouts where seekable playback is not supported, constrain the size of the frames array
* Skip all value formatting when the elements are not presented in the layout (e.g. runways19/29/39(
