### PR TITLE
trans trainer detection logic

### DIFF
--- a/public/producer/GameTracker.js
+++ b/public/producer/GameTracker.js
@@ -54,6 +54,13 @@ export default class GameTracker extends EventTarget {
 	_getLevelFromLines(lines, ocr_level_digits) {
 		if (lines === null || ocr_level_digits === null) return null;
 		if (!this.transition) return GameTracker.digitsToValue(ocr_level_digits);
+		// Transition trainer check
+		if (
+			lines < 14 &&
+			this.start_level != GameTracker.digitsToValue(ocr_level_digits)
+		)
+			this.transition = 10;
+
 		if (lines < this.transition) return this.start_level;
 		return this.start_level + 1 + Math.floor((lines - this.transition) / 10);
 	}


### PR DESCRIPTION
Adds a check for transition trainer games with a 0 line start (G mode) to get them to display the correct level/palette. Works by checking if the level changes on OCR in the first 13 lines and overwrites the transition lines value initialized at the start of the game if it does. Stats such as runway still use values in views/constants.js so these are still broken (todo?).