### PR TITLE
feat: adding npmrc for min release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3d


### PR DESCRIPTION
# Context

- Recent incidents like the [Axios npm supply chain attack](https://www.google.com/search?q=axios+npm+supply+chain+compromise&oq=axios+npm+supply&gs_lcrp=EgZjaHJvbWUqCggAEAAYxwMYgAQyCggAEAAYxwMYgAQyEQgBEEUYFBg5GIcCGMcDGIAEMgoIAhAAGMcDGIAEMgoIAxAAGMcDGIAEMgoIBBAAGMcDGIAEMg0IBRAAGIYDGIAEGIoFMg0IBhAAGIYDGIAEGIoFMgYIBxBFGDzSAQgxOTMyajBqN6gCALACAA&sourceid=chrome&ie=UTF-8) and the [TanStack npm supply chain attack](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) show how compromised packages can be published and widely consumed within hours, often before detection or remediation occurs.
- Both attacks exploited the ecosystem’s implicit trust in newly released versions, resulting in high-impact exposure (including credential exfiltration) despite the malicious packages being taken down quickly.
- Setting a minimum release age of 3 days introduces a buffer for detection and rollback, significantly reducing exposure to zero-day malicious releases while preserving reasonable developer velocity.

# Changes

Added a min-release-age `.npmrc` value of 3 days. 

# Small note
I'm new to contributing to FOS projects, so let me know if there something I'm missing. Thanks!